### PR TITLE
Fix Full RELRO/Partial RELRO/No RELRO check for Android

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/binary_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/binary_analysis.py
@@ -91,7 +91,7 @@ class Checksec:
             'description': desc,
         }
         relro = self.relro()
-        if relro == 'Full':
+        if relro == 'Full RELRO':
             severity = 'info'
             desc = (
                 'This shared object has full RELRO '
@@ -99,7 +99,7 @@ class Checksec:
                 'overwritten in vulnerable ELF binaries. '
                 'In Full RELRO, the entire GOT (.got and '
                 '.got.plt both) is marked as read-only.')
-        elif relro == 'Partial':
+        elif relro == 'Partial RELRO':
             severity = 'warning'
             desc = (
                 'This shared object has partial RELRO '


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

Returned string of relro() in mobsf/StaticAnalyzer/views/android/binary_analysis.py not properly checked in line 94 and 102, always leading to the "else" case in line 102 (no matter actual RELRO level of binary, always "No RELRO" is falsely shown).

This pull request fixes these checks accordingly.

### Checklist for PR

- [ OK] Run MobSF unit tests and lint `tox -e lint,test`
- [ Linux] Tested Working on Linux, Mac, Windows, and Docker
- [ - ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

iOS not impacted, as no RELRO there.
