### PR TITLE
Apktool 240

### DIFF
--- a/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/StaticAnalyzer/views/android/manifest_analysis.py
@@ -876,7 +876,7 @@ def get_manifest_file(app_path, app_dir, tools_dir):
         if len(settings.APKTOOL_BINARY) > 0 and isFileExists(settings.APKTOOL_BINARY):
             apktool_path = settings.APKTOOL_BINARY
         else:
-            apktool_path = os.path.join(tools_dir, 'apktool_2.3.4.jar')
+            apktool_path = os.path.join(tools_dir, 'apktool_2.4.0.jar')
         output_dir = os.path.join(app_dir, "apktool_out")
         args = [settings.JAVA_PATH + 'java', '-jar',
                 apktool_path, "--match-original", "-f", "-s", "d", app_path, "-o", output_dir]


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
Apgrade aoktool to 2.4.0
```

### Checklist for PR

- [X] Run MobSF unit tests (http://your-mobsf-@ip:8000/tests/ or python3 manage.py test).
- [X] Tested Working on Linux, Mac, Windows, and Docker
- [X] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)
- [X] Coding style (indentation, etc)

### Additional Comments (if any)

```
[#1893] Updated baksmali/smali to v2.2.6
[#1918] Fixed issue with new restriction with non-empty ids.xml file. (Thanks gino247)
[#1909] Fixed issue with PlatformBuildVersion properties changing to unexpected values. (Thanks gino247)
[#1943] Fixed issue with pending v5 Gradle upgrade, by taking point release v4.10.2. (Thanks Frieder Blumle)
[#1849] Added no-crunch support via new parameters - -nc | --no-crunch. (Thanks Novex)
[#1975] Added automatic tests on Windows environment.
[#1952] Fixed issue when decoding .xsd files between aapt1/aapt2.
[#1976] Fixed issue with decoding applications with a malformed chunk header. (Thanks sebras)
[#1996] Fixed issue with Mac scripts stealing focus.
[#1994, #1922] Fixed issue with array resource bag items having wrong type. (Thanks vbarthel-fr)
[#1522] Fixed issue with 9patch images missing vertical or horizontal divs. (Thanks IgorEisberg)
Fixed issue with resolving references to non-standard framework files. (Thanks IgorEisberg)
Fixed issue with resolving SDK Version Codes that were references. (Thanks IgorEisberg)
Added 32bit binaries for unix and win for aapt1/aapt2.
Added ability for api-level to be passed to smali. (Thanks IgorEisberg)
```
