### PR TITLE
better Trackers stat display

### DIFF
--- a/templates/static_analysis/android_binary_analysis.html
+++ b/templates/static_analysis/android_binary_analysis.html
@@ -1242,7 +1242,7 @@ Production ready applications should not be signed with 'Android Debug' Certific
                 {{k}}
               </td>
               <td>
-                {{v}}
+                <a target="_blank" href="{{v}}">{{v}}</a>
               </td>
               {% endfor %}
             </tr>

--- a/templates/static_analysis/android_binary_analysis.html
+++ b/templates/static_analysis/android_binary_analysis.html
@@ -129,9 +129,12 @@
           </br>
           <span class="label label-success">VirusTotal Detection</span> <b>{{ VT_RESULT.positives }}/{{ VT_RESULT.total }}</b>
         {% endif %}
-        {% if trackers %}
+        {% if trackers.detected_trackers > 0 %}
           </br>
           <span class="label label-warning">Trackers Detection</span> <b>{{ trackers.detected_trackers }}/{{ trackers.total_trackers }}</b>
+        {% else %}
+          </br>
+          <span class="label label-success">Trackers Detection</span> <b>{{ trackers.detected_trackers }}/{{ trackers.total_trackers }}</b>
         {% endif %}
         </div><!-- /.box-body -->
       </div><!-- /.box -->


### PR DESCRIPTION
use green colour if no trackers detected also dispkay trackers url as clickable url 

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
If no trackes found in apk we display result with a green label, if trackers found then label is Orange
Trackers URL are clickable
```

### Checklist for PR

- [X] Run MobSF unit tests (http://your-mobsf-@ip:8000/tests/ or python3 manage.py test).
- [X] Tested Working on Linux, Mac, Windows, and Docker
- [X] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)
- [X] Coding style (indentation, etc)


