### PR TITLE
Quit on error in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 if ! [ -x "$(command -v python3)" ]; then
   echo '[ERROR] python3 is not installed.' >&2
   exit 1
@@ -20,21 +21,21 @@ fi
 
 unamestr=$(uname)
 if [[ "$unamestr" == 'Darwin' ]]; then
-  export ARCHFLAGS='-arch x86_64'
-  export LDFLAGS='-L/usr/local/opt/openssl/lib'
-  export CFLAGS='-I/usr/local/opt/openssl/include'
-  current_macos_version="$(sw_vers -productVersion | awk -F '.' '{print $1 "." $2}')"
-  major=$(echo "$current_macos_version" | cut -d'.' -f1)
-  minor=$(echo "$current_macos_version" | cut -d'.' -f2)
-  is_installed=$(pkgutil --pkgs=com.apple.pkg.macOS_SDK_headers_for_macOS_${current_macos_version})
-  if [ -z "$is_installed" ]; then 
-      if [ "$major" -ge "10" ] && [ "$minor" -ge "14" ]; then 
-          echo 'Please install command-line tools and macOS headers.'
-          echo 'xcode-select --install'
-          echo "sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${current_macos_version}.pkg -target /"
-          exit 1
-      fi    
-  fi  
+    export ARCHFLAGS='-arch x86_64'
+    export LDFLAGS='-L/usr/local/opt/openssl/lib'
+    export CFLAGS='-I/usr/local/opt/openssl/include'
+    current_macos_version="$(sw_vers -productVersion | awk -F '.' '{print $1 "." $2}')"
+    major=$(echo "$current_macos_version" | cut -d'.' -f1)
+    minor=$(echo "$current_macos_version" | cut -d'.' -f2)
+    is_installed=$(pkgutil --pkgs=com.apple.pkg.macOS_SDK_headers_for_macOS_${current_macos_version})
+    if [ -z "$is_installed" ]; then
+        if [ "$major" -ge "10" ] && [ "$minor" -ge "14" ]; then
+            echo 'Please install command-line tools and macOS headers.'
+            echo 'xcode-select --install'
+            echo "sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${current_macos_version}.pkg -target /"
+            exit 1
+        fi
+    fi
 fi
 
 echo '[INSTALL] Using venv'
@@ -57,5 +58,7 @@ echo '[INSTALL] Migrating Database'
 python manage.py makemigrations
 python manage.py makemigrations StaticAnalyzer
 python manage.py migrate
-echo 'Download and Install wkhtmltopdf for PDF Report Generation - https://wkhtmltopdf.org/downloads.html'
+if ! [ -x "$(command -v wkhtmltopdf)" ]; then
+    echo 'Download and Install wkhtmltopdf for PDF Report Generation - https://wkhtmltopdf.org/downloads.html'
+fi
 echo '[INSTALL] Installation Complete'


### PR DESCRIPTION
use set -e to exit the script on any error. This is better than no
error handling at all and running code, even if the previous command
failed.

Also adding a check if wkhtmltopdf is already installed.

Using four space indentation for the whole file.

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
DESCRIBE THE DETAILS OF PULL REQUEST HERE
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`.
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
DESCRIBE HERE
```
