### PR TITLE
Update apktool 2.3.2

### DIFF
--- a/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/StaticAnalyzer/views/android/manifest_analysis.py
@@ -1292,7 +1292,7 @@ def get_manifest_file(app_path, app_dir, tools_dir):
         if len(settings.APKTOOL_BINARY) > 0 and isFileExists(settings.APKTOOL_BINARY):
             apktool_path = settings.APKTOOL_BINARY
         else:
-            apktool_path = os.path.join(tools_dir, 'apktool_2.3.1.jar')
+            apktool_path = os.path.join(tools_dir, 'apktool_2.3.2.jar')
         output_dir = os.path.join(app_dir, "apktool_out")
         args = [settings.JAVA_PATH + 'java', '-jar',
                 apktool_path, "-f", "-s", "d", app_path, "-o", output_dir]


### PR DESCRIPTION
APktool upgrade to 2.3.2

[#1742] - Android P Preview Support
[#1689] - Initial support for rebuilding with aapt2 binary
[#1730] - Fixed issue with application with empty resources.arsc file
[#1703] - Fixed issue with root depth kotlin folder not copied
[#1741] - Fixed building Apktool on Windows
Added warning if application with non-zero typeIdOffset is discovered
Upgraded baksmali to v2.2.2
Support for treating additional photo extensions (m4a) as raw
Prevent temporary BRUT files from clogging temporary directories