### PR TITLE
add warning for mojave and newer version 

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -34,7 +34,7 @@ if [[ "$unamestr" == 'Darwin' ]]; then
   is_installed=$(pkgutil --pkgs=com.apple.pkg.macOS_SDK_headers_for_macOS_${current_macos_version})
   if [ -z "$is_installed" ]; then 
       if [ "$major" -ge "10" ] && [ "$minor" -ge "14" ]; then 
-          echo 'Please install macOS headers to prevent apkid error 34'
+          echo 'Please install macOS headers.'
           echo 'sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${current_macos_version}.pkg -target /'
           exit 1
       fi    

--- a/setup.sh
+++ b/setup.sh
@@ -29,10 +29,12 @@ if [[ "$unamestr" == 'Darwin' ]]; then
   export LDFLAGS='-L/usr/local/opt/openssl/lib'
   export CFLAGS='-I/usr/local/opt/openssl/include'
   current_macos_version="$(sw_vers -productVersion | awk -F '.' '{print $1 "." $2}')"
-  if [ "${current_macos_version}" == "10.14" ]; then 
+  major=$(echo "$current_macos_version" | cut -d'.' -f1)
+  minor=$(echo "$current_macos_version" | cut -d'.' -f2)
+  if [ "$major" -ge "10" ] && [ "$minor" -ge "14" ]; then 
       echo 'Please install MacoS headers to prevent apkid error 34'
-      echo 'sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /'
-  fi    
+      echo 'sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${current_macos_version}.pkg -target /'
+  fi  
 fi
 
 echo '[INSTALL] Installing APKiD requirements - yara-python'

--- a/setup.sh
+++ b/setup.sh
@@ -31,9 +31,13 @@ if [[ "$unamestr" == 'Darwin' ]]; then
   current_macos_version="$(sw_vers -productVersion | awk -F '.' '{print $1 "." $2}')"
   major=$(echo "$current_macos_version" | cut -d'.' -f1)
   minor=$(echo "$current_macos_version" | cut -d'.' -f2)
-  if [ "$major" -ge "10" ] && [ "$minor" -ge "14" ]; then 
-      echo 'Please install MacoS headers to prevent apkid error 34'
-      echo 'sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${current_macos_version}.pkg -target /'
+  is_installed=$(pkgutil --pkgs=com.apple.pkg.macOS_SDK_headers_for_macOS_${current_macos_version})
+  if [ -z "$is_installed" ]; then 
+      if [ "$major" -ge "10" ] && [ "$minor" -ge "14" ]; then 
+          echo 'Please install MacoS headers to prevent apkid error 34'
+          echo 'sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${current_macos_version}.pkg -target /'
+          exit 1
+      fi    
   fi  
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -34,7 +34,7 @@ if [[ "$unamestr" == 'Darwin' ]]; then
   is_installed=$(pkgutil --pkgs=com.apple.pkg.macOS_SDK_headers_for_macOS_${current_macos_version})
   if [ -z "$is_installed" ]; then 
       if [ "$major" -ge "10" ] && [ "$minor" -ge "14" ]; then 
-          echo 'Please install MacoS headers to prevent apkid error 34'
+          echo 'Please install macOS headers to prevent apkid error 34'
           echo 'sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${current_macos_version}.pkg -target /'
           exit 1
       fi    

--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,12 @@ unamestr=$(uname)
 if [[ "$unamestr" == 'Darwin' ]]; then
   export ARCHFLAGS='-arch x86_64'
   export LDFLAGS='-L/usr/local/opt/openssl/lib'
-  export CFLAGS='-I/usr/local/opt/openssl/include'  
+  export CFLAGS='-I/usr/local/opt/openssl/include'
+  current_macos_version="$(sw_vers -productVersion | awk -F '.' '{print $1 "." $2}')"
+  if [ "${current_macos_version}" == "10.14" ]; then 
+      echo 'Please install MacoS headers to prevent apkid error 34'
+      echo 'sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /'
+  fi    
 fi
 
 echo '[INSTALL] Installing APKiD requirements - yara-python'


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
Mojave users must install headers, just add a warning cause nobody read the documentation
```

### Checklist for PR

- [X] Run MobSF unit tests and lint `tox -e lint,test`.
- [X] Tested Working on Linux, Mac, Windows, and Docker
- [X] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

