### PR TITLE
[Static Analysis][Android] Improve markers for possible hardcoded secrets

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/strings.py
+++ b/mobsf/StaticAnalyzer/views/android/strings.py
@@ -14,10 +14,13 @@ def is_secret(inp):
     inp = inp.lower()
     """Check if captures string is a possible secret."""
     iden = (
-        'api"', 'key"', 'api_"', 'secret"',
-        'password"', 'aws', 'gcp', 's3',
+        'api"', 'key"', 'api_', 'key_', 'secret"',
+        'password"', 'aws', 'gcp', 's3', 'secret_',
         'token"', 'username"', 'user_name"', 'user"',
-        'bearer', 'jwt', 'certificate"', 'credential', 
+        'bearer', 'jwt', 'certificate"', 'credential',
+        'azure', 'webhook', 'twilio_', 'bitcoin',
+        '_auth', 'firebase', 'oauth', 'authorization',
+        'private', 'pwd', 'session', 'token_',
     )
     not_string = (
         'label_', 'text', 'hint', 'msg_', 'create_',

--- a/mobsf/StaticAnalyzer/views/android/strings.py
+++ b/mobsf/StaticAnalyzer/views/android/strings.py
@@ -17,6 +17,7 @@ def is_secret(inp):
         'api"', 'key"', 'api_"', 'secret"',
         'password"', 'aws', 'gcp', 's3',
         'token"', 'username"', 'user_name"', 'user"',
+        'bearer', 'jwt', 'certificate"',
     )
     not_string = (
         'label_', 'text', 'hint', 'msg_', 'create_',

--- a/mobsf/StaticAnalyzer/views/android/strings.py
+++ b/mobsf/StaticAnalyzer/views/android/strings.py
@@ -17,7 +17,7 @@ def is_secret(inp):
         'api"', 'key"', 'api_"', 'secret"',
         'password"', 'aws', 'gcp', 's3',
         'token"', 'username"', 'user_name"', 'user"',
-        'bearer', 'jwt', 'certificate"',
+        'bearer', 'jwt', 'certificate"', 'credential', 
     )
     not_string = (
         'label_', 'text', 'hint', 'msg_', 'create_',


### PR DESCRIPTION
Within the static analysis routines for Android Apps, MobSF uses the `is_secret()` method to determine if a string could possibly hold a hardcoded secret. The method uses a list of markers for this.

GitHub scans repositories for secrets and has a pretty decent [documentation](https://docs.github.com/en/github/administering-a-repository/about-secret-scanning) for this. It includes a list of API slugs for many popular APIs. 

Considering this collection, MobSF could add further markers to catch at least most of the API slugs on that list.

Namely, I would like to propose to add the following markers:
* `bearer` (RFC 6749) 
* `jwt` (e.g. *atlassian_jwt*, *frameio_jwt*)
* `certificate `(e.g. *azure_management_certificate*)
* `credential` (e.g. *api_credential_assignment*, *codeship_credential*)

### Describe the Pull Request
I added the above mentioned markers to the `is_secret()` method:
```python
def is_secret(inp):
    inp = inp.lower()
    """Check if captures string is a possible secret."""
    iden = (
        'api"', 'key"', 'api_"', 'secret"',
        'password"', 'aws', 'gcp', 's3',
        'token"', 'username"', 'user_name"', 'user"',
        'bearer', 'jwt', 'certificate"', 'credential', 
    )
    not_string = (
        'label_', 'text', 'hint', 'msg_', 'create_',
        'message', 'new', 'confirm', 'activity_',
        'forgot', 'dashboard_', 'current_', 'signup',
        'sign_in', 'signin', 'title_', 'welcome_',
        'change_', 'this_', 'the_', 'placeholder',
        'invalid_', 'btn_', 'action_', 'prompt_',
        'lable', 'hide_', 'old', 'update', 'error',
        'empty', 'txt_', 'lbl_',
    )
    not_str = any(i in inp for i in not_string)
    return any(i in inp for i in iden) and not not_str
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

Beside this PR, based on GitHub's list, a further mapping could be possibly introduced to give a hint once a allegedly known secret identifier is encountered.
