### PR TITLE
Fixes to support AWS Genymotion Android AMI

### DIFF
--- a/DynamicAnalyzer/views/android/environment.py
+++ b/DynamicAnalyzer/views/android/environment.py
@@ -297,9 +297,14 @@ class Environment:
                                 'ro.serialno'], True)
         out += self.adb_command(['getprop',
                                 'ro.build.user'], True)
+        out += self.adb_command(['getprop',
+                                'ro.product.manufacturer'], True)
+
         if b'EMULATOR' in out:
             return 'emulator'
         elif b'genymotion' in out:
+            return 'genymotion'
+        elif b'Genymotion' in out:
             return 'genymotion'
         else:
             return ''
@@ -503,6 +508,8 @@ class Environment:
             frida_arch = 'arm64'
         elif arch == 'x86':
             frida_arch = 'x86'
+        elif arch == 'x86_64':
+            frida_arch = 'x86_64'
         else:
             logger.error('Make sure a Genymotion Android x86 VM'
                          ' or Android Studio Emulator'


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
Hi, MobSF authors.

I've faced some issues when I set up the Dynamic Analysis environment with MobSF in AWS.
In two words: current conditions can't detect Genymotion VM because:
1) incorrect properties calling
2) case sensitive issue: waiting for "genymotion" but get "Genymotion"
3) Frida server for x86_64 are not present in onDevice directory.

I think these issues could appear while Genymotion team assemble the AMI for AWS, but I'm not sure. Anyway, these fixes are solving the issues and can save hours for a lot of engineers.
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`.
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
DESCRIBE HERE
```
