### PR TITLE
Apkid anti debug

### DIFF
--- a/MalwareAnalyzer/views.py
+++ b/MalwareAnalyzer/views.py
@@ -68,6 +68,12 @@ def apkid_analysis(app_dir, apk_file):
                 "result"]["anti_disassembly"]
         else:
             apkid_dict["anti_disassembly"] = ""
+        
+        if "anti_debug" in apkid_dict["result"]:
+            apkid_dict["anti_disassembly"] = apkid_dict[
+                "result"]["anti_debug"]
+        else:
+            apkid_dict["anti_debug"] = ""
 
         if "dropper" in apkid_dict["result"]:
             apkid_dict["dropper"] = apkid_dict["result"]["dropper"]

--- a/MalwareAnalyzer/views.py
+++ b/MalwareAnalyzer/views.py
@@ -70,7 +70,7 @@ def apkid_analysis(app_dir, apk_file):
             apkid_dict["anti_disassembly"] = ""
         
         if "anti_debug" in apkid_dict["result"]:
-            apkid_dict["anti_disassembly"] = apkid_dict[
+            apkid_dict["anti_debug"] = apkid_dict[
                 "result"]["anti_debug"]
         else:
             apkid_dict["anti_debug"] = ""
@@ -107,6 +107,12 @@ def apkid_analysis(app_dir, apk_file):
         if "anti_disassembly" in apkid_dict["result"]:
             apkid_dict["anti_disassembly"] = apkid_dict[
                 "result"]["anti_disassembly"]
+            
+        if "anti_debug" in apkid_dict["result"]:
+            apkid_dict["anti_debug"] = apkid_dict[
+                "result"]["anti_debug"]
+        else:
+            apkid_dict["anti_debug"] = ""
         
         if "dropper" in apkid_dict["result"]:
             apkid_dict["dropper"] = apkid_dict["result"]["dropper"]

--- a/templates/static_analysis/static_analysis.html
+++ b/templates/static_analysis/static_analysis.html
@@ -802,6 +802,7 @@ Production ready applications should not be signed with 'Android Debug' Certific
                                                 <th>DROPPER</th>
                                                 <th>MANIPULATOR</th>
                                                 <th>ANTI-ASSEMBLY</th>
+						<th>ANTI-DEBUG</th>
                                                 <th>ABNORMAL PATTERN</th>
                                                 
                                                 
@@ -887,6 +888,17 @@ Production ready applications should not be signed with 'Android Debug' Certific
                             {% else %}
                               <span class="label label-danger">Anti-Disassembly Code Found</span></br>
                               {% for cmp in apkid|key:"anti_disassembly" %}
+                               {{cmp}}</br>
+                              {% endfor %}
+                          {% endif %}
+                        </td>
+                       
+                        <td>
+                          {% if apkid|key:"anti_debug" == "" %}
+                              <span class="label label-info">No Anti-Debug Code</span>
+                            {% else %}
+                              <span class="label label-info">Anti-Debug Code Found</span></br>
+                              {% for cmp in apkid|key:"anti_debug" %}
                                {{cmp}}</br>
                               {% endfor %}
                           {% endif %}


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

```
MobSf was not detecting Anti_debug Software in apk 
```

### How this PR fixes the problem?

```
search for the apkid key 'anti_debug' and siplay info if found or not 
```

### Check lists (check `x` in `[ ]` of list items)

- [X] Run MobSF unit tests
- [X] Tested Working on Linux, Mac
- [X] Coding style (indentation, etc)

### Additional Comments (if any)

```
Need to optimize and use get method as proposed 
```
