### PR TITLE
Update views.py

### DIFF
--- a/MalwareAnalyzer/views.py
+++ b/MalwareAnalyzer/views.py
@@ -32,7 +32,7 @@ def apkid_analysis(app_dir, apk_file):
         from StaticAnalyzer.tools.apkid import apkid
         apkid_dict = {}
         print("[INFO] APKiD Analysis on Dex file")
-        result = apkid.scan(dex_file, 30, True)
+        result = apkid.scan(app_dir, 30, True)
         if "files" in result:
             apkid_dict["result"] = result["files"][0]["results"]
         if "apkid_version" in result:
@@ -80,13 +80,9 @@ def apkid_analysis(app_dir, apk_file):
             apkid_dict["manipulator"] = ""
 
         apkid_dict["result"] = ""
-        print("[INFO] APKiD Analysis on apk file")
-        result = apkid.scan(apk_file, 30, True)
         if "files" in result:
-            apkid_dict["result"] = result["files"][0]["results"]
-        if "apkid_version" in result:
-            apkid_dict["apkid_version"] = result["apkid_version"]
-
+            apkid_dict["result"] = result["files"][1]["results"]
+        
         if "anti_vm" in apkid_dict["result"]:
             apkid_dict["anti_vm"] = apkid_dict["result"]["anti_vm"]
         


### PR DESCRIPTION
No need to launch apkid twice
also no need to specifiy the dex file cause we are launching apkid.scdan with parameters set to True so a directory is enough

<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

```
previous version launch to apk id on one dex and one on apk to detect obfuscator....
```

### How this PR fixes the problem?

```
Only one launch but thetre's to array not only one , so parsing also the second one 
```

### Check lists (check `x` in `[ ]` of list items)

- [X] Run MobSF unit tests
- [X] Tested Working on Linux, Mac,
- [X] Coding style (indentation, etc)

### Additional Comments (if any)

```
could also be imporoved I think 
```
