### PR TITLE
Correct Android manisfet xml output

### DIFF
--- a/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/StaticAnalyzer/views/android/manifest_analysis.py
@@ -1269,7 +1269,8 @@ def read_manifest(app_dir, tools_dir, typ, binary):
 
             args = [settings.JAVA_PATH + 'java', '-jar', cp_path, manifest]
             dat = subprocess.check_output(args)
-            dat = dat.replace(b"\n", b"")
+            #dat = dat.replace(b"\n", b"")
+            dat = dat.decode()
         else:
             print("[INFO] Getting Manifest from Source")
             if typ == "eclipse":

--- a/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/StaticAnalyzer/views/android/manifest_analysis.py
@@ -1270,7 +1270,7 @@ def read_manifest(app_dir, tools_dir, typ, binary):
             args = [settings.JAVA_PATH + 'java', '-jar', cp_path, manifest]
             dat = subprocess.check_output(args)
             #dat = dat.replace(b"\n", b"")
-            dat = dat.decode()
+            dat = dat.decode("utf-8", "ignore")
         else:
             print("[INFO] Getting Manifest from Source")
             if typ == "eclipse":


### PR DESCRIPTION
Since we go to Python 3 , the output of the android manifest was not correct due to the byte string output of python3 ( b'<xml  instead of <xml)

 #dat = dat.replace(b"\n", b"")
 dat = dat.decode()