### PR TITLE
Modify PWD stack to support health check

### DIFF
--- a/scripts/stack/docker-compose.yml
+++ b/scripts/stack/docker-compose.yml
@@ -1,8 +1,10 @@
-version: "3"
+version: "3.8"
 services:
   web:
     image: opensecurity/mobile-security-framework-mobsf:latest
     hostname: mobsfhost
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     deploy:
       replicas: 1
       restart_policy:


### PR DESCRIPTION
### Describe the Pull Request

The addition of HEALTHCHECK recently broke the PlayWithDocker (PWD) support, as host.docker.internal used in healthcheck was not resolving. 

Add extra_hosts to support resolution of host.docker.internal for healthcheck - [Reference](https://medium.com/@TimvanBaarsen/how-to-connect-to-the-docker-host-from-inside-a-docker-container-112b4c71bc66)

PWD still doesn't work on single click from the [link](https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/MobSF/Mobile-Security-Framework-MobSF/master/scripts/stack/docker-compose.yml) in MobSF readme - even after this fix. This fix works if one gets the compose file and manually do a docker-compose up on PWD node.

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [X] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

I am wondering if HEALTHCHECK in Dockerfile must be after EXPOSE, esp for Docker In Docker setup like PWD. Please verify and if there is no harm in exposing and then doing a healthcheck, please let me know, I can test and raise another PR for Dockerfile, especially for getting single click PWD. 
