### PR TITLE
Reduce Docker image size by replacing wkhtml with static compiled 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .github
 .tox
 .dockerignore
+.sonarcloud.properties
 .travis.yml
 tox.ini
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ LABEL \
 
 #Environment vars
 ENV DEBIAN_FRONTEND="noninteractive" \
-    JDK_FILE="openjdk-12_linux-x64_bin.tar.gz"
+    JDK_FILE="openjdk-12_linux-x64_bin.tar.gz" \
+    WKH_FILE="wkhtmltox-0.12.5-dev-163e124_linux-generic-amd64.tar.xz"
 
-ENV JDK_URL="https://download.java.net/java/GA/jdk12/GPL/${JDK_FILE}" 
+ENV JDK_URL="https://download.java.net/java/GA/jdk12/GPL/${JDK_FILE}" \
+    WKH_URL="http://www.ajvg.com/downloads/${WKH_FILE}"
 
 #Update the repository sources list
 #Install Required Libs
@@ -44,6 +46,11 @@ RUN apt update -y && apt install -y \
 RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
+#Install Wkhtmltopdf
+RUN wget --quiet -O /tmp/wkhtmltox.tar.xz "${WKH_URL}" && \
+    tar xJf /tmp/wkhtmltox.tar.xz -C /usr/bin/ --strip-component=2 wkhtmltox/bin/wkhtmltopdf && \
+    rm -f /tmp/wkhtmltox.tar.xz
+
 #Install OpenJDK12
 RUN wget --quiet "${JDK_URL}" && \
     tar zxf "${JDK_FILE}" && \
@@ -54,10 +61,6 @@ ENV PATH="$JAVA_HOME/bin:$PATH"
 #Add MobSF master
 COPY . /root/Mobile-Security-Framework-MobSF
 WORKDIR /root/Mobile-Security-Framework-MobSF
-
-#Symlink wkhtml tools
-RUN ln -s /root/Mobile-Security-Framework-MobSF/StaticAnalyzer/tools/wkhtmltox/bin/wkhtmltopdf /usr/bin/ \
-    ln -s /root/Mobile-Security-Framework-MobSF/StaticAnalyzer/tools/wkhtmltox/bin/wkhtmltoimage /usr/bin/
 
 #Enable Use Home Directory
 RUN sed -i 's/USE_HOME = False/USE_HOME = True/g' MobSF/settings.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,9 @@ LABEL \
 
 #Environment vars
 ENV DEBIAN_FRONTEND="noninteractive" \
-    JDK_FILE="openjdk-12_linux-x64_bin.tar.gz" \
-    WKH_FILE="wkhtmltox-0.12.5-dev-163e124_linux-generic-amd64.tar.xz"
+    JDK_FILE="openjdk-12_linux-x64_bin.tar.gz"
 
-ENV JDK_URL="https://download.java.net/java/GA/jdk12/GPL/${JDK_FILE}" \
-    WKH_URL="http://www.ajvg.com/downloads/${WKH_FILE}"
+ENV JDK_URL="https://download.java.net/java/GA/jdk12/GPL/${JDK_FILE}" 
 
 #Update the repository sources list
 #Install Required Libs
@@ -53,19 +51,13 @@ RUN wget --quiet "${JDK_URL}" && \
 ENV JAVA_HOME="/jdk-12" 
 ENV PATH="$JAVA_HOME/bin:$PATH"
 
