### PR TITLE
change ios info plist path

### DIFF
--- a/StaticAnalyzer/views/ios/plist_analysis.py
+++ b/StaticAnalyzer/views/ios/plist_analysis.py
@@ -197,7 +197,7 @@ def plist_analysis(src, is_source):
                 if ifile.endswith(".xcodeproj"):
                     app_name = ifile.replace(".xcodeproj", "")
                     break
-            app_plist_file = app_name + "-Info.plist"
+            app_plist_file = "Info.plist"
             for dirpath, dirnames, files in os.walk(src):
                 for name in files:
                     if "__MACOSX" not in dirpath and name == app_plist_file:


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### What was a problem?
Fix #699 #686 
```
Info.plist file name of  iOS project is Info.plist
```

### How this PR fixes the problem?

```
[INFO] ALL TESTS COMPLETED!
[INFO] Test Status: all tests completed
```

### Check lists (check `x` in `[ ]` of list items)

- [x] Run MobSF unit tests
- [ ] Tested Working on Linux, Mac, and Windows
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

```
DESCRIBE HERE
```
