### PR TITLE
Allow specifying a custom header

### DIFF
--- a/MobSF/views/api/rest_api.py
+++ b/MobSF/views/api/rest_api.py
@@ -26,14 +26,16 @@ def make_api_response(data, status=OK):
     resp = JsonResponse(data=data, status=status)
     resp['Access-Control-Allow-Origin'] = '*'
     resp['Access-Control-Allow-Methods'] = 'POST'
-    resp['Access-Control-Allow-Headers'] = 'Authorization'
+    resp['Access-Control-Allow-Headers'] = 'Authorization, X-Mobsf-Api-Key'
     resp['Content-Type'] = 'application/json; charset=utf-8'
     return resp
 
 
 def api_auth(meta):
     """Check if API Key Matches."""
-    if 'HTTP_AUTHORIZATION' in meta:
+    if 'HTTP_X_MOBSF_API_KEY' in meta:
+        return bool(api_key() == meta['HTTP_X_MOBSF_API_KEY'])
+    elif 'HTTP_AUTHORIZATION' in meta:
         return bool(api_key() == meta['HTTP_AUTHORIZATION'])
     return False
 

--- a/StaticAnalyzer/tests.py
+++ b/StaticAnalyzer/tests.py
@@ -189,6 +189,19 @@ def api_test():
         else:
             logger.error('Scan List API Test 2')
             return True
+        resp = http_client.get('/api/v1/scans', HTTP_X_MOBSF_API_KEY=auth)
+        if resp.status_code == 200:
+            logger.info('Scan List API Test with custom http header 1 success')
+        else:
+            logger.error('Scan List API Test custom http header 1')
+            return True
+        resp = http_client.get(
+            '/api/v1/scans?page=1&page_size=10', HTTP_X_MOBSF_API_KEY=auth)
+        if resp.status_code == 200:
+            logger.info('Scan List API Test custom http header 2 success')
+        else:
+            logger.error('Scan List API Test custom http header 2')
+            return True
         logger.info('[OK] Scan List API tests completed')
         # PDF Tests
         logger.info('Running PDF Generation API Test')
@@ -272,6 +285,14 @@ def api_test():
                 'hash2': '52c50ae824e329ba8b5b7a0f523efffe',
             },
             HTTP_AUTHORIZATION=auth)
+        assert (resp.status_code == 200)
+        resp = http_client.post(
+            '/api/v1/compare',
+            {
+                'hash1': '3a552566097a8de588b8184b059b0158',
+                'hash2': '52c50ae824e329ba8b5b7a0f523efffe',
+            },
+            HTTP_X_MOBSF_API_KEY=auth)
         assert (resp.status_code == 200)
         if resp.status_code == 200:
             logger.info('[OK] App compare API tests completed')

--- a/StaticAnalyzer/tests.py
+++ b/StaticAnalyzer/tests.py
@@ -193,14 +193,14 @@ def api_test():
         if resp.status_code == 200:
             logger.info('Scan List API Test with custom http header 1 success')
         else:
-            logger.error('Scan List API Test custom http header 1')
+            logger.error('Scan List API Test with custom http header 1')
             return True
         resp = http_client.get(
             '/api/v1/scans?page=1&page_size=10', HTTP_X_MOBSF_API_KEY=auth)
         if resp.status_code == 200:
-            logger.info('Scan List API Test custom http header 2 success')
+            logger.info('Scan List API Test with custom http header 2 success')
         else:
-            logger.error('Scan List API Test custom http header 2')
+            logger.error('Scan List API Test with custom http header 2')
             return True
         logger.info('[OK] Scan List API tests completed')
         # PDF Tests
@@ -225,6 +225,10 @@ def api_test():
         for pdf in pdfs:
             resp = http_client.post(
                 '/api/v1/download_pdf', pdf, HTTP_AUTHORIZATION=auth)
+            resp_custom = http_client.post(
+                '/api/v1/download_pdf', pdf, HTTP_X_MOBSF_API_KEY=auth)
+            assert (resp.status_code == 200)
+            assert (resp_custom.status_code == 200)
             if (resp.status_code == 200
                     and resp._headers['content-type'][1] == 'application/pdf'):
                 logger.info('[OK] PDF Report Generated: %s', pdf['hash'])
@@ -239,6 +243,10 @@ def api_test():
         for jsn in pdfs:
             resp = http_client.post(
                 '/api/v1/report_json', jsn, HTTP_AUTHORIZATION=auth)
+            resp_custom = http_client.post(
+                '/api/v1/report_json', jsn, HTTP_X_MOBSF_API_KEY=auth)
+            assert (resp.status_code == 200)
+            assert (resp_custom.status_code == 200)
             if (resp.status_code == 200
                     and resp._headers['content-type'][1] == ctype):
                 logger.info('[OK] JSON Report Generated: %s', jsn['hash'])
@@ -265,6 +273,10 @@ def api_test():
         for sfile in files:
             resp = http_client.post(
                 '/api/v1/view_source', sfile, HTTP_AUTHORIZATION=auth)
+            resp_custom = http_client.post(
+                '/api/v1/view_source', sfile, HTTP_X_MOBSF_API_KEY=auth)
+            assert (resp.status_code == 200)
+            assert (resp_custom.status_code == 200)
             if resp.status_code == 200:
                 dat = json.loads(resp.content.decode('utf-8'))
                 if dat['title']:
