### PR TITLE
Fix Android insecure Random Number Generator static rule

### DIFF
--- a/StaticAnalyzer/views/android/android_rules.py
+++ b/StaticAnalyzer/views/android/android_rules.py
@@ -220,7 +220,7 @@ RULES = [
     {
         'desc': 'The App uses an insecure Random Number Generator.',
         'type': 'regex',
-        'regex1': r'java\.util\.Random',
+        'regex1': r'\bjava\.util\.Random\b',
         'level': 'high',
         'match': 'single_regex',
         'input_case': 'exact',


### PR DESCRIPTION
This fixes an issue with "java.util.RandomAccess" being flagged by mistake because it contains "java.util.Random".