### PR TITLE
added an option to set api key via env var

### DIFF
--- a/MobSF/utils.py
+++ b/MobSF/utils.py
@@ -56,6 +56,10 @@ def upstream_proxy(flaw_type):
 
 def api_key():
     """Print REST API Key"""
+
+    if os.environ.get('API_KEY'):
+        return os.environ['API_KEY']
+
     secret_file = os.path.join(settings.MobSF_HOME, "secret")
     if isFileExists(secret_file):
         try:

--- a/MobSF/utils.py
+++ b/MobSF/utils.py
@@ -57,8 +57,9 @@ def upstream_proxy(flaw_type):
 def api_key():
     """Print REST API Key"""
 
-    if os.environ.get('API_KEY'):
-        return os.environ['API_KEY']
+    if os.environ.get('MOBSF_API_KEY'):
+        print("\nAPI Key read from environment variable")
+        return os.environ['MOBSF_API_KEY']
 
     secret_file = os.path.join(settings.MobSF_HOME, "secret")
     if isFileExists(secret_file):


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

It was hard to run MobSF in the CI - no simple way to control the API key (see #642 ).

### How this PR fixes the problem?

Added an option to set API key via env var - `API_KEY`.

### Check lists (check `x` in `[ ]` of list items)

- [x] Run MobSF unit tests - How can I do that? Could not find them, otherwise, I would have add tests
- [x] Tested Working on Linux, Mac, and Windows - Tested the docker container on my mac
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

