### PR TITLE
change request method decorator param to str

### DIFF
--- a/MobSF/views/api/rest_api.py
+++ b/MobSF/views/api/rest_api.py
@@ -59,7 +59,7 @@ def api_auth(meta):
     return False
 
 
-@request_method(['POST'])
+@request_method('POST')
 @csrf_exempt
 def api_upload(request):
     """POST - Upload API"""
@@ -68,7 +68,7 @@ def api_upload(request):
     return make_api_response(resp, code)
 
 
-@request_method(['POST'])
+@request_method('POST')
 @csrf_exempt
 def api_scan(request):
     """POST - Scan API"""
@@ -107,7 +107,7 @@ def api_scan(request):
     return response
 
 
-@request_method(['POST'])
+@request_method('POST')
 @csrf_exempt
 def api_delete_scan(request):
     """POST - Delete a Scan"""
@@ -123,7 +123,7 @@ def api_delete_scan(request):
     return response
 
 
-@request_method(['POST'])
+@request_method('POST')
 @csrf_exempt
 def api_pdf_report(request):
     """Generate and Download PDF"""
@@ -152,7 +152,7 @@ def api_pdf_report(request):
     return response
 
 
-@request_method(['POST'])
+@request_method('POST')
 @csrf_exempt
 def api_json_report(request):
     """Generate JSON Report"""
@@ -179,7 +179,7 @@ def api_json_report(request):
     return response
 
 
-@request_method(['POST'])
+@request_method('POST')
 @csrf_exempt
 def api_view_source(request):
     """

--- a/MobSF/views/helpers.py
+++ b/MobSF/views/helpers.py
@@ -40,23 +40,20 @@ class FileType(object):
         return (self.file_type in settings.APPX_MIME) and self.file_name_lower.endswith('.appx')
 
 
-def request_method(methods):
+def request_method(method):
     """
-    :param methods http method
+    :param method http method
     need django HttpRequest
     """
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-
-            if not isinstance(methods, list) and not isinstance(methods, tuple):
+            if not isinstance(method, str):
                 raise ValueError(
-                    'the parameter methods is not a list or tuple')
-
-            methods_upper = [m.upper() for m in methods]
-            for method in methods_upper:
-                if method not in ALLOW_METHODS:
-                    raise ValueError('This method is not allowed')
+                    'the parameter methods is not a str')
+            method_value = method.upper()
+            if method_value not in ALLOW_METHODS:
+                raise ValueError('This method is not allowed')
 
             request = None
             for arg in args:
@@ -65,8 +62,8 @@ def request_method(methods):
             if request is None:
                 raise ValueError('Request object not found')
 
-            if request.method not in methods_upper:
-                return HttpResponseNotAllowed(methods_upper)
+            if request.method != method_value:
+                return HttpResponseNotAllowed(method_value)
 
             return func(*args, **kwargs)
         return wrapper


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

```
Request method does not need to support multiple
```

### How this PR fixes the problem?

```
DESCRIBE HERE
```

### Check lists (check `x` in `[ ]` of list items)

- [x] Run MobSF unit tests (http://your-mobsf-@ip:8000/tests/ or python3 manage.py test)
- [x] Tested Working on Linux, Mac, and Windows
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

```
DESCRIBE HERE
```
