### PR TITLE
Update environment.py

### DIFF
--- a/DynamicAnalyzer/views/android/environment.py
+++ b/DynamicAnalyzer/views/android/environment.py
@@ -513,7 +513,7 @@ class Environment:
     def frida_setup(self):
         """Setup Frida."""
         frida_arch = None
-        frida_version = '12.9.8'
+        frida_version = '12.10.4'
         frida_dir = 'onDevice/frida/'
         arch = self.get_android_arch()
         logger.info('Android OS architecture identified as %s', arch)


### PR DESCRIPTION
Frida server version update to 12.10.4

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
Upon setting up android for dynamic analysis there was an error in the log regarding the wrong frida-server being pushed to the device. (Error message below.) 

[ERROR] 01/Jul/2020 02:43:28 - Error Running ADB Command

subprocess.CalledProcessError: Command '['~/Library/Android/sdk/platform-tools/adb', '-s', 'emulator-5554', 'push', '~/Mobile-Security-Framework-MobSF/DynamicAnalyzer/tools/onDevice/frida/frida-server-12.9.8-android-x86', '/system/fd_server']' returned non-zero exit status 1.

```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
DESCRIBE HERE
```
