### PR TITLE
remove configparser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Django==2.1.4
 pdfkit==0.6.1
-configparser==3.5.0
 androguard==3.2.1
 lxml==4.2.5
 rsa==4.0


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

```
This library brings the updated configparser from Python 3.5 to Python 2.6-3.5.
```

So unneeded if using python3, I guess it was when mobsf was in python2.

### How this PR fixes the problem?

removes the unneeded dependency

### Check lists (check `x` in `[ ]` of list items)

- [ ] Run MobSF unit tests (http://your-mobsf-@ip:8000/tests/ or python3 manage.py test)
- [ ] Tested Working on Linux, Mac, and Windows
- [x] Coding style (indentation, etc)

I didn't tested because I don't have a proper setup and I don't want to trash my actual machine by installing last version of mobsf.
