### PR TITLE
Fixed #1531

### DIFF
--- a/StaticAnalyzer/views/ios/code_analysis.py
+++ b/StaticAnalyzer/views/ios/code_analysis.py
@@ -65,7 +65,8 @@ def ios_source_analysis(src):
             if (
                 (pfile.suffix in ('.m', '.swift')
                     and any(skip_path in pfile.as_posix()
-                            for skip_path in skp) is False)
+                            for skip_path in skp) is False
+                    and pfile.is_dir() is False)
             ):
                 relative_java_path = pfile.as_posix().replace(src, '')
                 urls, urls_nf, emails_nf = url_n_email_extract(


### PR DESCRIPTION
Fixed #1531 

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

As of now for iOS source code analysis, MobSF checks for `.swift` files to scan. But if there is a directory named `Name.swift` is also considered as file and trying to read text and fails due to error. Hence I am checking if it's a directory or not and then process. Else skip the directory.

Using `pfile.is_dir()` to check if it's a directory and if True, skip it. More details for why this fix is required check #1531 

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

