### PR TITLE
fix typo in APK analysis (MANIFIEST > MANIFEST)

### DIFF
--- a/mobsf/templates/static_analysis/android_binary_analysis.html
+++ b/mobsf/templates/static_analysis/android_binary_analysis.html
@@ -923,7 +923,7 @@
         <div class="card">
           <div class="card-body">
             <p>
-             <strong><i class="fas fa-search"></i> MANIFIEST ANALYSIS</strong>
+             <strong><i class="fas fa-search"></i> MANIFEST ANALYSIS</strong>
              </p>
               <div class="table-responsive">
                 <table id="table_manifest" class="table table-bordered table-hover table-striped">


### PR DESCRIPTION
fix typo MANIFIEST > MANIFEST. This typo shows in the APK security reports.
Correct word is "MANIFEST" (https://developer.android.com/guide/topics/manifest/manifest-intro).

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
fix typo MANIFIEST > MANIFEST. This typo shows in the APK security reports.
Correct word is "MANIFEST" (https://developer.android.com/guide/topics/manifest/manifest-intro).
```

### Checklist for PR

- [ x ] Run MobSF unit tests and lint `tox -e lint,test`
- [ x ] Tested Working on Linux, Mac, Windows, and Docker
- [ x ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ x ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
No need to test.
```
