### PR TITLE
Fixed bug in the iOS static analyzer when the binary name was not the…

### DIFF
--- a/StaticAnalyzer/views/ios/binary_analysis.py
+++ b/StaticAnalyzer/views/ios/binary_analysis.py
@@ -488,7 +488,7 @@ def binary_analysis(src, tools_dir, app_dir, executable_name):
         # Bin Dir - Dir/Payload/x.app/
         bin_dir = os.path.join(src, dot_app_dir)
         if (executable_name
-                and is_file_exists(executable_name)):
+                and is_file_exists(os.path.join(bin_dir, executable_name))):
             bin_name = executable_name
         else:
             bin_name = dot_app_dir.replace('.app', '')


### PR DESCRIPTION
… same as the package name

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
The iOS Static Analyzer had a bug when the binary name was not the same as the package name. On the if clause, the is_file_exists function received just the binary name, without the complete path, thus this function returns always false.
```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