@@ -286,14 +298,14 @@ def api_test():
             },
             HTTP_AUTHORIZATION=auth)
         assert (resp.status_code == 200)
-        resp = http_client.post(
+        resp_custom = http_client.post(
             '/api/v1/compare',
             {
                 'hash1': '3a552566097a8de588b8184b059b0158',
                 'hash2': '52c50ae824e329ba8b5b7a0f523efffe',
             },
             HTTP_X_MOBSF_API_KEY=auth)
-        assert (resp.status_code == 200)
+        assert (resp_custom.status_code == 200)
         if resp.status_code == 200:
             logger.info('[OK] App compare API tests completed')
         else:

--- a/templates/general/apidocs.html
+++ b/templates/general/apidocs.html
@@ -1,4 +1,8 @@
-{% extends "base/base_layout.html" %} {% block sidebar_option %} sidebar-collapse {% endblock %} {% block content %}
+{% extends "base/base_layout.html" %}
+{% block sidebar_option %}
+    sidebar-collapse
+{% endblock %}
+{% block content %}
 <style>
   pre {
     white-space: pre-wrap; /* css-3 */

--- a/templates/general/apidocs.html
+++ b/templates/general/apidocs.html
@@ -1,619 +1,750 @@
-
-{% extends "base/base_layout.html" %}
- {% block sidebar_option %}
-      sidebar-collapse
-{% endblock %}
-{% block content %}
+{% extends "base/base_layout.html" %} {% block sidebar_option %} sidebar-collapse {% endblock %} {% block content %}
 <style>
-pre {
-      white-space: pre-wrap;       /* css-3 */
-      white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
-      white-space: -pre-wrap;      /* Opera 4-6 */
-      white-space: -o-pre-wrap;    /* Opera 7 */
-      word-wrap: break-word;       /* Internet Explorer 5.5+ */
-}
+  pre {
+    white-space: pre-wrap; /* css-3 */
+    white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+    white-space: -pre-wrap; /* Opera 4-6 */
+    white-space: -o-pre-wrap; /* Opera 7 */
+    word-wrap: break-word; /* Internet Explorer 5.5+ */
+  }
 </style>
 <div class="content-wrapper">
-  <div class="content-header">
-  </div>
-   <div class="container-fluid">
-        <div class="row">
-            <div class="col-lg-12">
-            <div class="card">
-              <div class="card-body">
-                 <h1><strong>REST API Docs</strong></h1>
-                    <p class="lead">
-                    REST API Key: <strong><code>{{ api_key}}</code></strong>
-                    </p>
+  <div class="content-header"></div>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-lg-12">
+        <div class="card">
+          <div class="card-body">
+            <h1><strong>REST API Docs</strong></h1>
+            <p class="lead">
+              REST API Key: <strong><code>{{ api_key}}</code></strong>
+            </p>
 
-                <!--API Docs -->
+            <!--API Docs -->
 
-                  <ol>
-                  <li><code>api/v1/upload</code> - <a href="#upload-file-api">Upload a File</a></li>
-                  <li><code>api/v1/scan</code> - <a href="#scan-file-api">Scan a File</a></li>
-                  <li><code>api/v1/scans</code> - <a href="#recent-scans-api">Display Recent Scans</a></li>
-                  <li><code>api/v1/delete_scan</code> - <a href="#delete-scan-api">Delete a Scan</a></li>
-                  <li><code>api/v1/download_pdf</code> - <a href="#generate-pdf-report-api">Download PDF Report</a></li>
-                  <li><code>api/v1/report_json</code> - <a href="#generate-json-report-api">Generate JSON Report</a></li>
-                  <li><code>api/v1/view_source</code> - <a href="#view-source-api">View Source Files</a></li>
-                  <li><code>api/v1/compare</code> - <a href="#compare-api">Compare Apps</a></li>
-                  </ol>
-                  <h2><a id="upload-file-api"></a><strong>Upload File API</strong></h2>
-                  <p>API to upload a file. Supported file types are apk, zip, ipa and appx.</p>
-                  <ul>
-                  <li>
-                  <p><strong>URL:</strong> <code>/api/v1/upload</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Method:</strong> <code>POST</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Data Params</strong></p>
-                  </li>
-                  </ul>
-                  <table class="table table-striped table-bordered">
-                  <thead>
-                  <tr>
+            <ol>
+              <li><code>api/v1/upload</code> - <a href="#upload-file-api">Upload a File</a></li>
+              <li><code>api/v1/scan</code> - <a href="#scan-file-api">Scan a File</a></li>
+              <li><code>api/v1/scans</code> - <a href="#recent-scans-api">Display Recent Scans</a></li>
+              <li><code>api/v1/delete_scan</code> - <a href="#delete-scan-api">Delete a Scan</a></li>
+              <li><code>api/v1/download_pdf</code> - <a href="#generate-pdf-report-api">Download PDF Report</a></li>
+              <li><code>api/v1/report_json</code> - <a href="#generate-json-report-api">Generate JSON Report</a></li>
+              <li><code>api/v1/view_source</code> - <a href="#view-source-api">View Source Files</a></li>
+              <li><code>api/v1/compare</code> - <a href="#compare-api">Compare Apps</a></li>
+            </ol>
+            <h2><a id="upload-file-api"></a><strong>Upload File API</strong></h2>
+            <p>API to upload a file. Supported file types are apk, zip, ipa and appx.</p>
+            <ul>
+              <li>
+                <p><strong>URL:</strong> <code>/api/v1/upload</code></p>
+              </li>
+              <li>
+                <p><strong>Method:</strong> <code>POST</code></p>
+              </li>
+              <li>
+                <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code> <strong>Or</strong> <code>X-Mobsf-Api-Key:&lt;api_key&gt;</code></p>
+              </li>
+              <li>
+                <p><strong>Data Params</strong></p>
+              </li>
+            </ul>
+            <table class="table table-striped table-bordered">
+              <thead>
+                <tr>
                   <th>Param Name</th>
                   <th>Param Value</th>
                   <th>Required</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  <tr>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
                   <td>file</td>
                   <td>multipart/form-data</td>
                   <td>Yes</td>
-                  </tr>
-                  </tbody>
-                  </table>
-                  <br>
-                  <ul>
+                </tr>
+              </tbody>
+            </table>
+            <br />
+            <ul>
+              <li>
+                <p><strong>Success Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Success Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>200</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;file_name&quot;: &quot;diva-beta.apk&quot;, &quot;hash&quot;: &quot;82ab8b2193b3cfb1c737e3a786be363a&quot;, &quot;scan_type&quot;: &quot;apk&quot;}</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>200</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;file_name&quot;: &quot;diva-beta.apk&quot;, &quot;hash&quot;: &quot;82ab8b2193b3cfb1c737e3a786be363a&quot;, &quot;scan_type&quot;: &quot;apk&quot;}</code>
                   </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Error Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Error Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong>  <code>500 Internal Server Error</code> or  <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code><br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code></li>
