### PR TITLE
api_json_report support 404 NotFound

### DIFF
--- a/MobSF/rest_api.py
+++ b/MobSF/rest_api.py
@@ -136,6 +136,8 @@ def api_pdf_report(request):
                 elif "pdf_dat" in resp:
                     response = HttpResponse(
                         resp["pdf_dat"], content_type='application/pdf')
+                elif "not Found" in resp.get("report"):
+                    response = make_api_response(resp, 404)
                 else:
                     response = make_api_response(
                         {"error": "PDF Generation Error"}, 500)

--- a/MobSF/rest_api.py
+++ b/MobSF/rest_api.py
@@ -162,6 +162,8 @@ def api_json_report(request):
                     response = make_api_response(resp, 500)
                 elif "report_dat" in resp:
                     response = make_api_response(resp["report_dat"], 200)
+                elif "not Found" in resp.get("report"):
+                    response = make_api_response(resp, 404)
                 else:
                     response = make_api_response(
                         {"error": "JSON Generation Error"}, 500)


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

```
`Generate PDF Report API` and `Generate JSON Report API` don't support 404 status 

```


### How this PR fixes the problem?

```
Determine if the return contains notfound

```
### Check lists (check `x` in `[ ]` of list items)

- [x] Run MobSF unit tests
- [ ] Tested Working on Linux, Mac, and Windows
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

```
DESCRIBE HERE
```
