### PR TITLE
bugfix: incorrect quotes cause settings configuration fields delete

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ LABEL \
 ENV DEBIAN_FRONTEND="noninteractive" \
     ANALYZER_IDENTIFIER="" \
     JDK_FILE="openjdk-12_linux-x64_bin.tar.gz" \
-    WKH_FILE="wkhtmltox_0.12.1.4-1.bionic_amd64.deb"
+    WKH_FILE="wkhtmltox_0.12.5-1.bionic_amd64.deb"
 
 ENV JDK_URL="https://download.java.net/java/GA/jdk12/GPL/${JDK_FILE}" \
-    WKH_URL="https://builds.wkhtmltopdf.org/0.12.1.4/${WKH_FILE}"
+    WKH_URL="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/${WKH_FILE}"
 
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
 RUN apt update -y && apt install -y \

--- a/scripts/postgres_support.sh
+++ b/scripts/postgres_support.sh
@@ -6,8 +6,8 @@ if [ "$POSTGRES" == True ]; then
  pip3 install psycopg2-binary
  #Enable postgres support
  sed -i '/# Sqlite3 suport/,/# End Sqlite3 support/d' ../MobSF/settings.py && \
- sed -i "/# Postgres DB - Install psycopg2/,/'''/d" ../MobSF/settings.py && \
- sed -i "/# End Postgres support/,/'''/d" ../MobSF/settings.py && \
+ sed -i '/# Postgres DB - Install psycopg2/,/"""/d' ../MobSF/settings.py && \
+ sed -i '/# End Postgres support/,/"""/d' ../MobSF/settings.py && \
  sed -i "s/'PASSWORD': '',/'PASSWORD': 'password',/" ../MobSF/settings.py && \
  sed -i "s/'HOST': 'localhost',/'HOST': 'postgres',/" ../MobSF/settings.py
 fi


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

MobSF/settings.py:

```
...
# Postgres DB - Install psycopg2
"""
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.postgresql_psycopg2',
        'NAME': 'mobsf',
        'USER': 'postgres',
        'PASSWORD': '',
        'HOST': 'localhost',
        'PORT': '',
    }
}
# End Postgres support
"""
...
```

after run below command, will delete all content after '# Postgres DB - Install psycopg2'
```
sed -i "/# Postgres DB - Install psycopg2/,/'''/d" ../MobSF/settings.py
```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
DESCRIBE HERE
```
