### PR TITLE
simplify clean script

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,10 +1,11 @@
 echo 
-echo "=======================MobSF Clean Script for Unix======================="
-echo "Running this script will delete the Scan database, all files uploaded and generated."
+echo '=======================MobSF Clean Script for Unix======================='
+echo 'Running this script will delete the Scan database, all files uploaded and generated.'
 
 script_path=$(dirname $0)
-if [ "$script_path" != "." ] && [ "$script_path" != "scripts" ] && [ "$script_path" != "./scripts" ]; then
-    echo "Please run script from MobSF scripts directory "
+if [ "$script_path" != "scripts" ] && [ "$script_path" != "./scripts" ]; then
+    echo 'Please run script from MobSF directory '
+    echo './scripts/clean.sh '
     exit  1
 fi
 
@@ -17,25 +18,25 @@ fi
 echo 
 if [[ $VAL =~ ^[Yy]$ ]]
 then
-	echo "Deleting all Uploads"
-	rm -rf ../uploads/*
-	echo "Deleting all Downloads"
-	rm -rf ../downloads/*
-	echo "Deleting Static Analyzer Migrations"
-	rm -rf ../StaticAnalyzer/migrations/*
-	echo "Deleting Dynamic Analyzer Migrations"
-	rm -rf ../DynamicAnalyzer/migrations/*
-	echo "Deleting MobSF Migrations"
-	rm -rf ../MobSF/migrations/*
-	echo "Deleting python byte code files"
-        find ../ -name "*.pyc" -exec rm -rf {} \;
-        find ../ | grep -E "(__pycache__|\.pyo$)" | xargs rm -rf
-        echo "Deleting temp and log files"
-	rm -rf ../logs/*
-	rm -rf ../classes-error.zip
-	echo "Deleting DB"
-	rm -rf ../db.sqlite3
-	echo "Deleting Secret File"
-	rm -rf ../secret
-	echo "Done"
+	echo 'Deleting all Uploads'
+	rm -rf ./uploads/*
+	echo 'Deleting all Downloads'
+	rm -rf ./downloads/*
+	echo 'Deleting Static Analyzer Migrations'
+	rm -rf ./StaticAnalyzer/migrations/*
+	echo 'Deleting Dynamic Analyzer Migrations'
+	rm -rf ./DynamicAnalyzer/migrations/*
+	echo 'Deleting MobSF Migrations'
+	rm -rf ./MobSF/migrations/*
+	echo 'Deleting python byte code files'
+        find ./ -name "*.pyc" -exec rm -rf {} \;
+        find ./ | grep -E "(__pycache__|\.pyo$)" | xargs rm -rf
+        echo 'Deleting temp and log files'
+	rm -rf ./logs/*
+	rm -rf ./classes-error.zip
+	echo 'Deleting DB'
+	rm -rf ./db.sqlite3
+	echo 'Deleting Secret File'
+	rm -rf ./secret
+	echo 'Done'
 fi


### PR DESCRIPTION
must be run only from mobsf directory, otherwise need to manage cases

<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

```
clean script must be run only from MobSF directory otherwise it coudl delete files from other program
```

### How this PR fixes the problem?

```
check script path and display error if script not launched from mobSF directory
```

### Check lists (check `x` in `[ ]` of list items)

- [X] Run MobSF unit tests (http://your-mobsf-@ip:8000/tests/ or python3 manage.py test)
- [X] Tested Working on Linux, Mac,, Docker
- [X ] Coding style (indentation, etc)

### Additional Comments (if any)

```
replace " with ' for echo cause no variable are displayed 
```
