### PR TITLE
Include browsable activities in comparer

### DIFF
--- a/mobsf/StaticAnalyzer/views/comparer.py
+++ b/mobsf/StaticAnalyzer/views/comparer.py
@@ -64,6 +64,7 @@ def diff_apkid(context: dict) -> None:
             x for x in tmp_flat_results['second_app'][key] if x not in
             tmp_flat_results['first_app'][key]]
 
+
 def diff_browsable_activites(context, first_app, second_app):
     # Browsable activites are 'complex' objects that contains additional
     # fields that should be compared. The generic diffing performed above
@@ -71,8 +72,8 @@ def diff_browsable_activites(context, first_app, second_app):
     # one app. For the activites present in one app we can just pretty-print
     # the details but for common browsable activities we need to perform the
     # diffing also on sub-keys, like hosts and schemes.
-    section = "browsable_activities"
-    common_activity = "common_browsable_activities"
+    section = 'browsable_activities'
+    common_activity = 'common_browsable_activities'
     browsable_activities_keys = ['schemes', 'mime_types', 'hosts', 'ports',
                                  'paths', 'path_prefixs', 'path_patterns']
 

--- a/mobsf/StaticAnalyzer/views/comparer.py
+++ b/mobsf/StaticAnalyzer/views/comparer.py
@@ -64,6 +64,38 @@ def diff_apkid(context: dict) -> None:
             x for x in tmp_flat_results['second_app'][key] if x not in
             tmp_flat_results['first_app'][key]]
 
+def diff_browsable_activites(context, first_app, second_app):
+    # Browsable activites are 'complex' objects that contains additional
+    # fields that should be compared. The generic diffing performed above
+    # only list which browsable activities are in common or present only in
+    # one app. For the activites present in one app we can just pretty-print
+    # the details but for common browsable activities we need to perform the
+    # diffing also on sub-keys, like hosts and schemes.
+    section = "browsable_activities"
+    common_activity = "common_browsable_activities"
+    browsable_activities_keys = ['schemes', 'mime_types', 'hosts', 'ports',
+                                 'paths', 'path_prefixs', 'path_patterns']
+
+    for act, _ in context[section]['common']:
+        context[common_activity][act] = {}
+        for key in browsable_activities_keys:
+            context[common_activity][act][key] = {}
+
+            context[common_activity][act][key]['common'] = [
+                y for y in first_app[section][act][key] if y in
+                second_app[section][act][key]
+            ]
+
+            context[common_activity][act][key]['only_first'] = [
+                y for y in first_app[section][act][key] if y not in
+                second_app[section][act][key]
+            ]
+
+            context[common_activity][act][key]['only_second'] = [
+                y for y in second_app[section][act][key] if y not in
+                first_app[section][act][key]
+            ]
+
 
 # suppose to get any 2 apps (android / ios / appx)
 # and then figure out what to do with them
