### PR TITLE
Add --no-cache-dir to pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /root/Mobile-Security-Framework-MobSF
 
 # Install Requirements
 COPY requirements.txt .
-RUN pip3 install --upgrade setuptools pip && \
+RUN pip3 install --upgrade --no-cache-dir setuptools pip && \
     pip3 install --quiet --no-cache-dir -r requirements.txt
 
 # Cleanup

--- a/scripts/install_java_wkhtmltopdf.sh
+++ b/scripts/install_java_wkhtmltopdf.sh
@@ -4,9 +4,9 @@ then
     WKH_FILE=$WKH_FILE_ARM
     JDK_FILE=$JDK_FILE_ARM
     apt install -y git
-    pip3 install wheel
+    pip3 install --no-cache-dir wheel
     pip3 wheel --wheel-dir=yara-python-dex git+https://github.com/MobSF/yara-python-dex.git
-    pip3 install --no-index --find-links=yara-python-dex yara-python-dex
+    pip3 install --no-cache-dir --no-index --find-links=yara-python-dex yara-python-dex
     rm -rf yara-python-dex
 fi
 


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

`pip` will update its lists and will not save them if you specify `--no-cache-dir`, and it has to be specified in each `pip install`.

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)