### PR TITLE
Remove ios strings

### DIFF
--- a/StaticAnalyzer/views/ios/binary_analysis.py
+++ b/StaticAnalyzer/views/ios/binary_analysis.py
@@ -301,7 +301,6 @@ def binary_analysis(src, tools_dir, app_dir, executable_name):
         bin_path = os.path.join(bin_dir, bin_name)
         binary_analysis_dict["libs"] = ''
         binary_analysis_dict["bin_res"] = ''
-        binary_analysis_dict["strings"] = ''
         if not isFileExists(bin_path):
             print("[WARNING] MobSF Cannot find binary in " + bin_path)
             print("[WARNING] Skipping Otool, Classdump and Strings")
@@ -311,10 +310,8 @@ def binary_analysis(src, tools_dir, app_dir, executable_name):
             # Classdumpz can fail on swift coded binaries
             if not cls_dump:
                 cls_dump = ""
-            strings_in_ipa = strings_on_ipa(bin_path)
             binary_analysis_dict["libs"] = otool_dict["libs"]
             binary_analysis_dict["bin_res"] = otool_dict["anal"] + cls_dump
-            binary_analysis_dict["strings"] = strings_in_ipa
         return binary_analysis_dict
     except:
         PrintException("[ERROR] iOS Binary Analysis")

--- a/StaticAnalyzer/views/ios/db_interaction.py
+++ b/StaticAnalyzer/views/ios/db_interaction.py
@@ -34,7 +34,6 @@ def get_context_from_analysis_ipa(app_dict, info_dict, bin_dict, files, sfiles):
             'libs': bin_dict["libs"],
             'files': files,
             'file_analysis': sfiles,
-            'strings': bin_dict["strings"],
             'permissions': info_dict["permissions"],
             'insecure_connections': info_dict["inseccon"]
         }
@@ -65,7 +64,6 @@ def get_context_from_db_entry_ipa(db_entry):
             'libs': db_entry[0].LIBS,
             'files': python_list(db_entry[0].FILES),
             'file_analysis': db_entry[0].SFILESX,
-            'strings': python_list(db_entry[0].STRINGS),
             'permissions': python_list(db_entry[0].PERMISSIONS),
             'insecure_connections': python_list(db_entry[0].INSECCON)
         }
@@ -96,7 +94,6 @@ def update_db_entry_ipa(app_dict, info_dict, bin_dict, files, sfiles):
             LIBS=bin_dict["libs"],
             FILES=files,
             SFILESX=sfiles,
-            STRINGS=bin_dict["strings"],
             PERMISSIONS=info_dict["permissions"],
             INSECCON=info_dict["inseccon"]
         )
@@ -126,7 +123,6 @@ def create_db_entry_ipa(app_dict, info_dict, bin_dict, files, sfiles):
             LIBS=bin_dict["libs"],
             FILES=files,
             SFILESX=sfiles,
-            STRINGS=bin_dict["strings"],
             PERMISSIONS=info_dict["permissions"],
             INSECCON=info_dict["inseccon"]
         )

--- a/templates/static_analysis/ios_binary_analysis.html
+++ b/templates/static_analysis/ios_binary_analysis.html
@@ -182,7 +182,7 @@
         <div class="box-body">
          <div align="center">
       <a data-target="#myModal" role="button" class="btn btn-info" data-toggle="modal"><i class="fa fa-list"></i> View Info.plist</a>
-      <a data-target="#myModalStrings" role="button" class="btn btn-info" data-toggle="modal"><i class="fa fa-list"></i> View Strings</a>
+      <!-- <a data-target="#myModalStrings" role="button" class="btn btn-info" data-toggle="modal"><i class="fa fa-list"></i> View Strings</a> -->
       <a target="_blank" href="../ViewFile/?file=classdump.txt&type=txt&md5={{ md5 }}&mode=ios" class="btn btn-warning" role="button"><i class="fa fa-code"></i> View Class Dump</a>
       <a href="../StaticAnalyzer_iOS/?checksum={{ md5 }}&amp;name={{ name }}&amp;type=ipa&amp;rescan=1" class="btn btn-info" role="button"><i class="glyphicon glyphicon-refresh"></i> Rescan</a>
 </div>


### PR DESCRIPTION
fix #754 

Unfortunately, ipa can't decompile useful source code information like apk, I recommend removing it.