### PR TITLE
fixed get apk strings, change get dict value method

### DIFF
--- a/StaticAnalyzer/views/android/strings.py
+++ b/StaticAnalyzer/views/android/strings.py
@@ -24,7 +24,10 @@ def strings_jar(app_file, app_dir):
         pkg = rsrc.get_packages_names()[0]
         rsrc.get_strings_resources()
         for i in rsrc.values[pkg].keys():
-            for duo in rsrc.values[pkg][i]['string']:
+            string = rsrc.values[pkg][i].get('string')
+            if string is None:
+                return dat
+            for duo in string:
                 dat.append('"'+duo[0]+'" : "'+duo[1]+'"') 
         return dat
     except:


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### What was a problem?
Fix #687
```
When the method of strings_jar  throw a exception, The MobSF save to database will report an error and cannot be written to database.
```

### How this PR fixes the problem?

```
instead of  ['']  , use get() 
```

### Check lists (check `x` in `[ ]` of list items)

- [x] Run MobSF unit tests
- [ ] Tested Working on Linux, Mac, and Windows
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

```
DESCRIBE HERE
```
