### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==2.0.3
 pdfkit==0.6.1
 configparser==3.5.0
-ak-androguard==3.3.6
+androguard==3.1.0
 lxml==4.2.0
 rsa==3.4.2
 git+https://github.com/MobSF/CapFuzz.git


### PR DESCRIPTION
androguard 3.1.0 is out 
What has changed?

Ported Androguard to python3! You can now use py2.7 or py>=3.3!
Tainted Analysis is gone and will be replaced by XREFs using the androguard.core.analysis.analysis.Analysis module.
Better support for Multidex
Adding JADX decompiler support
Fixed bugs in DEX and AXML parser
Fixed bugs in DAD (decompiler)
New certificate parsing using pyasn1 and cryptography. There is no need to use chilkat anymore.
switched from PScout to axplorer. These data should be more accurate.
removed elsim, as it depends on tained (might come back in the future)
APK v2 signatures are now supported
implied permissions can be queried
get uses-features directly from the APK