-                  </ul>
-                  <p>OR</p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>401 Unauthorized</code><br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code><br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>500 Internal Server Error</code> or <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code><br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code>
                   </li>
+                </ul>
+                <p>OR</p>
+                <ul>
                   <li>
-                  <p><strong>Sample Call:</strong></p>
-                  <pre><code>curl -F 'file=@/Users/ajin/Desktop/diva-beta.apk' http://localhost:8000/api/v1/upload -H &quot;Authorization:{{ api_key}}&quot;
+                    <strong>Code:</strong> <code>401 Unauthorized</code><br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code><br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Sample Call:</strong></p>
+                <ul>
+                  <li>
+                    <pre><code>curl -F 'file=@/Users/ajin/Desktop/diva-beta.apk' http://localhost:8000/api/v1/upload -H &quot;Authorization:{{ api_key}}&quot;
                   </code></pre>
                   </li>
-                  </ul>
-                  <hr/>
-                  <h2><a id="scan-file-api"></a><strong>Scan File API</strong></h2>
-                  <p>API to scan a file that is already uploaded.</p>
-                  <ul>
+                </ul>
+                <p>OR</p>
+                <ul>
                   <li>
-                  <p><strong>URL:</strong> <code>/api/v1/scan</code></p>
+                    <pre><code>curl -F 'file=@/Users/ajin/Desktop/diva-beta.apk' http://localhost:8000/api/v1/upload -H &quot;X-Mobsf-Api-Key:{{ api_key}}&quot;
+                  </code></pre>
                   </li>
-                  <li>
-                  <p><strong>Method:</strong> <code>POST</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Data Params</strong></p>
-                  </li>
-                  </ul>
-                  <table class="table table-striped table-bordered">
-                  <thead>
-                  <tr>
+                </ul>
+              </li>
+            </ul>
+            <hr />
+            <h2><a id="scan-file-api"></a><strong>Scan File API</strong></h2>
+            <p>API to scan a file that is already uploaded.</p>
+            <ul>
+              <li>
+                <p><strong>URL:</strong> <code>/api/v1/scan</code></p>
+              </li>
+              <li>
+                <p><strong>Method:</strong> <code>POST</code></p>
+              </li>
+              <li>
+                <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code> <strong>Or</strong> <code>X-Mobsf-Api-Key:&lt;api_key&gt;</code></p>
+              </li>
+              <li>
+                <p><strong>Data Params</strong></p>
+              </li>
+            </ul>
+            <table class="table table-striped table-bordered">
+              <thead>
+                <tr>
                   <th>Param Name</th>
                   <th>Param Value</th>
                   <th>Required</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  <tr>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
                   <td>scan_type</td>
                   <td>apk, zip, ipa, or appx</td>
                   <td>Yes</td>
-                  </tr>
-                  <tr>
+                </tr>
+                <tr>
                   <td>file_name</td>
                   <td>Name of the app with extension</td>
                   <td>Yes</td>
-                  </tr>
-                  <tr>
+                </tr>
+                <tr>
                   <td>hash</td>
                   <td>hash of the scan</td>
                   <td>Yes</td>
-                  </tr>
-                  <tr>
+                </tr>
+                <tr>
                   <td>re_scan</td>
                   <td>0 or 1, default is 0</td>
                   <td>No</td>
