### PR TITLE
added masvs:storage-6 android_rule

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/rules/android_rules.yaml
+++ b/mobsf/StaticAnalyzer/views/android/rules/android_rules.yaml
@@ -8,6 +8,26 @@
   cwe: cwe-200
   owasp-mobile: ''
   masvs: code-2
+- id: Sensitive Stored Data Has Been Exposed via IPC Mechanisms
+  description: >-
+    As part of the IPC mechanisms, content providers allow app’s
+    stored data to be accessed and modified by other apps .The app may be
+    leaking sensitive data
+  type: RegexOr
+  pattern:
+  - android\.content\.ContentProvider
+  - android\.database\.Cursor
+  - android\.database\.sqlite
+  - (.*?)\.query
+  - (.*?)\.update
+  - (.*?)\.delete
+  severity: warning
+  input_case: exact
+  cvss: 4.6
+  cwe: 'cwe-922'
+  owasp-mobile: 'm2'
+  masvs: storage-6
+  ref: https://github.com/OWASP/owasp-mstg/blob/1.1.3-excel/Document/0x05d-Testing-Data-Storage.md#determining-whether-sensitive-stored-data-has-been-exposed-via-ipc-mechanisms-mstg-storage-6
 - id: android_hiddenui
   description: >-
     Hidden elements in view can be used to hide data from user. But this data


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
android_rules.yaml misses the masvs storage-6 rule in the static_analyzer.
I've created the rule according to owasp-mstg :
https://github.com/OWASP/owasp-mstg/blob/1.1.3-excel/Document/0x05d-Testing-Data-Storage.md#determining-whether-sensitive-stored-data-has-been-exposed-via-ipc-mechanisms-mstg-storage-6

```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
