### PR TITLE
Ensure iOS Static Analysis can complete without Info.plist being present

### DIFF
--- a/mobsf/StaticAnalyzer/views/ios/plist_analysis.py
+++ b/mobsf/StaticAnalyzer/views/ios/plist_analysis.py
@@ -81,7 +81,7 @@ def plist_analysis(src, is_source):
             plist_files = [plist_file]
 
         # Skip Plist Analysis if there is no Info.plist
-        if plist_file is None or not is_file_exists(plist_file):
+        if not plist_file or not is_file_exists(plist_file):
             logger.warning(
                 'Cannot find Info.plist file. Skipping Plist Analysis.')
             return plist_info

--- a/mobsf/StaticAnalyzer/views/ios/plist_analysis.py
+++ b/mobsf/StaticAnalyzer/views/ios/plist_analysis.py
@@ -55,6 +55,7 @@ def plist_analysis(src, is_source):
             'build_version_name': '',
             'bundle_url_types': [],
             'bundle_supported_platforms': [],
+            'bundle_version_name': '',
         }
         plist_file = None
         plist_files = []

--- a/mobsf/StaticAnalyzer/views/ios/plist_analysis.py
+++ b/mobsf/StaticAnalyzer/views/ios/plist_analysis.py
@@ -80,7 +80,7 @@ def plist_analysis(src, is_source):
             plist_files = [plist_file]
 
         # Skip Plist Analysis if there is no Info.plist
-        if not is_file_exists(plist_file):
+        if plist_file is None or not is_file_exists(plist_file):
             logger.warning(
                 'Cannot find Info.plist file. Skipping Plist Analysis.')
             return plist_info


### PR DESCRIPTION
A couple minor changes to 

* Prevent the possibility of a TypeError from being raised in `plist_analysis.py` from `is_file_exists`
* Allow a static scan to be saved to the database when the info_plist information does not exist

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request


The following traceback is raised when an "Info.plist" file is not found in the source code:

```
File “/…/Mobile-Security-Framework-MobSF/mobsf/StaticAnalyzer/views/ios/plist_analysis.py", line 83, in plist_analysis
	if not is_file_exists(plist_file):
File "/root/Mobile-Security-Framework-MobSF/mobsf/MobSF/utils.py", line 297, in is_file_exists
	if os.path.isfile(file_path):
File "/usr/lib/python3.8/genericpath.py", line 30, in isfile
	st = os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

Given that the logic is to pass silently when the file does not exist, this fix adds a check beforehand to see if the file path value is still unset


### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=wbierbower:patch-1)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
