### PR TITLE
Update clean.sh

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -3,7 +3,7 @@ echo "=======================MobSF Clean Script for Unix======================="
 echo "Running this script will delete the Scan database, all files uploaded and generated."
 
 script_path=$(dirname $0)
-if [ "$script_path" != "." ] && [ "$script_path" != "./scripts" ]; then
+if [ "$script_path" != "." ] && [ "$script_path" != "scripts" ] && [ "$script_path" != "./scripts" ]; then
     echo "Please run script from MobSF scripts directory "
     exit  1
 fi

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -4,7 +4,7 @@ echo "Running this script will delete the Scan database, all files uploaded and 
 
 script_path=$(dirname $0)
 if [ "$script_path" != "." ] && [ "$script_path" != "./scripts" ]; then
-    echo "Please run script from MobSF script directory "
+    echo "Please run script from MobSF scripts directory "
     exit  1
 fi
 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -2,6 +2,12 @@ echo
 echo "=======================MobSF Clean Script for Unix======================="
 echo "Running this script will delete the Scan database, all files uploaded and generated."
 
+script_path=$(dirname $0)
+if [ "$script_path" != "." ] && [ "$script_path" != "./scripts" ]; then
+    echo "Please run script from MobSF script directory "
+    exit  1
+fi
+
 if [ "$1" != "" ]; then
     VAL="$1"
 else


### PR DESCRIPTION
prevent script from being launched outside of Mobsf path

<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

```
clean script could delete directory outside of MobSF path if launched outside of MobSF path
```

### How this PR fixes the problem?

```
it check it script is launched from .  or from ./scripts
```

### Check lists (check `x` in `[ ]` of list items)

- [ ] Run MobSF unit tests (http://your-mobsf-@ip:8000/tests/ or python3 manage.py test)
- [X] Tested Working on Linux, Mac, and Windows
- [X] Coding style (indentation, etc)

### Additional Comments (if any)

```

```
