### PR TITLE
Fix a bug with checking if package name exist in Android SKIP_CLASSES

### DIFF
--- a/StaticAnalyzer/views/android/code_analysis.py
+++ b/StaticAnalyzer/views/android/code_analysis.py
@@ -49,7 +49,7 @@ def code_analysis(app_dir, perms, typ):
                                        jfile.replace('+', 'x'))
                     shutil.move(jfile_path, p_2)
                     jfile_path = p_2
-                repath = dir_name.replace(java_src, '')
+                repath = dir_name.replace(java_src, '') + '/'
                 if (
                         jfile.endswith('.java')
                         and any(re.search(cls, repath)


### PR DESCRIPTION
Static analyzer would skip over classes in sub-packages but it wouldn't skip classes in top-level package.

For example, "okhttp3/OkHttpClient.java" file would still be processed, even though "okhttp3" is in SKIP_CLASSES.
