### PR TITLE
Removing the semi-colon from insecure Random Regex

### DIFF
--- a/StaticAnalyzer/views/android/rules/android_rules.yaml
+++ b/StaticAnalyzer/views/android/rules/android_rules.yaml
@@ -65,7 +65,7 @@
 - id: android_insecure_random
   description: The App uses an insecure Random Number Generator.
   type: Regex
-  pattern: java\.util\.Random;
+  pattern: java\.util\.Random
   severity: high
   input_case: exact
   cvss: 7.5


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
Removes the semi-colon from the insecure random regex rule. In Kotlin the semi-colon is not required, and we want to
catch this vulnerability in applications built with Kotlin. https://kotlinlang.org/docs/reference/packages.html#imports
```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`.
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Make sure build is passing on your PR. [![Build Status](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF.svg?branch=master)](https://travis-ci.com/MobSF/Mobile-Security-Framework-MobSF/pull_requests)

### Additional Comments (if any)

```
There should be an issue with past compatibility, and should still apply to java code.
```
