### PR TITLE
Bump OpenSSL Version from 1.1.1g to 1.1.1h

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -15,7 +15,7 @@ where python >nul 2>&1 && (
     echo [INSTALL] Found OpenSSL executable
   ) else (
    echo [ERROR] OpenSSL executable not found in [C:\\Program Files\\OpenSSL-Win64\\bin\\openssl.exe]
-   echo [INFO] Install OpenSSL - https://slproweb.com/download/Win64OpenSSL-1_1_1g.exe
+   echo [INFO] Install OpenSSL - https://slproweb.com/download/Win64OpenSSL-1_1_1h.exe
    pause
    exit /b
   )


### PR DESCRIPTION

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
Bump OpenSSL version since 1.1.1g is not available for download 
```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