@@ -82,6 +114,8 @@ def generic_compare(request,
         'urls': {},
         'android_api': {},
         'permissions': {},
+        'browsable_activities': {},
+        'common_browsable_activities': {},
         'apkid': {},
     }
     static_fields = ['md5', 'file_name', 'size', 'icon_found',
@@ -160,6 +194,7 @@ def generic_compare(request,
     for section, is_tuples in [
         ('permissions', True),
         ('android_api', True),
+        ('browsable_activities', True),
         ('urls', False),
     ]:
         if is_tuples:
@@ -188,6 +223,9 @@ def generic_compare(request,
             context[section]['only_second'] = [
                 x for x in second_app[section] if x not in
                 first_app[section]]
+
+    diff_browsable_activites(context, first_app, second_app)
+
     template = 'static_analysis/compare.html'
     if api:
         return context

--- a/mobsf/templates/static_analysis/compare.html
+++ b/mobsf/templates/static_analysis/compare.html
@@ -624,6 +624,296 @@
         </div>
 </section>
 
+<a id="browsable_activities" class="anchor"></a>
+<section class="content">
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="card">
+                    <div class="card-body">
+                        <p>
+                            <strong><i class="fas fa-link"></i> Browsable Activities</strong>
+                        </p>
+                        {% if browsable_activities %}
+                        <div class="table-responsive">
+                            {% for activity, data in browsable_activities.only_first %}
+                            <table class="table table-bordered table-hover table-striped">
+                                <thead>
+                                    <th colspan="8">{{activity}}</th>
+                                    <tr>
+                                        <th></th>
+                                        <th>SCHEMES</th>
+                                        <th>MIME TYPE</th>
+                                        <th>HOSTS</th>
+                                        <th>PORTS</th>
+                                        <th>PATHS</th>
+                                        <th>PATH PREFIXS</th>
+                                        <th>PATH PATTERNS</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            <strong>{{first_app.name_ver}}</strong>
+                                        </td>
+                                        <td>
+                                            {% for cmp in data|key:"schemes" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data|key:"mime_types" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        
+                                        <td>
+                                            {% for cmp in data|key:"hosts" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data|key:"ports" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        
+                                        <td>
+                                            {% for cmp in data|key:"paths" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data|key:"path_prefixs" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data|key:"path_patterns" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                            {% endfor %}
+                            {% for activity, data in browsable_activities.only_second %}
+                            <table class="table table-bordered table-hover table-striped">
+                                <thead>
+                                    <th colspan="8">{{activity}}</th>
+                                    <tr>
+                                        <th></th>
+                                        <th>SCHEMES</th>
+                                        <th>MIME TYPE</th>
+                                        <th>HOSTS</th>
+                                        <th>PORTS</th>
+                                        <th>PATHS</th>
+                                        <th>PATH PREFIXS</th>
+                                        <th>PATH PATTERNS</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            <strong>{{second_app.name_ver}}</strong>
+                                        </td>
+                                        <td>
+                                            {% for cmp in data|key:"schemes" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data|key:"mime_types" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        
+                                        <td>
+                                            {% for cmp in data|key:"hosts" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data|key:"ports" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        
+                                        <td>
+                                            {% for cmp in data|key:"paths" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data|key:"path_prefixs" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data|key:"path_patterns" %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                            {% endfor %}
+                            {% for activity, data in common_browsable_activities.items %}
+                            <table class="table table-bordered table-hover table-striped">
+                                <thead>
+                                    <th colspan="8">{{activity}}</th>
+                                    <tr>
+                                        <th></th>
+                                        <th>SCHEMES</th>
+                                        <th>MIME TYPE</th>
+                                        <th>HOSTS</th>
+                                        <th>PORTS</th>
+                                        <th>PATHS</th>
+                                        <th>PATH PREFIXS</th>
+                                        <th>PATH PATTERNS</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            <strong>Common</strong>
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.schemes.common %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.mime_types.common %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        
+                                        <td>
+                                            {% for cmp in data.hosts.common %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.ports.common %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        
+                                        <td>
+                                            {% for cmp in data.paths.common %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.path_prefixs.common %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.path_patterns.common %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <strong>{{first_app.name_ver}}</strong>
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.schemes.only_first %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.mime_types.only_first %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        
+                                        <td>
+                                            {% for cmp in data.hosts.only_first %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.ports.only_first %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        
+                                        <td>
+                                            {% for cmp in data.paths.only_first %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.path_prefixs.only_first %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.path_patterns.only_first %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <strong>{{second_app.name_ver}}</strong>
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.schemes.only_second %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.mime_types.only_second %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        
+                                        <td>
+                                            {% for cmp in data.hosts.only_second %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.ports.only_second %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        
+                                        <td>
+                                            {% for cmp in data.paths.only_second %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.path_prefixs.only_second %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                        <td>
+                                            {% for cmp in data.path_patterns.only_second %}
+                                            {{cmp}}<br/>
+                                            {% endfor %}
+                                        </td>
+                                    </tr>                                    
+                                </tbody>
+                            </table>
+                            {% endfor %}
+                            {% else %}
+                            <p align="center"><strong>Error/ No browsable activities</strong></p>
+                            {% endif %}
+                        </div>
+                    </div><!-- /.card -->
+                </div>
+            </div><!-- end row -->
+        </div>
+    </div>
+</section>
+
 <a id="urls" class="anchor"></a>
 <section class="content">
       <div class="container-fluid">

--- a/mobsf/templates/static_analysis/compare.html
+++ b/mobsf/templates/static_analysis/compare.html
@@ -624,7 +624,7 @@
         </div>
 </section>
 
-<a id="browsable_activities" class="anchor"></a>
+<a id="browsable" class="anchor"></a>
 <section class="content">
     <div class="container-fluid">
         <div class="row">
@@ -632,284 +632,216 @@
                 <div class="card">
                     <div class="card-body">
                         <p>
-                            <strong><i class="fas fa-link"></i> Browsable Activities</strong>
+                            <strong><i class="fas fa-clone"></i> BROWSABLE ACTIVITIES</strong>
                         </p>
-                        {% if browsable_activities %}
                         <div class="table-responsive">
-                            {% for activity, data in browsable_activities.only_first %}
-                            <table class="table table-bordered table-hover table-striped">
-                                <thead>
-                                    <th colspan="8">{{activity}}</th>
-                                    <tr>
-                                        <th></th>
-                                        <th>SCHEMES</th>
-                                        <th>MIME TYPE</th>
-                                        <th>HOSTS</th>
-                                        <th>PORTS</th>
-                                        <th>PATHS</th>
-                                        <th>PATH PREFIXS</th>
-                                        <th>PATH PATTERNS</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr>
-                                        <td>
-                                            <strong>{{first_app.name_ver}}</strong>
-                                        </td>
-                                        <td>
-                                            {% for cmp in data|key:"schemes" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data|key:"mime_types" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
+                            <table id="table_browsable" class="table table-bordered table-hover table-striped">
+                                <tr>
+                                    <th>Common</th>
+                                    <th>Only in {{ first_app.name_ver }}</th>
+                                    <th>Only in {{ second_app.name_ver }}</th>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        {% if browsable_activities.common %}
+                                        <table>
+                                            <thead>
+                                                <tr>
+                                                    <th>ACTIVITY</th>
+                                                    <th>INTENT</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {% for activity,intent_details in browsable_activities.common %}
+                                                <tr>
+                                                    <td>{{activity}}</td>
+                                                    <td>
+                                                        {% if intent_details|key:"schemes" %}
+                                                        <strong>Schemes</strong>:
+                                                        {% for scheme in intent_details|key:"schemes" %}
+                                                        {{scheme}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"hosts" %}
+                                                        <strong>Hosts:</strong> {% for host in intent_details|key:"hosts" %}
+                                                        {{host}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"ports" %}
+                                                        <strong>Ports:</strong> {% for port in intent_details|key:"ports" %}
+                                                        {{port}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"mime_types" %}
+                                                        <strong>Mime Types:</strong> {% for mime in intent_details|key:"mime_types" %}
+                                                        {{mime}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"paths" %}
+                                                        <strong>Paths:</strong> {% for path in intent_details|key:"paths" %}
+                                                        {{path}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"path_prefixs" %}
+                                                        <strong>Path Prefixes:</strong> {% for prefix in intent_details|key:"path_prefixs" %}
+                                                        {{prefix}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"path_patterns" %}
+                                                        <strong>Path Patterns:</strong> {% for pattern in intent_details|key:"path_patterns" %}
+                                                        {{pattern}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% endfor %}
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if browsable_activities.only_first %}
                                         
-                                        <td>
-                                            {% for cmp in data|key:"hosts" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data|key:"ports" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        
-                                        <td>
-                                            {% for cmp in data|key:"paths" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data|key:"path_prefixs" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data|key:"path_patterns" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                    </tr>
-                                </tbody>
+                                        <table>
+                                            <thead>
+                                                <tr>
+                                                    <th>ACTIVITY</th>
+                                                    <th>INTENT</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {% for activity,intent_details in browsable_activities.only_first %}
+                                                <tr>
+                                                    <td>{{activity}}</td>
+                                                    <td>
+                                                        {% if intent_details|key:"schemes" %}
+                                                        <strong>Schemes</strong>:
+                                                        {% for scheme in intent_details|key:"schemes" %}
+                                                        {{scheme}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"hosts" %}
+                                                        <strong>Hosts:</strong> {% for host in intent_details|key:"hosts" %}
+                                                        {{host}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"ports" %}
+                                                        <strong>Ports:</strong> {% for port in intent_details|key:"ports" %}
+                                                        {{port}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"mime_types" %}
+                                                        <strong>Mime Types:</strong> {% for mime in intent_details|key:"mime_types" %}
+                                                        {{mime}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"paths" %}
+                                                        <strong>Paths:</strong> {% for path in intent_details|key:"paths" %}
+                                                        {{path}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"path_prefixs" %}
+                                                        <strong>Path Prefixes:</strong> {% for prefix in intent_details|key:"path_prefixs" %}
+                                                        {{prefix}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"path_patterns" %}
+                                                        <strong>Path Patterns:</strong> {% for pattern in intent_details|key:"path_patterns" %}
+                                                        {{pattern}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% endfor %}
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if browsable_activities.only_second %}
+                                        <table>
+                                            <thead>
+                                                <tr>
+                                                    <th>ACTIVITY</th>
+                                                    <th>INTENT</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {% for activity,intent_details in browsable_activities.only_second %}
+                                                <tr>
+                                                    <td>{{activity}}</td>
+                                                    <td>
+                                                        {% if intent_details|key:"schemes" %}
+                                                        <strong>Schemes</strong>:
+                                                        {% for scheme in intent_details|key:"schemes" %}
+                                                        {{scheme}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"hosts" %}
+                                                        <strong>Hosts:</strong> {% for host in intent_details|key:"hosts" %}
+                                                        {{host}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"ports" %}
+                                                        <strong>Ports:</strong> {% for port in intent_details|key:"ports" %}
+                                                        {{port}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"mime_types" %}
+                                                        <strong>Mime Types:</strong> {% for mime in intent_details|key:"mime_types" %}
+                                                        {{mime}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"paths" %}
+                                                        <strong>Paths:</strong> {% for path in intent_details|key:"paths" %}
+                                                        {{path}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"path_prefixs" %}
+                                                        <strong>Path Prefixes:</strong> {% for prefix in intent_details|key:"path_prefixs" %}
+                                                        {{prefix}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% if intent_details|key:"path_patterns" %}
+                                                        <strong>Path Patterns:</strong> {% for pattern in intent_details|key:"path_patterns" %}
+                                                        {{pattern}},
+                                                        {% endfor %}
+                                                        <br/>
+                                                        {% endif %}
+                                                        {% endfor %}
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                    {% endif %}
+                                </tr>
                             </table>
-                            {% endfor %}
-                            {% for activity, data in browsable_activities.only_second %}
-                            <table class="table table-bordered table-hover table-striped">
-                                <thead>
-                                    <th colspan="8">{{activity}}</th>
-                                    <tr>
-                                        <th></th>
-                                        <th>SCHEMES</th>
-                                        <th>MIME TYPE</th>
-                                        <th>HOSTS</th>
-                                        <th>PORTS</th>
-                                        <th>PATHS</th>
-                                        <th>PATH PREFIXS</th>
-                                        <th>PATH PATTERNS</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr>
-                                        <td>
-                                            <strong>{{second_app.name_ver}}</strong>
-                                        </td>
-                                        <td>
-                                            {% for cmp in data|key:"schemes" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data|key:"mime_types" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        
-                                        <td>
-                                            {% for cmp in data|key:"hosts" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data|key:"ports" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        
-                                        <td>
-                                            {% for cmp in data|key:"paths" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data|key:"path_prefixs" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data|key:"path_patterns" %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                            {% endfor %}
-                            {% for activity, data in common_browsable_activities.items %}
-                            <table class="table table-bordered table-hover table-striped">
-                                <thead>
-                                    <th colspan="8">{{activity}}</th>
-                                    <tr>
-                                        <th></th>
-                                        <th>SCHEMES</th>
-                                        <th>MIME TYPE</th>
-                                        <th>HOSTS</th>
-                                        <th>PORTS</th>
-                                        <th>PATHS</th>
-                                        <th>PATH PREFIXS</th>
-                                        <th>PATH PATTERNS</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr>
-                                        <td>
-                                            <strong>Common</strong>
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.schemes.common %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.mime_types.common %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        
-                                        <td>
-                                            {% for cmp in data.hosts.common %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.ports.common %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        
-                                        <td>
-                                            {% for cmp in data.paths.common %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.path_prefixs.common %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.path_patterns.common %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            <strong>{{first_app.name_ver}}</strong>
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.schemes.only_first %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.mime_types.only_first %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        
-                                        <td>
-                                            {% for cmp in data.hosts.only_first %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.ports.only_first %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        
-                                        <td>
-                                            {% for cmp in data.paths.only_first %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.path_prefixs.only_first %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.path_patterns.only_first %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            <strong>{{second_app.name_ver}}</strong>
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.schemes.only_second %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.mime_types.only_second %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        
-                                        <td>
-                                            {% for cmp in data.hosts.only_second %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.ports.only_second %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        
-                                        <td>
-                                            {% for cmp in data.paths.only_second %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.path_prefixs.only_second %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                        <td>
-                                            {% for cmp in data.path_patterns.only_second %}
-                                            {{cmp}}<br/>
-                                            {% endfor %}
-                                        </td>
-                                    </tr>                                    
-                                </tbody>
-                            </table>
-                            {% endfor %}
-                            {% else %}
-                            <p align="center"><strong>Error/ No browsable activities</strong></p>
-                            {% endif %}
                         </div>
-                    </div><!-- /.card -->
-                </div>
-            </div><!-- end row -->
+                    </div>
+                </div><!-- /.card -->
+            </div>
+            <!-- end row -->
         </div>
     </div>
 </section>

--- a/mobsf/templates/static_analysis/compare.html
+++ b/mobsf/templates/static_analysis/compare.html
@@ -60,6 +60,14 @@
               </p>
             </a>
           </li>
+          <li class="nav-item">
+            <a href="#browsable" class="nav-link">
+              <i class="nav-icon fas fa-clone"></i>
+              <p>
+                Browsable Activities
+              </p>
+            </a>
+          </li>
            <li class="nav-item">
               <a href="#urls" class="nav-link">
                 <i class="nav-icon fas fa-globe"></i>

--- a/mobsf/templates/static_analysis/compare.html
+++ b/mobsf/templates/static_analysis/compare.html
@@ -634,6 +634,7 @@
                         <p>
                             <strong><i class="fas fa-clone"></i> BROWSABLE ACTIVITIES</strong>
                         </p>
+                        {% if browsable_activities %}
                         <div class="table-responsive">
                             <table id="table_browsable" class="table table-bordered table-hover table-striped">
                                 <tr>
@@ -838,6 +839,9 @@
                                 </tr>
                             </table>
                         </div>
+                        {% else %}
+                            <p align="center"><strong>Error/ No browsable activities</strong></p>
+                        {% endif %}
                     </div>
                 </div><!-- /.card -->
             </div>


### PR DESCRIPTION
### Describe the Pull Request
Comparer is really helpful to analyse differences between applications but it lack some important features.
One of these is the ability to detect differences between browsable activities (deeplinks/universal links) in Android, which is a big attack surface and it can be very interesting to monitor and to detect additions.
Since browsable activities are more complex objects that others (i.e. activities) we need to perform comparison not only on the first level (which browsable activities are in common and which not) but also in deep: from the browsable activities in common, which schemes, hosts, paths are in common and which not?

This PR include a new diffing function for common browsable activities that explore each activity in both apps to detect differences for a set of keys (scheme/hosts etc..) and include them in the context. 
Additionally, browsable activities that are not in common are added to the proper `only_first` or `only_second` component.
The template is responsible to display these information: for each browsable activity a table is shown with a row header indicating the browsable activity, and the information are shown like for APKiD information. For common browsable activities the table has 3 rows to show differences between the components of the browsable activity, as shown on this example:

![br_act](https://user-images.githubusercontent.com/32750504/119956866-d0e15400-bfa1-11eb-88d0-9f8524ff90ab.png)


### Checklist for PR

- [x] Tested Working on Linux, Mac, Windows, and Docker