### PR TITLE
Fix malware false positive

### DIFF
--- a/MalwareAnalyzer/views/domain_check.py
+++ b/MalwareAnalyzer/views/domain_check.py
@@ -61,7 +61,6 @@ def update_malware_db():
 
 
 def malware_check(urllist):
-    # noqa: ignore=F93,E501
     result = {}
     try:
         if not settings.DOMAIN_MALWARE_SCAN:
@@ -93,7 +92,7 @@ def malware_check(urllist):
                     if (details_dict['domain_or_url'].startswith(domain)
                             or (domain.startswith(details_dict['domain_or_url'], 4)
                                 and (len(details_dict['domain_or_url']) > 1))
-                            or details_dict['ip'].startswith(domain)):
+                            or details_dict['ip'].startswith(domain)):     # noqa: E501
                         result[domain] = details_dict
         # Good Domains
         for domain in domainlist:

--- a/MalwareAnalyzer/views/domain_check.py
+++ b/MalwareAnalyzer/views/domain_check.py
@@ -92,7 +92,7 @@ def malware_check(urllist):
                     if (details_dict['domain_or_url'].startswith(domain)
                             or (domain.startswith(details_dict['domain_or_url'], 4)
                                 and (len(details_dict['domain_or_url']) > 1))
-                            or details_dict['ip'].startswith(domain)):     # noqa: E501
+                            or details_dict['ip'].startswith(domain)):  # noqa E501
                         result[domain] = details_dict
         # Good Domains
         for domain in domainlist:

--- a/MalwareAnalyzer/views/domain_check.py
+++ b/MalwareAnalyzer/views/domain_check.py
@@ -1,3 +1,4 @@
+# noqa: E501
 # -*- coding: utf_8 -*-
 # Module for Malware Analysis
 import io
@@ -92,7 +93,7 @@ def malware_check(urllist):
                     if (details_dict['domain_or_url'].startswith(domain)
                             or (domain.startswith(details_dict['domain_or_url'], 4)
                                 and (len(details_dict['domain_or_url']) > 1))
-                            or details_dict['ip'].startswith(domain)):  # noqa E501
+                            or details_dict['ip'].startswith(domain)):
                         result[domain] = details_dict
         # Good Domains
         for domain in domainlist:

--- a/MalwareAnalyzer/views/domain_check.py
+++ b/MalwareAnalyzer/views/domain_check.py
@@ -1,5 +1,4 @@
 # -*- coding: utf_8 -*-
-# noqa: E501
 # Module for Malware Analysis
 import io
 import logging
@@ -89,10 +88,11 @@ def malware_check(urllist):
                 details_dict['ip'] = enlist[2]
                 details_dict['desc'] = enlist[4]
                 details_dict['bad'] = 'yes'
+                dmn_url = details_dict['domain_or_url']
                 for domain in domainlist:
-                    if (details_dict['domain_or_url'].startswith(domain)
-                            or (domain.startswith(details_dict['domain_or_url'], 4)
-                                and (len(details_dict['domain_or_url']) > 1))
+                    if (dmn_url.startswith(domain)
+                            or (domain.startswith(dmn_url, 4)
+                                and (len(dmn_url) > 1))
                             or details_dict['ip'].startswith(domain)):
                         result[domain] = details_dict
         # Good Domains

--- a/MalwareAnalyzer/views/domain_check.py
+++ b/MalwareAnalyzer/views/domain_check.py
@@ -1,5 +1,5 @@
-# noqa: E501
 # -*- coding: utf_8 -*-
+# noqa: E501
 # Module for Malware Analysis
 import io
 import logging

--- a/MalwareAnalyzer/views/domain_check.py
+++ b/MalwareAnalyzer/views/domain_check.py
@@ -61,6 +61,7 @@ def update_malware_db():
 
 
 def malware_check(urllist):
+    # noqa: ignore=F93,E501
     result = {}
     try:
         if not settings.DOMAIN_MALWARE_SCAN:

--- a/MalwareAnalyzer/views/domain_check.py
+++ b/MalwareAnalyzer/views/domain_check.py
@@ -89,8 +89,8 @@ def malware_check(urllist):
                 details_dict['desc'] = enlist[4]
                 details_dict['bad'] = 'yes'
                 for domain in domainlist:
-                    if (domain in details_dict['domain_or_url']
-                            or (details_dict['domain_or_url'] in domain
+                    if ((details_dict["domain_or_url"].startswith(domain)
+                            or (domain.startswith(details_dict["domain_or_url"], 4)
                                 and (len(details_dict['domain_or_url']) > 1))
                             or details_dict['ip'].startswith(domain)):
                         result[domain] = details_dict

--- a/MalwareAnalyzer/views/domain_check.py
+++ b/MalwareAnalyzer/views/domain_check.py
@@ -89,8 +89,8 @@ def malware_check(urllist):
                 details_dict['desc'] = enlist[4]
                 details_dict['bad'] = 'yes'
                 for domain in domainlist:
-                    if (details_dict["domain_or_url"].startswith(domain)
-                            or (domain.startswith(details_dict["domain_or_url"], 4)
+                    if (details_dict['domain_or_url'].startswith(domain)
+                            or (domain.startswith(details_dict['domain_or_url'], 4)
                                 and (len(details_dict['domain_or_url']) > 1))
                             or details_dict['ip'].startswith(domain)):
                         result[domain] = details_dict

--- a/MalwareAnalyzer/views/domain_check.py
+++ b/MalwareAnalyzer/views/domain_check.py
@@ -89,7 +89,7 @@ def malware_check(urllist):
                 details_dict['desc'] = enlist[4]
                 details_dict['bad'] = 'yes'
                 for domain in domainlist:
-                    if ((details_dict["domain_or_url"].startswith(domain)
+                    if (details_dict["domain_or_url"].startswith(domain)
                             or (domain.startswith(details_dict["domain_or_url"], 4)
                                 and (len(details_dict['domain_or_url']) > 1))
                             or details_dict['ip'].startswith(domain)):


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
using in instead of startswith will produce false positive example for chrombeta which use 
g.co. if we use in it will match malware url 
```

### Checklist for PR

- [X] Run MobSF unit tests and lint `tox -e lint,test`.
- [X] Tested Working on Linux, Mac, Windows, and Docker
- [X] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

