### PR TITLE
Fix on Static Analysis on a zipped Android repository

### DIFF
--- a/StaticAnalyzer/views/android/code_analysis.py
+++ b/StaticAnalyzer/views/android/code_analysis.py
@@ -63,7 +63,7 @@ def code_analysis(app_dir, perms, typ):
                     jfile_path = p_2
                 repath = dir_name.replace(java_src, '') + '/'
                 if (
-                        jfile.endswith('.java')
+                        (jfile.endswith('.java') or jfile.endswith('.kt'))
                         and any(re.search(cls, repath)
                                 for cls in settings.SKIP_CLASSES) is False
                 ):

--- a/StaticAnalyzer/views/android/icon_analysis.py
+++ b/StaticAnalyzer/views/android/icon_analysis.py
@@ -79,16 +79,15 @@ def find_icon_path_zip(res_dir, icon_paths_from_manifest):
                         res_dir, path_array[0] + size_str, rel_path + '.png')
                     if os.path.exists(tmp_path):
                         return tmp_path
-            else:
-                if icon_path.startswith('res/') or icon_path.startswith('/res/'):
-                    stripped_relative_path = icon_path.strip(
-                        '/res')  # Works for neither /res and res
-                    full_path = os.path.join(res_dir, stripped_relative_path)
-                    if os.path.exists(full_path):
-                        return full_path
-                    full_path += '.png'
-                    if os.path.exists(full_path):
-                        return full_path
+            elif icon_path.startswith('res/') or icon_path.startswith('/res/'):
+                stripped_relative_path = icon_path.strip(
+                    '/res')  # Works for neither /res and res
+                full_path = os.path.join(res_dir, stripped_relative_path)
+                if os.path.exists(full_path):
+                    return full_path
+                full_path += '.png'
+                if os.path.exists(full_path):
+                    return full_path
 
             file_name = icon_path.split(os.sep)[-1]
             if file_name.endswith('.png'):

--- a/StaticAnalyzer/views/android/icon_analysis.py
+++ b/StaticAnalyzer/views/android/icon_analysis.py
@@ -79,7 +79,7 @@ def find_icon_path_zip(res_dir, icon_paths_from_manifest):
                         res_dir, path_array[0] + size_str, rel_path + '.png')
                     if os.path.exists(tmp_path):
                         return tmp_path
-            elif icon_path.startswith('res/') or icon_path.startswith('/res/'):
+            elif icon_path.startswith(('res/', '/res/')):
                 stripped_relative_path = icon_path.strip(
                     '/res')  # Works for neither /res and res
                 full_path = os.path.join(res_dir, stripped_relative_path)

--- a/StaticAnalyzer/views/android/icon_analysis.py
+++ b/StaticAnalyzer/views/android/icon_analysis.py
@@ -80,7 +80,7 @@ def find_icon_path_zip(res_dir, icon_paths_from_manifest):
                     if os.path.exists(tmp_path):
                         return tmp_path
             else:
-                if icon_path.starswith('res/') or icon_path.starswith('/res/'):
+                if icon_path.startswith('res/') or icon_path.startswith('/res/'):
                     stripped_relative_path = icon_path.strip(
                         '/res')  # Works for neither /res and res
                     full_path = os.path.join(res_dir, stripped_relative_path)

--- a/StaticAnalyzer/views/android/view_source.py
+++ b/StaticAnalyzer/views/android/view_source.py
@@ -41,7 +41,7 @@ def run(request, api=False):
             if api:
                 return err
             return print_n_send_error_response(request, err, False, exp)
-        if fil.endswith('.java'):
+        if fil.endswith('.java') or fil.endswith('.kt'):
             if typ == 'eclipse':
                 src = os.path.join(settings.UPLD_DIR, md5 + '/src/')
             elif typ == 'studio':

--- a/StaticAnalyzer/views/android/view_source.py
+++ b/StaticAnalyzer/views/android/view_source.py
@@ -41,7 +41,7 @@ def run(request, api=False):
             if api:
                 return err
             return print_n_send_error_response(request, err, False, exp)
-        if fil.endswith('.java') or fil.endswith('.kt'):
+        if fil.endswith(('.java', '.kt')):
             if typ == 'eclipse':
                 src = os.path.join(settings.UPLD_DIR, md5 + '/src/')
             elif typ == 'studio':


### PR DESCRIPTION
### Describe the Pull Request

This Pull Request is embedding three things:
  - A typo in the `find_icon_path_zip` function, the`starswith()` method does not exist for a string. The author certainly wanted to use the `startswith()` method. There was a crash while Static Analysis on a zipped Android repository, but not blocking.

  - During a Static Analysis on a zipped Android repository, only the `.java` files support a "Code Analysis". Kotlin and Java share many functions and it is useful to also analyze `.kt` files.

  - Allowing to display kotlin files (`.kt`) on the `ViewSource` feature, this is the same location than java files.

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)
