### PR TITLE
Bail on APKiD failure

### DIFF
--- a/MalwareAnalyzer/views/apkid.py
+++ b/MalwareAnalyzer/views/apkid.py
@@ -29,7 +29,7 @@ def apkid_analysis(app_dir, apk_file, apk_name):
     options = Options(
         timeout=30,
         verbose=False,
-        entry_max_scan_size=100 * 1024 * 1024,
+        entry_max_scan_size=settings.DATA_UPLOAD_MAX_MEMORY_SIZE,
         recursive=True,
     )
     output = OutputFormatter(
@@ -45,7 +45,13 @@ def apkid_analysis(app_dir, apk_file, apk_name):
         findings = output._build_json_output(res)['files']
     except AttributeError:
         # apkid >= 2.0.3
-        findings = output.build_json_output(res)['files']
+        try:
+            findings = output.build_json_output(res)['files']
+        except AttributeError:
+            logger.error('yara-python dependency required by '
+                         'APKiD is not installed properly. '
+                         'Skipping APKiD analysis!')
+            findings = {}
     sanitized = {}
     for item in findings:
         filename = item['filename']


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
This is a fix to continue analysis on APKiD failure. The failure mostly occurs when dependencies are not installed as recommenced by official docs. Some of our users are bit adventurous on running the setup in ways undocumented.
```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=apkid_bail)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
DESCRIBE HERE
```
