### PR TITLE
upgrade maximum upload file size

### DIFF
--- a/templates/general/index.html
+++ b/templates/general/index.html
@@ -170,7 +170,7 @@ function responseHandler (json, isbutton) {
  Dropzone.options.uploadWidget = {
   paramName: 'file',
   createImageThumbnails: false,
-  maxFilesize: 100, // MB
+  maxFilesize: 300, // MB
   maxFiles: 8,
   dictDefaultMessage: 'Drag files here or click Upload & Analyze',
   acceptedFiles: '.apk,.ipa,.zip,.appx',


### PR DESCRIPTION
Maximum upload fiel size is set to 100MB

recent ipa are  bigger than this perhaps we could increase to 300 ?

In particular because that's not easy for regular user to find where this value is stored 
