### PR TITLE
don't convert URLs to lower

### DIFF
--- a/StaticAnalyzer/views/shared_func.py
+++ b/StaticAnalyzer/views/shared_func.py
@@ -556,7 +556,7 @@ def url_n_email_extract(dat, relative_path):
             r'[\w().=/;,#:@?&~*+!$%\'{}-]+)'
         ),
         re.UNICODE)
-    urllist = re.findall(pattern, dat.lower())
+    urllist = re.findall(pattern, dat)
     uflag = 0
     for url in urllist:
         if url not in urls:


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
When extracted urls were converted to lower, we shouldn't do that cause for example filename could be uppercase , and if we test the url we will have a 404 
```

### Checklist for PR

- [X] Run MobSF unit tests and lint `tox -e lint,test`.
- [X] Tested Working on Linux, Mac, Windows, and Docker
- [X] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

solve #1074 