### PR TITLE
environment variable conflict

### DIFF
--- a/MobSF/utils.py
+++ b/MobSF/utils.py
@@ -65,9 +65,9 @@ def upstream_proxy(flaw_type):
 
 def api_key():
     """Print REST API Key."""
-    if os.environ.get('MOBSF_API_KEY'):
+    if os.environ.get('MOBSF_SECRET_KEY'):
         logger.info('\nAPI Key read from environment variable')
-        return os.environ['MOBSF_API_KEY']
+        return os.environ['MOBSF_SECRET_KEY']
 
     secret_file = os.path.join(settings.MobSF_HOME, 'secret')
     if is_file_exists(secret_file):


### PR DESCRIPTION
### Describe the Pull Request

```
MOBSF_API_KEY is not defined variable. It must MOBSF_SECRET_KEY. Cause it to can't set api key from dockerfile.

```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`.
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)


