### PR TITLE
[WIP] Update utils.py for Python 3.8

### DIFF
--- a/MobSF/utils.py
+++ b/MobSF/utils.py
@@ -93,7 +93,7 @@ def print_version():
     logger.info('OS: %s', platform.system())
     logger.info('Platform: %s', platform.platform())
     if platform.linux_distribution()[0]:
-        logger.info('Dist: %s', str(platform.dist()))
+        logger.info('Dist: %s', str(platform.linux_distribution()))
     find_java_binary()
     check_basic_env()
     thread = threading.Thread(target=check_update, name='check_update')

--- a/MobSF/utils.py
+++ b/MobSF/utils.py
@@ -93,7 +93,7 @@ def print_version():
     logger.info('OS: %s', platform.system())
     logger.info('Platform: %s', platform.platform())
     if platform.linux_distribution()[0]:
-        logger.info('Dist: %s', str(platform.linux_distribution()))
+        logger.info('Dist: %s', ' '.join(platform.linux_distribution()))
     find_java_binary()
     check_basic_env()
     thread = threading.Thread(target=check_update, name='check_update')

--- a/MobSF/utils.py
+++ b/MobSF/utils.py
@@ -92,7 +92,7 @@ def print_version():
         print('REST API Key: ' + Color.BOLD + api_key() + Color.END)
     logger.info('OS: %s', platform.system())
     logger.info('Platform: %s', platform.platform())
-    if platform.dist()[0]:
+    if platform.linux_distribution()[0]:
         logger.info('Dist: %s', str(platform.dist()))
     find_java_binary()
     check_basic_env()


### PR DESCRIPTION
plaftorm.dist is obsolete and removed in Python 3.8

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
platform.dist is removed in 3.8 an ddeprecated in 3.6 replace it with platform.linux_distribution()

```

### Checklist for PR

- [X] Run MobSF unit tests and lint `tox -e lint,test`.
- [X] Tested Working on Linux, Mac, Windows, and Docker
- [X] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
DESCRIBE HERE
```
