### PR TITLE
Support der extension for certificates

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/cert_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/cert_analysis.py
@@ -30,7 +30,7 @@ def get_hardcoded_cert_keystore(files):
             if '.' not in file_name:
                 continue
             ext = file_name.split('.')[-1]
-            if re.search('cer|pem|cert|crt|pub|key|pfx|p12', ext):
+            if re.search('cer|pem|cert|crt|pub|key|pfx|p12|der', ext):
                 certz.append(escape(file_name))
             if re.search('jks|bks', ext):
                 key_store.append(escape(file_name))

--- a/mobsf/StaticAnalyzer/views/ios/file_analysis.py
+++ b/mobsf/StaticAnalyzer/views/ios/file_analysis.py
@@ -40,7 +40,7 @@ def ios_list_files(src, md5_hash, binary_form, mode):
                     filez.append(fileparam)
                     full_paths.append(file_path)
                     ext = jfile.split('.')[-1]
-                    if re.search(r'cer|pem|cert|crt|pub|key|pfx|p12', ext):
+                    if re.search(r'cer|pem|cert|crt|pub|key|pfx|p12|der', ext):
                         certz.append({
                             'file_path': escape(file_path.replace(src, '')),
                             'type': None,


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request
Just adding `der` as supported extension for certificates, as some applications use this extension.


### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker