### PR TITLE
Make setup.sh  macOS Catalina compliant

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,12 +30,12 @@ if [[ "$unamestr" == 'Darwin' ]]; then
             echo "sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${current_macos_version}.pkg -target /"
             exit 1
         else    
-           xcode-select -v		
-	         if ! [ $? -eq 0 ]; then
+            xcode-select -v		
+	    if ! [ $? -eq 0 ]; then
                echo 'Please install command-line tools'
                echo 'xcode-select --install' 
                exit 1
-	         fi    
+	    fi    
         fi    
     fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,14 @@ if [[ "$unamestr" == 'Darwin' ]]; then
             echo 'xcode-select --install'
             echo "sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${current_macos_version}.pkg -target /"
             exit 1
-        fi
+        else    
+           xcode-select -v		
+	         if ! [ $? -eq 0 ]; then
+               echo 'Please install command-line tools'
+               echo 'xcode-select --install' 
+               exit 1
+	         fi    
+        fi    
     fi
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ if [[ "$unamestr" == 'Darwin' ]]; then
     minor=$(echo "$current_macos_version" | cut -d'.' -f2)
     is_installed=$(pkgutil --pkgs=com.apple.pkg.macOS_SDK_headers_for_macOS_${current_macos_version})
     if [ -z "$is_installed" ]; then
-        if [ "$major" -ge "10" ] && [ "$minor" -ge "14" ]; then
+        if [ "$major" -ge "10" ] && [ "$minor" -lt "15" ]; then
             echo 'Please install command-line tools and macOS headers.'
             echo 'xcode-select --install'
             echo "sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${current_macos_version}.pkg -target /"


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
on Mojave headers are not installed by default but they are on Catalina so on catalina we only need to check if command line utility is installed 

```

### Checklist for PR

- [X] Run MobSF unit tests and lint `tox -e lint,test`.
- [X] Tested Working on Linux, Mac and Docker
- [X] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

