### PR TITLE
hotfix to allow independent script execution

### DIFF
--- a/scripts/start_avd.py
+++ b/scripts/start_avd.py
@@ -4,7 +4,6 @@ import platform
 import subprocess
 import django
 from os.path import dirname, abspath
-from scripts.qcow2 import Qcow2
 
 
 MobSF_path = dirname(dirname(abspath(__file__)))
@@ -194,4 +193,7 @@ def main():
 
 
 if __name__ == '__main__':
+    from qcow2 import Qcow2
     sys.exit(main())
+else:
+    from scripts.qcow2 import Qcow2


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

```
Running start_avd.py independently won't work due to an import error
```

### How this PR fixes the problem?

```
A quick fix to have two different imports based on how the script it executed
```

### Check lists (check `x` in `[ ]` of list items)

- [x] Run MobSF unit tests
- [ ] Tested Working on Linux, Mac, and Windows //Not applicable as it's alpha and supports only Mac
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

```
DESCRIBE HERE
```
