### PR TITLE
correct issue reading plist

### DIFF
--- a/StaticAnalyzer/views/ios/plist_analysis.py
+++ b/StaticAnalyzer/views/ios/plist_analysis.py
@@ -4,6 +4,7 @@
 import os
 import logging
 import plistlib
+import biplist
 from MobSF.utils import (
     PrintException,
     isFileExists
@@ -17,11 +18,14 @@ logger = logging.getLogger(__name__)
 
 def convert_bin_xml(bin_xml_file):
     """Convert Binary XML to Readable XML"""
-    plist_obj = readPlist(bin_xml_file)
-    data = writePlistToString(plist_obj)
-    return data
-
-
+    try:
+      plist_obj = readPlist(bin_xml_file)
+      data = writePlistToString(plist_obj)
+      return data
+    except biplist.InvalidPlistException:
+      logger.warning("Failed to convert plist")
+    
+    
 def __check_permissions(p_list):
     """Check the permissions the app requests."""
     # List taken from


### PR DESCRIPTION
temporary fix to prevent abort

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
This fix prevent MobSf from generating a 503 and stop analyzing an ipa with plist in json format
#770 
```

### Checklist for PR

- [X] Run MobSF unit tests (http://your-mobsf-@ip:8000/tests/ or python3 manage.py test).
- [X] Tested Working on Linux, Mac, Windows, and Docker
- [X] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)
- [X] Coding style (indentation, etc)

### Additional Comments (if any)

```
Must be improved to better handle such case but can be enough for the moment 
```
