### PR TITLE
Update components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ matrix:
     - PATH=/c/Python37:/c/Python37/Scripts:$JAVA_HOME\\bin:$PATH
     before_install:
     - export TRAVIS_COMMIT_MSG="$(git log --format=%B --no-merges -n 1)"
-    - choco install wkhtmltopdf
     - choco install python --version 3.7.5
+    - choco install wkhtmltopdf --version 0.12.5
     - choco install openjdk --version 12.0.2
 install:
 - set PYTHONIOENCODING=UTF8

--- a/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/StaticAnalyzer/views/android/manifest_analysis.py
@@ -857,7 +857,7 @@ def get_manifest_file(app_path, app_dir, tools_dir):
                 and is_file_exists(settings.APKTOOL_BINARY)):
             apktool_path = settings.APKTOOL_BINARY
         else:
-            apktool_path = os.path.join(tools_dir, 'apktool_2.4.0.jar')
+            apktool_path = os.path.join(tools_dir, 'apktool_2.4.1.jar')
         output_dir = os.path.join(app_dir, 'apktool_out')
         args = [settings.JAVA_BINARY,
                 '-jar',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==2.2.7
 pdfkit==0.6.1
 androguard==3.3.5
-lxml==4.4.1
+lxml==4.4.2
 rsa==4.0
 biplist==1.0.3
 requests==2.22.0
@@ -11,9 +11,9 @@ macholib==1.11
 google-play-scraper==0.0.1.1
 whitenoise==4.1.4
 waitress==1.3.1
-gunicorn==20.0.0
+gunicorn==20.0.4
 frida==12.7.20
-psutil==5.6.5
+psutil==5.6.7
 shelljob==0.5.6
 asn1crypto==1.2.0
 oscrypto==1.1.0


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
Apktool update to 2.4.1  (add Android 10 support ...) 
`8afe0ea0336139fd57eb504433d602e6 md5
bdeb66211d1dc1c71f138003ce35f6d0cd19af6f8de7ffbdd5b118d02d825a52 sha256`

Update requirements:
lxml
gunicorn
psutil
```

### Checklist for PR

- [X] Run MobSF unit tests and lint `tox -e lint,test`.
- [X] Tested Working on Linux, Mac, and Docker
- [X] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

Win build using travis fail cause wkhtmlto pdf can't be found 
