### PR TITLE
Setup: add macOS info

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,8 @@ if [[ "$unamestr" == 'Darwin' ]]; then
   is_installed=$(pkgutil --pkgs=com.apple.pkg.macOS_SDK_headers_for_macOS_${current_macos_version})
   if [ -z "$is_installed" ]; then 
       if [ "$major" -ge "10" ] && [ "$minor" -ge "14" ]; then 
-          echo 'Please install macOS headers.'
+          echo 'Please install command-line tools and macOS headers.'
+          echo 'xcode-select --install'
           echo "sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${current_macos_version}.pkg -target /"
           exit 1
       fi    


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
For macOS users, some tools must be installed:

- command-line tools

- macOS headers

The setup will now display a message if headers are not there, and provide command to install both tools which are required for setup
```

### Checklist for PR

- [X] Run MobSF unit tests and lint `tox -e lint,test`.
- [X] Tested Working on Linux, Mac, Windows, and Docker
- [X] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)