-#Install wkhtmltopdf for PDF Reports
-WORKDIR /tmp
-RUN wget --quiet "${WKH_URL}" && \
-    tar xJf "${WKH_FILE}"
-WORKDIR /tmp/wkhtmltox/bin
-RUN cp ./* /usr/bin
-WORKDIR /tmp
-RUN rm -rf ./wkhtmltox && \
-    rm -f "${WKH_FILE}"
-
 #Add MobSF master
 COPY . /root/Mobile-Security-Framework-MobSF
 WORKDIR /root/Mobile-Security-Framework-MobSF
+
+#Symlink wkhtml tools
+RUN ln -s /root/Mobile-Security-Framework-MobSF/StaticAnalyzer/tools/wkhtmltox/bin/wkhtmltopdf /usr/bin/ \
+    ln -s /root/Mobile-Security-Framework-MobSF/StaticAnalyzer/tools/wkhtmltox/bin/wkhtmltoimage /usr/bin/
 
 #Enable Use Home Directory
 RUN sed -i 's/USE_HOME = False/USE_HOME = True/g' MobSF/settings.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,8 @@ RUN apt update -y && apt install -y \
     xfonts-75dpi \
     python3.6 \
     python3-dev \
-    python3-setuptools \
-    wget && \
-    python3 /usr/lib/python3/dist-packages/easy_install.py pip
+    python3-pip \
+    wget
      
 #set locales
 RUN locale-gen en_US.UTF-8
@@ -59,7 +58,7 @@ WORKDIR /tmp
 RUN wget --quiet "${WKH_URL}" && \
     tar xJf "${WKH_FILE}"
 WORKDIR /tmp/wkhtmltox/bin
-RUN cp * /usr/bin
+RUN cp ./* /usr/bin
 WORKDIR /tmp
 RUN rm -rf ./wkhtmltox && \
     rm -f "${WKH_FILE}"
@@ -96,6 +95,11 @@ RUN pip3 install --quiet --no-cache-dir -r requirements.txt
 RUN \
     apt remove -y \
         git \
+        libssl-dev \
+        libffi-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        python3-dev \
         wget && \
     apt clean && \
     apt autoclean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ WORKDIR /root/Mobile-Security-Framework-MobSF
 RUN mkdir -p /root/.local/share/apktool/framework
 
 #Install APKiD dependencies
-RUN pip3 install --quiet --no-cache-dir wheel && \
+RUN pip3 install --quiet --no-cache-dir wheel==0.33.4 && \
     pip3 wheel --quiet --no-cache-dir --wheel-dir=/tmp/yara-python --build-option="build" --build-option="--enable-dex" git+https://github.com/VirusTotal/yara-python.git && \
     pip3 install --quiet --no-cache-dir --no-index --find-links=/tmp/yara-python yara-python
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,61 +11,59 @@ LABEL \
     description="Mobile Security Framework is an intelligent, all-in-one open source mobile application (Android/iOS/Windows) automated pen-testing framework capable of performing static, dynamic analysis and web API testing"
 
 #Environment vars
-ENV DEBIAN_FRONTEND="noninteractive"
-ENV PDFGEN_PKGFILE="wkhtmltox_0.12.5-1.bionic_amd64.deb" 
-ENV PDFGEN_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/${PDFGEN_PKGFILE}"
-ENV JDK_FILE="openjdk-12_linux-x64_bin.tar.gz"
-ENV JDK_URL="https://download.java.net/java/GA/jdk12/GPL/${JDK_FILE}"
+ENV DEBIAN_FRONTEND="noninteractive" \
+    JDK_FILE="openjdk-12_linux-x64_bin.tar.gz" \
+    WKH_FILE="wkhtmltox-0.12.5-dev-163e124_linux-generic-amd64.tar.xz"
+
+ENV JDK_URL="https://download.java.net/java/GA/jdk12/GPL/${JDK_FILE}" \
+    WKH_URL="http://www.ajvg.com/downloads/${WKH_FILE}"
 
 #Update the repository sources list
 #Install Required Libs
 #see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
 RUN apt update -y && apt install -y \
     build-essential \
+    git \
     libssl-dev \
     libffi-dev \
     libxml2-dev \
     libxslt1-dev \
     locales \
-    wget
-
+    sqlite3 \
+    fontconfig-config \
+    libjpeg-turbo8 \
+    libxrender1 \
+    libfontconfig1 \ 
+    libxext6 \
+    fontconfig \
+    xfonts-75dpi \
+    python3.6 \
+    python3-dev \
+    python3-setuptools \
+    wget && \
+    python3 /usr/lib/python3/dist-packages/easy_install.py pip
+     
 #set locales
 RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 #Install OpenJDK12
 RUN wget --quiet "${JDK_URL}" && \
-    tar zxvf "${JDK_FILE}" && \
+    tar zxf "${JDK_FILE}" && \
     rm -f "${JDK_FILE}"
-ENV JAVA_HOME=/jdk-12
-ENV PATH=$JAVA_HOME/bin:$PATH
-
-#Install Python 3
-RUN \
-    apt install -y \
-    python3.6 \
-    python3-dev \
-    python3-setuptools && \
-    python3 /usr/lib/python3/dist-packages/easy_install.py pip
-
-#Install git, sqlite3 client and pdf generator needed dependencies
-RUN \
-    apt install -y \
-    sqlite3 \
-    fontconfig-config \
-    libjpeg-turbo8 \
-    fontconfig \
-    xorg \
-    xfonts-75dpi \
-    git
+ENV JAVA_HOME="/jdk-12" 
+ENV PATH="$JAVA_HOME/bin:$PATH"
 
 #Install wkhtmltopdf for PDF Reports
 WORKDIR /tmp
-RUN wget --quiet ${PDFGEN_URL} && \
-    dpkg -i ${PDFGEN_PKGFILE} && \
-    rm -rf ${PDFGEN_PKGFILE}
+RUN wget --quiet "${WKH_URL}" && \
+    tar xJf "${WKH_FILE}"
+WORKDIR /tmp/wkhtmltox/bin
+RUN cp * /usr/bin
+WORKDIR /tmp
+RUN rm -rf ./wkhtmltox && \
+    rm -f "${WKH_FILE}"
 
-   
 #Add MobSF master
 COPY . /root/Mobile-Security-Framework-MobSF
 WORKDIR /root/Mobile-Security-Framework-MobSF
@@ -87,16 +85,18 @@ WORKDIR /root/Mobile-Security-Framework-MobSF
 RUN mkdir -p /root/.local/share/apktool/framework
 
 #Install APKiD dependencies
-RUN pip3 install --no-cache-dir wheel
-RUN pip3 wheel --no-cache-dir --wheel-dir=/tmp/yara-python --build-option="build" --build-option="--enable-dex" git+https://github.com/VirusTotal/yara-python.git
-RUN pip3 install --no-cache-dir --no-index --find-links=/tmp/yara-python yara-python
+RUN pip3 install --quiet --no-cache-dir wheel && \
+    pip3 wheel --quiet --no-cache-dir --wheel-dir=/tmp/yara-python --build-option="build" --build-option="--enable-dex" git+https://github.com/VirusTotal/yara-python.git && \
+    pip3 install --quiet --no-cache-dir --no-index --find-links=/tmp/yara-python yara-python
 
 #Install Dependencies
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 install --quiet --no-cache-dir -r requirements.txt
 
 #Cleanup
 RUN \
-    apt remove -y git && \
+    apt remove -y \
+        git \
+        wget && \
     apt clean && \
     apt autoclean && \
     apt autoremove -y && \
@@ -106,6 +106,7 @@ RUN \
 EXPOSE 8000
 
 RUN python3 manage.py makemigrations && \
+    python3 manage.py makemigrations StaticAnalyzer && \
     python3 manage.py migrate
 
 #Run MobSF


### PR DESCRIPTION


<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```

- Reduce Docker image Size 

- Reorder command to reduce layer

- Reduce Layer

- Silent some command

- Use Static compiled version of Wkhtmltopdf 

- Remove no more needed binaries

```

### Checklist for PR

- [X] Run MobSF unit tests and lint `tox -e lint,test`.
- [X] Tested Working on Linux, Mac, Windows, and Docker
- [X] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
wkhtml static version is downloaded from internet but if needed we can put it in MobSF repo
Docker file is reordered to have a base layer in case we decide to split it 

```
