### PR TITLE
Update apktool to 2.3.3

### DIFF
--- a/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/StaticAnalyzer/views/android/manifest_analysis.py
@@ -1292,7 +1292,7 @@ def get_manifest_file(app_path, app_dir, tools_dir):
         if len(settings.APKTOOL_BINARY) > 0 and isFileExists(settings.APKTOOL_BINARY):
             apktool_path = settings.APKTOOL_BINARY
         else:
-            apktool_path = os.path.join(tools_dir, 'apktool_2.3.2.jar')
+            apktool_path = os.path.join(tools_dir, 'apktool_2.3.3.jar')
         output_dir = os.path.join(app_dir, "apktool_out")
         args = [settings.JAVA_PATH + 'java', '-jar',
                 apktool_path, "--match-original", "-f", "-s", "d", app_path, "-o", output_dir]


### PR DESCRIPTION
update apktool from 2.3.2 to 2.3.3

2018.04.26

    Fixed regression with compressing default AOSP filetypes like mp3. (Issue 1769)
    Fixed detection of aapt2 builds older than certain SDK versions. (Issue 1774)
