### PR TITLE
change permissons for android to dict

### DIFF
--- a/StaticAnalyzer/views/android/code_analysis.py
+++ b/StaticAnalyzer/views/android/code_analysis.py
@@ -75,9 +75,9 @@ def code_analysis(app_dir, perms, typ):
                     # print "[INFO] Doing Code Analysis on - " + jfile_path
                     relative_java_path = jfile_path.replace(java_src, '')
                     code_rule_matcher(
-                        code_findings, list(perms.keys()), dat, relative_java_path, code_rules)
+                        code_findings, perms, dat, relative_java_path, code_rules)
                     # API Check
-                    api_rule_matcher(api_findings, list(perms.keys()),
+                    api_rule_matcher(api_findings, perms,
                                      dat, relative_java_path, api_rules)
                      # Extract URLs and Emails
                     urls, urls_nf, emails_nf = url_n_email_extract(dat, relative_java_path)

--- a/StaticAnalyzer/views/android/code_analysis.py
+++ b/StaticAnalyzer/views/android/code_analysis.py
@@ -75,9 +75,9 @@ def code_analysis(app_dir, perms, typ):
                     # print "[INFO] Doing Code Analysis on - " + jfile_path
                     relative_java_path = jfile_path.replace(java_src, '')
                     code_rule_matcher(
-                        code_findings, perms, dat, relative_java_path, code_rules)
+                        code_findings, list(perms.keys()), dat, relative_java_path, code_rules)
                     # API Check
-                    api_rule_matcher(api_findings, perms,
+                    api_rule_matcher(api_findings, list(perms.keys()),
                                      dat, relative_java_path, api_rules)
                      # Extract URLs and Emails
                     urls, urls_nf, emails_nf = url_n_email_extract(dat, relative_java_path)

--- a/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/StaticAnalyzer/views/android/manifest_analysis.py
@@ -1231,13 +1231,21 @@ def manifest_analysis(mfxml, man_data_dic):
                 icon_hidden = False
                 break
 
+        permissons = {}
+        for k, permisson in man_data_dic['perm'].items():
+            permissons[k] = (
+                {
+                    'status': permisson[0],
+                    'info': permisson[1],
+                    'description': permisson[2]
+                })
         # Prepare return dict
         man_an_dic = {
             'manifest_anal': ret_value,
             'exported_act': exported,
             'exported_cnt': exp_count,
             'browsable_activities': browsable_activities,
-            'permissons': man_data_dic['perm'],
+            'permissons': permissons,
             'cnt_act': len(man_data_dic['activities']),
             'cnt_pro': len(man_data_dic['providers']),
             'cnt_ser': len(man_data_dic['services']),

--- a/templates/static_analysis/static_analysis.html
+++ b/templates/static_analysis/static_analysis.html
@@ -417,18 +417,18 @@ Production ready applications should not be signed with 'Android Debug' Certific
                     <tr>
                     <td>{{ perm }}</td>
                     <td>
-                    {% if desc.0 == 'dangerous' %}
+                    {% if desc.status == 'dangerous' %}
                       <span class="label label-danger">dangerous</span>
-                    {% elif desc.0 == 'normal' %}
+                    {% elif desc.status == 'normal' %}
                       <span class="label label-info">normal</span>
-                    {% elif desc.0 == 'signatureOrSystem' %}
+                    {% elif desc.status == 'signatureOrSystem' %}
                       <span class="label label-warning">SignatureOrSystem</span>
-                    {% elif desc.0 == 'signature' %}
+                    {% elif desc.status == 'signature' %}
                       <span class="label label-success">signature</span>
                     {% endif %}
                     </td>
-                    <td>{{ desc.1 }}</td>
-                    <td>{{ desc.2 }}</td>
+                    <td>{{ desc.info }}</td>
+                    <td>{{ desc.description }}</td>
                     </tr>
                     {% endfor %}
                     </tbody>


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

The API of the permission part of Android static analysis is not good enough. The permission field returns a dictionary. The value of the dictionary is a list instead of a dictionary, so the order must be guaranteed. This change may cause historical compatibility issues and requires caution

origin
```
{'android.permission.RECEIVE_BOOT_COMPLETED': ['normal', 'automatically start at boot', 'Allows an application to start itself as soon as the system has finished booting. This can make it take longer to start the phone and allow the application to slow down the overall phone by always running.'}
```

now
```
{'android.permission.RECEIVE_BOOT_COMPLETED': {'status': 'normal', 'info': 'automatically start at boot', 'description': 'Allows an application to start itself as soon as the system has finished booting. This can make it take longer to start the phone and allow the application to slow down the overall phone by always running.'},
```

### How this PR fixes the problem?

```
DESCRIBE HERE
```

### Check lists (check `x` in `[ ]` of list items)

- [x] Run MobSF unit tests
- [ ] Tested Working on Linux, Mac, and Windows
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

```
DESCRIBE HERE
```
