### PR TITLE
Fix issue #824 - Binary analysis of windows apps failed

### DIFF
--- a/StaticAnalyzer/views/windows.py
+++ b/StaticAnalyzer/views/windows.py
@@ -384,25 +384,48 @@ def __parse_binskim(bin_an_dic, output):
     current_run = output['runs'][0]
 
     if 'results' in current_run:
-        rules = output['runs'][0]['rules']
-        for res in current_run['results']:
-            if res['level'] != "pass":
-                result = {
-                    "rule_id": res['ruleId'],
-                    "status": "Insecure",
-                    "desc": rules[res['ruleId']]['shortDescription']
-                }
-                if len(res['formattedRuleMessage']["arguments"])>2:
-                    result["info"] = res['formattedRuleMessage']["arguments"][2]
+        try:
+            # Json result changed, so first try old format
+            rules = output['runs'][0]['rules']
+            for res in current_run['results']:
+                if res['level'] != "pass":
+                    result = {
+                        "rule_id": res['ruleId'],
+                        "status": "Insecure",
+                        "desc": rules[res['ruleId']]['shortDescription']
+                    }
+                    if len(res['formattedRuleMessage']["arguments"])>2:
+                        result["info"] = res['formattedRuleMessage']["arguments"][2]
+                    else:
+                        result["info"] = ""
                 else:
-                    result["info"] = ""
-            else:
-                result = {
-                    "rule_id": res['ruleId'],
-                    "status": "Secure",
-                    "desc": rules[res['ruleId']]['shortDescription']
-                }
-            bin_an_dic['results'].append(result)
+                    result = {
+                        "rule_id": res['ruleId'],
+                        "status": "Secure",
+                        "desc": rules[res['ruleId']]['shortDescription']
+                    }
+                bin_an_dic['results'].append(result)
+        except:
+            # Old format failed, so parse it with the new format
+            rules = output['runs'][0]['resources']['rules']
+            for res in current_run['results']:
+                if res['level'] != "pass":
+                    result = {
+                        "rule_id": res['ruleId'],
+                        "status": "Insecure",
+                        "desc": rules[res['ruleId']]['shortDescription']['text']
+                    }
+                    if len(res['message']["arguments"])>2:
+                        result["info"] = res['message']["arguments"][2]
+                    else:
+                        result["info"] = ""
+                else:
+                    result = {
+                        "rule_id": res['ruleId'],
+                        "status": "Secure",
+                        "desc": rules[res['ruleId']]['shortDescription']['text']
+                    }
+                bin_an_dic['results'].append(result)
     else:
         print("[WARNING] binskim has no results.")
         # Create an warining for the gui


### PR DESCRIPTION
Format of json response changed

<!-- Thank you for your contribution to MobSF! -->

### What was a problem?

```
Windows apps static analysis is returning an error.
See Issue #824 .
The format of the response changed.
```

### How this PR fixes the problem?

```
Added parsing for the new result.
```

### Check lists (check `x` in `[ ]` of list items)

- [x] Run MobSF unit tests (http://your-mobsf-@ip:8000/tests/ or python3 manage.py test)
- [x] Tested Working on ~Linux~, Mac, ~Windows~, and ~Docker~
- [ ] Coding style (indentation, etc)

### Additional Comments (if any)

```
BinSkim is installed in version 1.6.0-beta.1 by the setup.py on windows.
Nuget: https://www.nuget.org/packages/Microsoft.CodeAnalysis.BinSkim/1.6.0-beta.1
```
