### PR TITLE
Request method decorator and update form errors

### DIFF
--- a/MobSF/forms.py
+++ b/MobSF/forms.py
@@ -26,7 +26,7 @@ class FormUtil(object):
         """
         data = form.errors.get_json_data()
         for k, v in data.items():
-            data[k] = '; '.join([value_detail['message'] for value_detail in v])
+            data[k] = ' '.join([value_detail['message'] for value_detail in v])
         return data
 
     @staticmethod

--- a/MobSF/forms.py
+++ b/MobSF/forms.py
@@ -16,14 +16,19 @@ class FormUtil(object):
         form.errors.get_json_data() django 2.0 or higher
 
         :return
-        example { "error": "file This field is required." }
+        example
+        {
+        "error": {
+            "file": "This field is required.", 
+            "test": "This field is required."
+            }
+        }
         """
-        errors_messages = []
-        for k, value in form.errors.get_json_data().items():
-            errors_messages.append(
-                (k + ' ' + ' , '.join([i['message'] for i in value])))
-        return '; '.join(errors_messages)
+        data = form.errors.get_json_data()
+        for k, v in data.items():
+            data[k] = '; '.join([value_detail['message'] for value_detail in v])
+        return data
 
     @staticmethod
     def errors(form):
-        return form.errors.items()
+        return form.errors.get_json_data()

--- a/MobSF/rest_api.py
+++ b/MobSF/rest_api.py
@@ -39,15 +39,14 @@ def api_auth(meta):
     return False
 
 
+from MobSF.utils import request_method
+
+@request_method(['POST'])
 @csrf_exempt
 def api_upload(request):
     """POST - Upload API"""
-    if request.method == POST:
-        upload = Upload(request)
-        return upload.upload_api()
-    else:
-        return HttpResponseNotAllowed([POST])
-
+    upload = Upload(request)
+    return upload.upload_api()
 
 
 @csrf_exempt

--- a/MobSF/rest_api.py
+++ b/MobSF/rest_api.py
@@ -21,6 +21,8 @@ from StaticAnalyzer.views.windows import staticanalyzer_windows
 from django.http import HttpResponse, JsonResponse, HttpResponseBadRequest, HttpResponseNotAllowed
 from django.views.decorators.csrf import csrf_exempt
 
+from MobSF.utils import request_method
+
 POST = 'POST'
 
 def make_api_response(data, status=200):
@@ -38,8 +40,6 @@ def api_auth(meta):
         return bool(api_key() == meta["HTTP_AUTHORIZATION"])
     return False
 
-
-from MobSF.utils import request_method
 
 @request_method(['POST'])
 @csrf_exempt

--- a/MobSF/utils.py
+++ b/MobSF/utils.py
@@ -19,7 +19,8 @@ import shutil
 from . import settings
 
 from django.shortcuts import render
-from django.http import HttpResponseNotAllowed, HttpRequest
+from django.http import (HttpResponseNotAllowed,
+                        HttpRequest)
 
 
 ALLOW_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD', 'TRACE', ]
@@ -654,14 +655,14 @@ def request_method(methods):
             methods_upper = [m.upper() for m in methods]
             for method in methods_upper:
                 if method not in ALLOW_METHODS:
-                    raise ValueError('the methods is not allow')
+                    raise ValueError('This method is not allowed')
 
             request = None
             for arg in args:
                 if isinstance(arg, HttpRequest):
                     request = arg
             if request is None:
-                raise ValueError('the parameter not have request')
+                raise ValueError('Request object not found')
             
             if request.method not in methods_upper:
                 return HttpResponseNotAllowed(methods_upper)

--- a/MobSF/utils.py
+++ b/MobSF/utils.py
@@ -13,11 +13,16 @@ import hashlib
 import io
 import ast
 import unicodedata
+import functools
 import requests
 import shutil
 from . import settings
 
 from django.shortcuts import render
+from django.http import HttpResponseNotAllowed, HttpRequest
+
+
+ALLOW_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS', 'HEAD', 'TRACE', ]
 
 
 class Color(object):
@@ -631,3 +636,36 @@ class FileType(object):
         return (self.file_type in settings.IPA_MIME) and self.file_name_lower.endswith('.ipa')
     def is_appx(self):
         return (self.file_type in settings.APPX_MIME) and self.file_name_lower.endswith('.appx')
+
+
+
+def request_method(methods):
+    """
+    :param methods http method
+    need django HttpRequest
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+
+            if not isinstance(methods, list) and not isinstance(methods, tuple):
+                raise ValueError('the parameter methods is not a list or tuple')
+            
+            methods_upper = [m.upper() for m in methods]
+            for method in methods_upper:
+                if method not in ALLOW_METHODS:
+                    raise ValueError('the methods is not allow')
+
+            request = None
+            for arg in args:
+                if isinstance(arg, HttpRequest):
+                    request = arg
+            if request is None:
+                raise ValueError('the parameter not have request')
+            
+            if request.method not in methods_upper:
+                return HttpResponseNotAllowed(methods_upper)
+
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

```
change the Django form error to
        {
        "error": {
            "file": "This field is required.", 
            "test": "This field is required."
            }
        }

the decorator of request method is easy to use
put the ['get'] or ['post'] on func name
```

### How this PR fixes the problem?

```
DESCRIBE HERE
```

### Check lists (check `x` in `[ ]` of list items)

- [x] Run MobSF unit tests
- [ ] Tested Working on Linux, Mac, and Windows
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

```
DESCRIBE HERE
```