-                  </tr>
-                  </tbody>
-                  </table>
-                  <br>
-                  <ul>
+                </tr>
+              </tbody>
+            </table>
+            <br />
+            <ul>
+              <li>
+                <p><strong>Success Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Success Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>200</code><br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code><br>
-                  <strong>Content:</strong></li>
-                  </ul>
-                  <pre><code>{&quot;act_count&quot;: &quot;17&quot;, &quot;api&quot;: {&quot;Loading Native Code (Shared Library) &quot;: {&quot;path&quot;: 
-                  [&quot;jakhar/aseem/diva/DivaJni.java&quot;]}, &quot;Local File I/O Operations&quot;: {&quot;path&quot;: 
-                  [&quot;jakhar/aseem/diva/InsecureDataStorage2Activity.java&quot;, &quot;jakhar/aseem/diva/SQLInjectionActivity.java&quot;]}, 
-                  &quot;Starting Activity&quot;: {&quot;path&quot;: [&quot;jakhar/aseem/diva/AccessControl1Activity.java&quot;, 
-                  &quot;jakhar/aseem/diva/AccessControl2Activity.java&quot;, &quot;jakhar/aseem/diva/AccessControl3Activity.java&quot;, 
-                  &quot;jakhar/aseem/diva/MainActivity.java&quot;]}, &quot;Query Database of SMS, Contacts etc.&quot;: {&quot;path&quot;: 
+                    <strong>Code:</strong> <code>200</code><br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code><br />
+                    <strong>Content:</strong>
+                  </li>
+                </ul>
+                <pre><code>{&quot;act_count&quot;: &quot;17&quot;, &quot;api&quot;: {&quot;Loading Native Code (Shared Library) &quot;: {&quot;path&quot;:
+                  [&quot;jakhar/aseem/diva/DivaJni.java&quot;]}, &quot;Local File I/O Operations&quot;: {&quot;path&quot;:
+                  [&quot;jakhar/aseem/diva/InsecureDataStorage2Activity.java&quot;, &quot;jakhar/aseem/diva/SQLInjectionActivity.java&quot;]},
+                  &quot;Starting Activity&quot;: {&quot;path&quot;: [&quot;jakhar/aseem/diva/AccessControl1Activity.java&quot;,
+                  &quot;jakhar/aseem/diva/AccessControl2Activity.java&quot;, &quot;jakhar/aseem/diva/AccessControl3Activity.java&quot;,
+                  &quot;jakhar/aseem/diva/MainActivity.java&quot;]}, &quot;Query Database of SMS, Contacts etc.&quot;: {&quot;path&quot;:
                   [&quot;jakhar/aseem/diva/AccessControl3NotesActivity.java&quot;, &quot;jakhar/aseem/diva/NotesProvider.java&quot;]}
                   SNIPPED
                   </code></pre>
-                  </li>
+              </li>
+              <li>
+                <p><strong>Error Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Error Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong>  <code>500 Internal Server Error</code> or  <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code><br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code><br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code></li>
-                  </ul>
-                  <p>OR</p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>401 Unauthorized</code><br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code><br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>500 Internal Server Error</code> or <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code><br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code><br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code>
                   </li>
+                </ul>
+                <p>OR</p>
+                <ul>
                   <li>
-                  <p><strong>Sample Call:</strong></p>
-                  <pre><code>curl -X POST --url http://localhost:8000/api/v1/scan --data &quot;scan_type=apk&amp;file_name=diva-beta.apk&amp;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;Authorization:{{ api_key}}&quot;
+                    <strong>Code:</strong> <code>401 Unauthorized</code><br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code><br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Sample Call:</strong></p>
+                <ul>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/scan --data &quot;scan_type=apk&amp;file_name=diva-beta.apk&amp;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;Authorization:{{ api_key}}&quot;
                   </code></pre>
                   </li>
-                  </ul>
-                  <hr/>
-                  <h2><a id="delete-scan-api"></a><strong>Delete Scan API</strong></h2>
-                  <p>API to delete scan results.</p>
-                  <ul>
+                </ul>
+                <p>OR</p>
+                <ul>
                   <li>
-                  <p><strong>URL:</strong> <code>/api/v1/delete_scan</code></p>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/scan --data &quot;scan_type=apk&amp;file_name=diva-beta.apk&amp;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;X-Mobsf-Api-Key:{{ api_key}}&quot;
+                  </code></pre>
                   </li>
-                  <li>
-                  <p><strong>Method:</strong> <code>POST</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Data Params</strong></p>
-                  </li>
-                  </ul>
-                  <table class="table table-striped table-bordered">
-                  <thead>
-                  <tr>
+                </ul>
+              </li>
+            </ul>
+            <hr />
+            <h2><a id="delete-scan-api"></a><strong>Delete Scan API</strong></h2>
+            <p>API to delete scan results.</p>
+            <ul>
+              <li>
+                <p><strong>URL:</strong> <code>/api/v1/delete_scan</code></p>
+              </li>
+              <li>
+                <p><strong>Method:</strong> <code>POST</code></p>
+              </li>
+              <li>
+                <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code> <strong>Or</strong> <code>X-Mobsf-Api-Key:&lt;api_key&gt;</code></p>
+              </li>
+              <li>
+                <p><strong>Data Params</strong></p>
+              </li>
+            </ul>
+            <table class="table table-striped table-bordered">
+              <thead>
+                <tr>
                   <th>Param Name</th>
                   <th>Param Value</th>
                   <th>Required</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  <tr>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
                   <td>hash</td>
                   <td>hash of the scan</td>
                   <td>Yes</td>
-                  </tr>
-                  </tbody>
-                  </table>
-                  <br>
-                  <ul>
+                </tr>
+              </tbody>
+            </table>
+            <br />
+            <ul>
+              <li>
+                <p><strong>Success Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Success Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>200</code><br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;deleted&quot;: &quot;yes&quot;}</code> or <code>{&quot;deleted&quot;: &quot;scan hash not found&quot;}</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>200</code><br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;deleted&quot;: &quot;yes&quot;}</code> or <code>{&quot;deleted&quot;: &quot;scan hash not found&quot;}</code>
                   </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Error Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Error Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong>  <code>500 Internal Server Error</code> or  <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code><br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code><br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code></li>
-                  </ul>
-                  <p>OR</p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>401 Unauthorized</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code><br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>500 Internal Server Error</code> or <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code><br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code><br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code>
                   </li>
+                </ul>
+                <p>OR</p>
+                <ul>
                   <li>
-                  <p><strong>Sample Call:</strong></p>
-                  <pre><code>curl -X POST --url http://localhost:8000/api/v1/delete_scan --data &quot;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;Authorization:{{ api_key}}&quot;
+                    <strong>Code:</strong> <code>401 Unauthorized</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code><br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Sample Call:</strong></p>
+                <ul>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/delete_scan --data &quot;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;Authorization:{{ api_key}}&quot;
                   </code></pre>
                   </li>
-                  </ul>
-                  <hr/>
-                  <h2><a id="generate-pdf-report-api"></a><strong>Generate PDF Report API</strong></h2>
-                  <p>API to generate PDF Report.</p>
-                  <ul>
+                </ul>
+                <p>OR</p>
+                <ul>
                   <li>
-                  <p><strong>URL:</strong> <code>/api/v1/download_pdf</code></p>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/delete_scan --data &quot;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;X-Mobsf-Api-Key:{{ api_key}}&quot;
+                  </code></pre>
                   </li>
-                  <li>
-                  <p><strong>Method:</strong> <code>POST</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Data Params</strong></p>
-                  </li>
-                  </ul>
-                  <table class="table table-striped table-bordered">
-                  <thead>
-                  <tr>
+                </ul>
+              </li>
+            </ul>
+            <hr />
+            <h2><a id="generate-pdf-report-api"></a><strong>Generate PDF Report API</strong></h2>
+            <p>API to generate PDF Report.</p>
+            <ul>
+              <li>
+                <p><strong>URL:</strong> <code>/api/v1/download_pdf</code></p>
+              </li>
+              <li>
+                <p><strong>Method:</strong> <code>POST</code></p>
+              </li>
+              <li>
+                <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code> <strong>Or</strong> <code>X-Mobsf-Api-Key:&lt;api_key&gt;</code></p>
+              </li>
+              <li>
+                <p><strong>Data Params</strong></p>
+              </li>
+            </ul>
+            <table class="table table-striped table-bordered">
+              <thead>
+                <tr>
                   <th>Param Name</th>
                   <th>Param Value</th>
                   <th>Required</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  <tr>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
                   <td>hash</td>
                   <td>hash of the scan</td>
                   <td>Yes</td>
-                  </tr>
-                  </tbody>
-                  </table>
-                  <br>
-                  <ul>
+                </tr>
+              </tbody>
+            </table>
+            <br />
+            <ul>
+              <li>
+                <p><strong>Success Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Success Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>200</code><br>
-                  <strong>Content-Type:</strong>  <code>application/pdf</code> <br>
-                  <strong>Content:</strong> <code>PDF Contents</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>200</code><br />
+                    <strong>Content-Type:</strong> <code>application/pdf</code> <br />
+                    <strong>Content:</strong> <code>PDF Contents</code>
                   </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Error Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Error Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong>  <code>500 Internal Server Error</code> or  <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code></li>
-                  </ul>
-                  <p>OR</p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>401 Unauthorized</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>500 Internal Server Error</code> or <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code>
                   </li>
+                </ul>
+                <p>OR</p>
+                <ul>
                   <li>
-                  <p><strong>Sample Call:</strong></p>
-                  <pre><code>curl -X POST --url http://localhost:8000/api/v1/download_pdf --data &quot;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;Authorization:{{ api_key}}&quot;
+                    <strong>Code:</strong> <code>401 Unauthorized</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Sample Call:</strong></p>
+                <ul>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/download_pdf --data &quot;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;Authorization:{{ api_key}}&quot;
                   </code></pre>
                   </li>
-                  </ul>
+                </ul>
+                <p>OR</p>
+                <ul>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/download_pdf --data &quot;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;X-Mobsf-Api-Key:{{ api_key}}&quot;
+                  </code></pre>
+                  </li>
+                </ul>
+              </li>
+            </ul>
 
-                  <hr/>
-                  <h2><a id="generate-json-report-api"></a><strong>Generate JSON Report API</strong></h2>
-                  <p>API to generate JSON Report.</p>
-                  <ul>
-                  <li>
-                  <p><strong>URL:</strong> <code>/api/v1/report_json</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Method:</strong> <code>POST</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Data Params</strong></p>
-                  </li>
-                  </ul>
-                  <table class="table table-striped table-bordered">
-                  <thead>
-                  <tr>
+            <hr />
+            <h2><a id="generate-json-report-api"></a><strong>Generate JSON Report API</strong></h2>
+            <p>API to generate JSON Report.</p>
+            <ul>
+              <li>
+                <p><strong>URL:</strong> <code>/api/v1/report_json</code></p>
+              </li>
+              <li>
+                <p><strong>Method:</strong> <code>POST</code></p>
+              </li>
+              <li>
+                <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code> <strong>Or</strong> <code>X-Mobsf-Api-Key:&lt;api_key&gt;</code></p>
+              </li>
+              <li>
+                <p><strong>Data Params</strong></p>
+              </li>
+            </ul>
+            <table class="table table-striped table-bordered">
+              <thead>
+                <tr>
                   <th>Param Name</th>
                   <th>Param Value</th>
                   <th>Required</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  <tr>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
                   <td>hash</td>
                   <td>hash of the scan</td>
                   <td>Yes</td>
-                  </tr>                
-                  </tbody>
-                  </table>
-                  <br>
-                  <ul>
+                </tr>
+              </tbody>
+            </table>
+            <br />
+            <ul>
+              <li>
+                <p><strong>Success Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Success Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>200</code><br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>JSON Contents</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>200</code><br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>JSON Contents</code>
                   </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Error Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Error Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong>  <code>500 Internal Server Error</code> or  <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code></li>
-                  </ul>
-                  <p>OR</p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>401 Unauthorized</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>500 Internal Server Error</code> or <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code>
                   </li>
+                </ul>
+                <p>OR</p>
+                <ul>
                   <li>
-                  <p><strong>Sample Call:</strong></p>
-                  <pre><code>curl -X POST --url http://localhost:8000/api/v1/report_json --data &quot;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;Authorization:{{ api_key}}&quot;
+                    <strong>Code:</strong> <code>401 Unauthorized</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Sample Call:</strong></p>
+                <ul>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/report_json --data &quot;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;Authorization:{{ api_key}}&quot;
                   </code></pre>
                   </li>
-                  </ul>
+                </ul>
+                <p>OR</p>
+                <ul>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/report_json --data &quot;hash=82ab8b2193b3cfb1c737e3a786be363a&quot; -H &quot;X-Mobsf-Api-Key:{{ api_key}}&quot;
+                  </code></pre>
+                  </li>
+                </ul>
+              </li>
+            </ul>
 
-                  <hr/>
-                  <h2><a id="view-source-api"></a><strong>View Source Files API</strong></h2>
-                  <p>API to view source files.</p>
-                  <ul>
-                  <li>
-                  <p><strong>URL:</strong> <code>/api/v1/view_source</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Method:</strong> <code>POST</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Data Params</strong></p>
-                  </li>
-                  </ul>
-                  <table class="table table-striped table-bordered">
-                  <thead>
-                  <tr>
+            <hr />
+            <h2><a id="view-source-api"></a><strong>View Source Files API</strong></h2>
+            <p>API to view source files.</p>
+            <ul>
+              <li>
+                <p><strong>URL:</strong> <code>/api/v1/view_source</code></p>
+              </li>
+              <li>
+                <p><strong>Method:</strong> <code>POST</code></p>
+              </li>
+              <li>
+                <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code> <strong>Or</strong> <code>X-Mobsf-Api-Key:&lt;api_key&gt;</code></p>
+              </li>
+              <li>
+                <p><strong>Data Params</strong></p>
+              </li>
+            </ul>
+            <table class="table table-striped table-bordered">
+              <thead>
+                <tr>
                   <th>Param Name</th>
                   <th>Param Value</th>
                   <th>Required</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  <tr>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
                   <td>hash</td>
                   <td>hash of the scan</td>
                   <td>Yes</td>
-                  </tr>
-                  <tr>
+                </tr>
+                <tr>
                   <td>file</td>
                   <td>relative file path</td>
                   <td>Yes</td>
-                  </tr>
-                  <tr>
+                </tr>
+                <tr>
                   <td>type</td>
                   <td>apk/ipa/studio/eclipse/ios</td>
                   <td>Yes</td>
-                  </tr>
-                  </tbody>
-                  </table>
-                  <br>
-                  <ul>
+                </tr>
+              </tbody>
+            </table>
+            <br />
+            <ul>
+              <li>
+                <p><strong>Success Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Success Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>200</code><br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>JSON Contents</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>200</code><br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>JSON Contents</code>
                   </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Error Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Error Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong>  <code>500 Internal Server Error</code> or  <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code></li>
-                  </ul>
-                  <p>OR</p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>401 Unauthorized</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>500 Internal Server Error</code> or <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code>
                   </li>
+                </ul>
+                <p>OR</p>
+                <ul>
                   <li>
-                  <p><strong>Sample Call:</strong></p>
-                  <pre><code>curl -X POST --url http://localhost:8000/api/v1/view_source --data "hash=18e244926da1e49c5b8ffc1c30de8abc&amp;type=apk&amp;file=b/a/a/a/a/a.java" -H "Authorization:{{ api_key}}"
+                    <strong>Code:</strong> <code>401 Unauthorized</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Sample Call:</strong></p>
+                <ul>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/view_source --data "hash=18e244926da1e49c5b8ffc1c30de8abc&amp;type=apk&amp;file=b/a/a/a/a/a.java" -H "Authorization:{{ api_key}}"
                   </code></pre>
-                  <pre><code>curl -X POST --url http://localhost:8000/api/v1/view_source --data "hash=6c23c2970551be15f32bbab0b5db0c71&amp;type=ipa&amp;file=classdump.txt" -H "Authorization:{{ api_key}}"
+                  </li>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/view_source --data "hash=6c23c2970551be15f32bbab0b5db0c71&amp;type=ipa&amp;file=classdump.txt" -H "Authorization:{{ api_key}}"
                   </code></pre>
                   </li>
-                  </ul>
+                </ul>
+                <p>OR</p>
+                <ul>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/view_source --data "hash=18e244926da1e49c5b8ffc1c30de8abc&amp;type=apk&amp;file=b/a/a/a/a/a.java" -H "X-Mobsf-Api-Key:{{ api_key}}"
+                  </code></pre>
+                  </li>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/view_source --data "hash=6c23c2970551be15f32bbab0b5db0c71&amp;type=ipa&amp;file=classdump.txt" -H "X-Mobsf-Api-Key:{{ api_key}}"
+                  </code></pre>
+                  </li>
+                </ul>
+              </li>
+            </ul>
 
-
-
-                  <hr/>
-                  <h2><a id="recent-scans-api"></a><strong>Display Recent Scans API</strong></h2>
-                  <p>API to Display Recent Scans.</p>
-                  <ul>
-                  <li>
-                  <p><strong>URL:</strong> <code>/api/v1/scans</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Method:</strong> <code>GET</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Data Params</strong></p>
-                  </li>
-                  </ul>
-                  <table class="table table-striped table-bordered">
-                  <thead>
-                  <tr>
+            <hr />
+            <h2><a id="recent-scans-api"></a><strong>Display Recent Scans API</strong></h2>
+            <p>API to Display Recent Scans.</p>
+            <ul>
+              <li>
+                <p><strong>URL:</strong> <code>/api/v1/scans</code></p>
+              </li>
+              <li>
+                <p><strong>Method:</strong> <code>GET</code></p>
+              </li>
+              <li>
+                <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code> <strong>Or</strong> <code>X-Mobsf-Api-Key:&lt;api_key&gt;</code></p>
+              </li>
+              <li>
+                <p><strong>Data Params</strong></p>
+              </li>
+            </ul>
+            <table class="table table-striped table-bordered">
+              <thead>
+                <tr>
                   <th>Param Name</th>
                   <th>Param Value</th>
                   <th>Required</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  <tr>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
                   <td>page</td>
                   <td>the number of page</td>
                   <td>1</td>
-                  </tr>
-                  <tr>
+                </tr>
+                <tr>
                   <td>page_size</td>
                   <td>per page size</td>
                   <td>10</td>
-                  </tr>
-                  </tbody>
-                  </table>
-                  <br>
-                  <ul>
+                </tr>
+              </tbody>
+            </table>
+            <br />
+            <ul>
+              <li>
+                <p><strong>Success Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Success Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>200</code><br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{
-                      "content": [
-                        {
-                          "id": 1,
-                          "FILE_NAME": "xxxxx.ipa",
-                          "MD5": "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
-                          "URL": "StaticAnalyzer_iOS/?name=xxxxx.ipa&amp;type=ipa&amp;checksum=xxxxxxxxxxxxxxx",
-                          "TIMESTAMP": "2019-03-09T08:08:51.813Z"
-                        }
-                      ],
-                      "count": 1,
-                      "num_pages": 1
-                    }</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>200</code><br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong>
+                    <code>
+                      { "content": [ { "id": 1, "FILE_NAME": "xxxxx.ipa", "MD5": "xxxxxxxxxxxxxxxxxxxxxxxxxxx", "URL": "StaticAnalyzer_iOS/?name=xxxxx.ipa&amp;type=ipa&amp;checksum=xxxxxxxxxxxxxxx", "TIMESTAMP": "2019-03-09T08:08:51.813Z" }
+                      ], "count": 1, "num_pages": 1 }
+                    </code>
                   </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Error Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Error Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong>  <code>500 Internal Server Error</code> or  <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code></li>
-                  </ul>
-                  <p>OR</p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>401 Unauthorized</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>500 Internal Server Error</code> or <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code>
                   </li>
+                </ul>
+                <p>OR</p>
+                <ul>
                   <li>
-                  <p><strong>Sample Call:</strong></p>
-                  <pre><code>curl --url "http://localhost:8000/api/v1/scans" -H "Authorization:{{ api_key}}"
-                  </code></pre>
-                  <pre><code>curl --url "http://localhost:8000/api/v1/scans?page=1&amp;page_size=10" -H "Authorization:{{ api_key}}"
+                    <strong>Code:</strong> <code>401 Unauthorized</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Sample Call:</strong></p>
+                <ul>
+                  <li>
+                    <pre><code>curl --url "http://localhost:8000/api/v1/scans" -H "Authorization:{{ api_key}}"
                   </code></pre>
                   </li>
-                  </ul>
+                  <li>
+                    <pre><code>curl --url "http://localhost:8000/api/v1/scans?page=1&amp;page_size=10" -H "Authorization:{{ api_key}}"
+                  </code></pre>
+                  </li>
+                </ul>
+                <p>OR</p>
+                <ul>
+                  <li>
+                    <pre><code>curl --url "http://localhost:8000/api/v1/scans" -H "X-Mobsf-Api-Key:{{ api_key}}"
+                  </code></pre>
+                  </li>
+                  <li>
+                    <pre><code>curl --url "http://localhost:8000/api/v1/scans?page=1&amp;page_size=10" -H "X-Mobsf-Api-Key:{{ api_key}}"
+                  </code></pre>
+                  </li>
+                </ul>
+              </li>
+            </ul>
 
-
-                <hr/>
-                  <h2><a id="compare-api"></a><strong>Compare Apps API</strong></h2>
-                  <p>API to Compare scan results.</p>
-                  <ul>
-                  <li>
-                  <p><strong>URL:</strong> <code>/api/v1/compare</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Method:</strong> <code>POST</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code></p>
-                  </li>
-                  <li>
-                  <p><strong>Data Params</strong></p>
-                  </li>
-                  </ul>
-                  <table class="table table-striped table-bordered">
-                  <thead>
-                  <tr>
+            <hr />
+            <h2><a id="compare-api"></a><strong>Compare Apps API</strong></h2>
+            <p>API to Compare scan results.</p>
+            <ul>
+              <li>
+                <p><strong>URL:</strong> <code>/api/v1/compare</code></p>
+              </li>
+              <li>
+                <p><strong>Method:</strong> <code>POST</code></p>
+              </li>
+              <li>
+                <p><strong>Header:</strong> <code>Authorization:&lt;api_key&gt;</code> <strong>Or</strong> <code>X-Mobsf-Api-Key:&lt;api_key&gt;</code></p>
+              </li>
+              <li>
+                <p><strong>Data Params</strong></p>
+              </li>
+            </ul>
+            <table class="table table-striped table-bordered">
+              <thead>
+                <tr>
                   <th>Param Name</th>
                   <th>Param Value</th>
                   <th>Required</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  <tr>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
                   <td>hash1</td>
                   <td>first scan hash</td>
                   <td>Yes</td>
-                  </tr>
-                  <tr>
+                </tr>
+                <tr>
                   <td>hash2</td>
                   <td>second scan hash to compare with</td>
                   <td>Yes</td>
-                  </tr>
-                  </tbody>
-                  </table>
-                  <br>
-                  <ul>
+                </tr>
+              </tbody>
+            </table>
+            <br />
+            <ul>
+              <li>
+                <p><strong>Success Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Success Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>200</code><br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>JSON Contents</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>200</code><br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>JSON Contents</code>
                   </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Error Response:</strong></p>
+                <ul>
                   <li>
-                  <p><strong>Error Response:</strong></p>
-                  <ul>
-                  <li><strong>Code:</strong>  <code>500 Internal Server Error</code> or  <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code></li>
-                  </ul>
-                  <p>OR</p>
-                  <ul>
-                  <li><strong>Code:</strong> <code>401 Unauthorized</code> <br>
-                  <strong>Content-Type:</strong>  <code>application/json; charset=utf-8</code> <br>
-                  <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code></li>
-                  </ul>
+                    <strong>Code:</strong> <code>500 Internal Server Error</code> or <code>405 Method Not Allowed</code> or <code>422 Unprocessable Entity</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &lt;error message&gt; }</code>
                   </li>
+                </ul>
+                <p>OR</p>
+                <ul>
                   <li>
-                  <p><strong>Sample Call:</strong></p>
-                  <pre><code>curl -X POST --url http://localhost:8000/api/v1/compare --data "hash1=82ab8b2193b3cfb1c737e3a786be363a&hash2=f56c96f2b1f0a7c46eb6fef3a035f3dd" -H "Authorization:{{ api_key}}""
+                    <strong>Code:</strong> <code>401 Unauthorized</code> <br />
+                    <strong>Content-Type:</strong> <code>application/json; charset=utf-8</code> <br />
+                    <strong>Content:</strong> <code>{&quot;error&quot;: &quot;You are unauthorized to make this request.&quot; }</code>
+                  </li>
+                </ul>
+              </li>
+              <li>
+                <p><strong>Sample Call:</strong></p>
+                <ul>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/compare --data "hash1=82ab8b2193b3cfb1c737e3a786be363a&hash2=f56c96f2b1f0a7c46eb6fef3a035f3dd" -H "Authorization:{{ api_key}}""
                   </code></pre>
                   </li>
-                  </ul>
+                </ul>
+                <p>OR</p>
+                <ul>
+                  <li>
+                    <pre><code>curl -X POST --url http://localhost:8000/api/v1/compare --data "hash1=82ab8b2193b3cfb1c737e3a786be363a&hash2=f56c96f2b1f0a7c46eb6fef3a035f3dd" -H "X-Mobsf-Api-Key:{{ api_key}}""
+                  </code></pre>
+                  </li>
+                </ul>
+              </li>
+            </ul>
 
-                <!-- end API Docs-->
+            <!-- end API Docs-->
           </div>
         </div>
-       </div>
-     </div>
+      </div>
     </div>
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request
This will allow users to specifiy a custom header to define the Api Key in conjunction with a `Bearer` authorization. That way when MobSF is behind a reverse proxy or an IdP. The user can send a request as follow: 
```
curl --url "https://fqdn/api/v1/scans" -H "Authorization: Bearer {{MY_IDP_ACCESS_TOKEN}}" -H "X-Mobsf-Api-Key:{{ api_key}}"
```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
DESCRIBE HERE
```
