### PR TITLE
Hide WinError3 in Windows

### DIFF
--- a/StaticAnalyzer/views/android/code_analysis.py
+++ b/StaticAnalyzer/views/android/code_analysis.py
@@ -62,9 +62,15 @@ def code_analysis(app_dir, typ):
                     and any(skip_path in pfile.as_posix()
                             for skip_path in skp) is False)
             ):
+                content = None
+                try:
+                    content = pfile.read_text('utf-8', 'ignore')
+                    # Certain file path cannot be read in windows
+                except Exception:
+                    continue
                 relative_java_path = pfile.as_posix().replace(src, '')
                 urls, urls_nf, emails_nf = url_n_email_extract(
-                    pfile.read_text('utf-8', 'ignore'), relative_java_path)
+                    content, relative_java_path)
                 url_list.extend(urls)
                 url_n_file.extend(urls_nf)
                 email_n_file.extend(emails_nf)

--- a/StaticAnalyzer/views/android/converter.py
+++ b/StaticAnalyzer/views/android/converter.py
@@ -67,7 +67,8 @@ def apk_2_java(app_path, app_dir, tools_dir):
         logger.info('Decompiling to Java with jadx')
 
         if os.path.exists(output):
-            shutil.rmtree(output)
+            # WinError3: ignore_error
+            shutil.rmtree(output, ignore_errors=True)
 
         if (len(settings.JADX_BINARY) > 0
                 and is_file_exists(settings.JADX_BINARY)):

--- a/StaticAnalyzer/views/android/converter.py
+++ b/StaticAnalyzer/views/android/converter.py
@@ -67,7 +67,7 @@ def apk_2_java(app_path, app_dir, tools_dir):
         logger.info('Decompiling to Java with jadx')
 
         if os.path.exists(output):
-            # WinError3: ignore_error
+            # ignore WinError3 in Windows
             shutil.rmtree(output, ignore_errors=True)
 
         if (len(settings.JADX_BINARY) > 0


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
Windows has a file path restriction in terms of length and characters allowed. Python standard libs like pathlib or shutil can throw exceptions unexpectedly, ignore or skip file on exception and allow scan to complete.
```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=win_path)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
DESCRIBE HERE
```
