### PR TITLE
Replace tracker URL by Exodus tracker URL with more details

### DIFF
--- a/MalwareAnalyzer/views/Trackers.py
+++ b/MalwareAnalyzer/views/Trackers.py
@@ -170,5 +170,6 @@ class Trackers:
                         'total_trackers': self.nb_trackers_signature,
                         'trackers': []}
         for trk in trackers:
-            tracker_dict['trackers'].append({trk.name: trk.website})
+            trk_url = '{}/trackers/{}'.format(settings.TRACKERS_URL, trk.id)
+            tracker_dict['trackers'].append({trk.name: trk_url})
         return tracker_dict

--- a/MobSF/settings.py
+++ b/MobSF/settings.py
@@ -330,7 +330,8 @@ else:
     # -----External URLS--------------------------
     MALWARE_DB_URL = 'http://www.malwaredomainlist.com/mdlcsv.php'
     VIRUS_TOTAL_BASE_URL = 'https://www.virustotal.com/vtapi/v2/file/'
-    TRACKERS_DB_URL = 'https://reports.exodus-privacy.eu.org/api/trackers'
+    TRACKERS_URL = 'https://reports.exodus-privacy.eu.org'
+    TRACKERS_DB_URL = '{}/api/trackers'.format(TRACKERS_URL)
 
     # ========DISABLED COMPONENTS===================
 


### PR DESCRIPTION
Hello there! :)

### Describe the Pull Request

Replacing the URL of the trackers website with the trackers profile from [εxodus](http://reports.exodus-privacy.eu.org/trackers/)

**Benefits:**
- Shows the code detection which was used to detect the tracker
- Displays additional details about the tracker alongside statistics from εxodus
- Indirectly credits the project which is used to detect trackers

**Example:**
![image](https://user-images.githubusercontent.com/6069449/66266443-6e17d380-e825-11e9-99e5-e07535dd70ab.png)


### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
- Although the changes are very minor, note that I didn't manage to run the tox linter with the provided documentation
- I changed the settings.py file to make sure the URL is defined only once. Any suggestions are welcome :). 
```
