### PR TITLE
Only warn about singleTask/singleInstance when API level is <21

### DIFF
--- a/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/StaticAnalyzer/views/android/manifest_analysis.py
@@ -762,6 +762,7 @@ def manifest_analysis(mfxml, man_data_dic):
 
                 # LaunchMode
                 if (
+                        int(man_data_dic['min_sdk']) < 21 and
                         itemname in ['Activity', 'Activity-Alias'] and
                         (
                             node.getAttribute("android:launchMode") == 'singleInstance' or

--- a/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/StaticAnalyzer/views/android/manifest_analysis.py
@@ -18,6 +18,10 @@ from MobSF.utils import (
 from .dvm_permissions import DVM_PERMISSIONS
 
 
+ANDROID_4_2_LEVEL = 17
+ANDROID_5_0_LEVEL = 21
+
+
 def get_manifest(app_path, app_dir, tools_dir, typ, binary):
     """Get the manifest file."""
     try:
@@ -762,7 +766,7 @@ def manifest_analysis(mfxml, man_data_dic):
 
                 # LaunchMode
                 try:
-                    affected_sdk = int(man_data_dic['min_sdk']) < 21
+                    affected_sdk = int(man_data_dic['min_sdk']) < ANDROID_5_0_LEVEL
                 except:
                     # in case min_sdk is not defined we assume vulnerability
                     affected_sdk = True
@@ -1027,8 +1031,8 @@ def manifest_analysis(mfxml, man_data_dic):
                                     # app will not be run on a system where the
                                     # system's API level is below 17.
                         else:
-                            if man_data_dic['min_sdk'] and man_data_dic['target_sdk'] and int(man_data_dic['min_sdk']) < 17:
-                                if itemname == 'Content Provider' and int(man_data_dic['target_sdk']) < 17:
+                            if man_data_dic['min_sdk'] and man_data_dic['target_sdk'] and int(man_data_dic['min_sdk']) < ANDROID_4_2_LEVEL:
+                                if itemname == 'Content Provider' and int(man_data_dic['target_sdk']) < ANDROID_4_2_LEVEL:
                                     perm = ''
                                     item = node.getAttribute("android:name")
                                     if node.getAttribute("android:permission"):

--- a/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/StaticAnalyzer/views/android/manifest_analysis.py
@@ -761,8 +761,14 @@ def manifest_analysis(mfxml, man_data_dic):
                     ret_list.append(("a_taskaffinity", (item,), tuple(),))
 
                 # LaunchMode
+                try:
+                    affected_sdk = int(man_data_dic['min_sdk']) < 21
+                except:
+                    # in case min_sdk is not defined we assume vulnerability
+                    affected_sdk = True
+
                 if (
-                        int(man_data_dic['min_sdk']) < 21 and
+                        affected_sdk and
                         itemname in ['Activity', 'Activity-Alias'] and
                         (
                             node.getAttribute("android:launchMode") == 'singleInstance' or


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

```
The underlying vulnerability is that with ActivityManager.getRecentTasks()
any app with the permission GET_TASKS can read the Intents sent to create
the task. This would reveal the possibly sensitive contents of these Intents.
MobSF warns about Activities using singleTask/singleInstance because these
would be affected by this issue.

According to the Android documentation at https://developer.android.com/reference/android/app/ActivityManager.html#getRecentTasks(int,%20int)
starting with API level 21 it is no longer possible to read all Intents sent
to a root activity by using ActivityManager.getRecentTasks(). After API
level 21, only Intents sent from your own app and other apps to be known
insensitive like the home/launcher app.

See also chapter 4.1.3.3 (page 94) in http://www.jssec.org/dl/android_securecoding_en.pdf
```

### How this PR fixes the problem?

```
This PR checks if the min_sdk level is less than 21 and only then applies this issue in the manifest analysis.
```

### Check lists (check `x` in `[ ]` of list items)

- [x] Run MobSF unit tests
- [ ] Tested Working on Linux, Mac, and Windows
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

```
Only testet on Linux.

I did not find how to run the unit tests. Standard `python manage.py tests` runs 0 tests.
```
