### PR TITLE
Fix Appmonsta privacyPolicy response

### DIFF
--- a/StaticAnalyzer/views/android/playstore.py
+++ b/StaticAnalyzer/views/android/playstore.py
@@ -65,7 +65,7 @@ def app_search(app_id):
         det['developerWebsite'] = resp.get('publisher_url', '')
         det['developerEmail'] = resp.get('publisher_email', '')
         det['released'] = resp.get('release_date', '')
-        det['privacyPolicy'] = resp.get('publisher_url', '')
+        det['privacyPolicy'] = resp.get('privacy_url', '')
         description = BeautifulSoup(resp.get('description', ''),
                                     features='lxml')
         det['description'] = description.get_text()


### PR DESCRIPTION
### Describe the Pull Request

Fixes MobSF/Mobile-Security-Framework-MobSF#1449

Fix `det['privacyPolicy']`

Correct response field from Appmonsta for privacyPolicy is privacy_url

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

