### PR TITLE
Support multi plist ats/permission analysis during Static Analysis

### DIFF
--- a/StaticAnalyzer/views/ios/plist_analysis.py
+++ b/StaticAnalyzer/views/ios/plist_analysis.py
@@ -82,7 +82,7 @@ def plist_analysis(src, is_source):
 
         # Generic Plist Analysis
         plist_obj = plistlib.readPlist(plist_file)
-        plist_info['plist_xml'] = plistlib.writePlistToBytes(
+        plist_info['plist_xml'] = plistlib.dumps(
             plist_obj).decode('utf-8', 'ignore')
         plist_info['bin_name'] = (plist_obj.get('CFBundleDisplayName', '')
                                   or plist_obj.get('CFBundleName', ''))

--- a/StaticAnalyzer/views/ios/plist_analysis.py
+++ b/StaticAnalyzer/views/ios/plist_analysis.py
@@ -73,38 +73,41 @@ def plist_analysis(src, is_source):
             bin_dir = os.path.join(src, dot_app_dir)  # Full Dir/Payload/x.app
             plist_file = os.path.join(bin_dir, 'Info.plist')
             plist_files = [plist_file]
+
+        # Skip Plist Analysis if there is no Info.plist
         if not is_file_exists(plist_file):
             logger.warning(
                 'Cannot find Info.plist file. Skipping Plist Analysis.')
-        else:
-            # Generic Plist Analysis
-            plist_obj = plistlib.readPlist(plist_file)
-            plist_info['plist_xml'] = plistlib.writePlistToBytes(
-                plist_obj).decode('utf-8', 'ignore')
-            plist_info['bin_name'] = (plist_obj.get('CFBundleDisplayName', '')
-                                      or plist_obj.get('CFBundleName', ''))
-            if not plist_info['bin_name'] and not is_source:
-                # For iOS IPA
-                plist_info['bin_name'] = dot_app_dir.replace('.app', '')
-            plist_info['bin'] = plist_obj.get('CFBundleExecutable', '')
-            plist_info['id'] = plist_obj.get('CFBundleIdentifier', '')
-            plist_info['build'] = plist_obj.get('CFBundleVersion', '')
-            plist_info['sdk'] = plist_obj.get('DTSDKName', '')
-            plist_info['pltfm'] = plist_obj.get('DTPlatformVersion', '')
-            plist_info['min'] = plist_obj.get('MinimumOSVersion', '')
-            plist_info['bundle_name'] = plist_obj.get('CFBundleName', '')
-            plist_info['bundle_version_name'] = plist_obj.get(
-                'CFBundleShortVersionString', '')
-            plist_info['bundle_url_types'] = plist_obj.get(
-                'CFBundleURLTypes', [])
-            plist_info['bundle_supported_platforms'] = plist_obj.get(
-                'CFBundleSupportedPlatforms', [])
-            for plist_file_ in plist_files:
-                plist_obj_ = plistlib.readPlist(plist_file_)
-                # Check for app-permissions
-                plist_info['permissions'] += check_permissions(plist_obj_)
-                # Check for ats misconfigurations
-                plist_info['inseccon'] += check_transport_security(plist_obj_)
+            return plist_info
+
+        # Generic Plist Analysis
+        plist_obj = plistlib.readPlist(plist_file)
+        plist_info['plist_xml'] = plistlib.writePlistToBytes(
+            plist_obj).decode('utf-8', 'ignore')
+        plist_info['bin_name'] = (plist_obj.get('CFBundleDisplayName', '')
+                                  or plist_obj.get('CFBundleName', ''))
+        if not plist_info['bin_name'] and not is_source:
+            # For iOS IPA
+            plist_info['bin_name'] = dot_app_dir.replace('.app', '')
+        plist_info['bin'] = plist_obj.get('CFBundleExecutable', '')
+        plist_info['id'] = plist_obj.get('CFBundleIdentifier', '')
+        plist_info['build'] = plist_obj.get('CFBundleVersion', '')
+        plist_info['sdk'] = plist_obj.get('DTSDKName', '')
+        plist_info['pltfm'] = plist_obj.get('DTPlatformVersion', '')
+        plist_info['min'] = plist_obj.get('MinimumOSVersion', '')
+        plist_info['bundle_name'] = plist_obj.get('CFBundleName', '')
+        plist_info['bundle_version_name'] = plist_obj.get(
+            'CFBundleShortVersionString', '')
+        plist_info['bundle_url_types'] = plist_obj.get(
+            'CFBundleURLTypes', [])
+        plist_info['bundle_supported_platforms'] = plist_obj.get(
+            'CFBundleSupportedPlatforms', [])
+        for plist_file_ in plist_files:
+            plist_obj_ = plistlib.readPlist(plist_file_)
+            # Check for app-permissions
+            plist_info['permissions'] += check_permissions(plist_obj_)
+            # Check for ats misconfigurations
+            plist_info['inseccon'] += check_transport_security(plist_obj_)
         return plist_info
     except Exception:
         logger.exception('Reading from Info.plist')


### PR DESCRIPTION
During the Static Analysis of a zipped iOS project the current configuration only allows the first Info.plist to be analysed.
There is sometimes multiple plist files in a repository and scan them all before compilation can give way more security information.

This Pull Request adds every .plist files to be analysed during a source-code Static Analysis, especially for permissions and ATS.

**Fixtures**:
  - Replace 'writePlist()' function by 'dumps()', deprecated in  plistlib>3.4 in `plist_analysis.py` 
  - Remove unnecessary 'else' statement in `plist_analysis.py` 

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

