### PR TITLE
Corrected 'format' typo and moved 'url' declaration

### DIFF
--- a/DynamicAnalyzer/views/android/dynamic.py
+++ b/DynamicAnalyzer/views/android/dynamic.py
@@ -177,7 +177,7 @@ def take_screenshot(request):
                     ['screencap', '-p', '/data/local/screen.png'], True)
                 adb_command(['pull',
                              '/data/local/screen.png',
-                             '{}creenshot-{}.png'.fomat(
+                             '{}creenshot-{}.png'.format(
                                  screen_dir,
                                  str(rand_int))])
                 logger.info('Screenshot Taken')
@@ -807,7 +807,7 @@ def handle_sqlite(sfile):
             data += ('\nTABLE: {}'
                      ' \n==============='
                      '==================='
-                     '===================\n'.fomat(table[0]))
+                     '===================\n'.format(table[0]))
             cur.execute('PRAGMA table_info(\'%s\')' % table)
             rows = cur.fetchall()
             head = ''
@@ -890,8 +890,8 @@ def capfuzz_start(request):
             project = request.GET['project']
         else:
             project = ''
-            url = ('http://localhost:{}'
-                   '/dashboard/{}'.fomat(
+        url = ('http://localhost:{}'
+                   '/dashboard/{}'.format(
                        str(settings.PORT),
                        project))
         return HttpResponseRedirect(url)


### PR DESCRIPTION
### Describe the Pull Request

Receiving two errors upon launching CapFuzz.

```
[ERROR] 19/Jul/2019 12:47:21 - Starting CapFuzz Web UI
Traceback (most recent call last):
  File "C:\Working\docker\Mobile-Security-Framework-MobSF\DynamicAnalyzer\views\android\dynamic.py", line 897, in capfuzz_start
    url = ('http://localhost:{}'
UnboundLocalError: local variable 'url' referenced before assignment
[ERROR] 19/Jul/2019 12:47:21 - Error Starting CapFuzz UI
[ERROR] 19/Jul/2019 12:47:21 - Internal Server Error: /capfuzz
```
```
[ERROR] 19/Jul/2019 12:51:12 - Starting CapFuzz Web UI
Traceback (most recent call last):
  File "C:\Working\docker\Mobile-Security-Framework-MobSF\DynamicAnalyzer\views\android\dynamic.py", line 891, in capfuzz_start
    url = ('http://localhost:{}'
AttributeError: 'str' object has no attribute 'fomat'
[ERROR] 19/Jul/2019 12:51:12 - Error Starting CapFuzz UI
[ERROR] 19/Jul/2019 12:51:12 - Internal Server Error: /capfuzz
```

### Additional Comments (if any)

```
Moved the url declaration outside of the 'else' condition and changed 'fomat' to 'format'.

Is there a more appropriate location and/or default value for the url other than what I have set it to?
```
