### PR TITLE
it's better not to use `apt` in scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV DEBIAN_FRONTEND="noninteractive" \
 ENV PATH="$JAVA_HOME/bin:$PATH"
 
 # See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
-RUN apt update -y && apt install -y  --no-install-recommends \
+RUN apt-get update -y && apt-get install -y  --no-install-recommends \
     build-essential \
     locales \
     sqlite3 \
@@ -61,16 +61,16 @@ RUN pip3 install --upgrade --no-cache-dir setuptools pip && \
 
 # Cleanup
 RUN \
-    apt remove -y \
-        libssl-dev \
-        libffi-dev \
-        libxml2-dev \
-        libxslt1-dev \
-        python3-dev \
-        wget && \
-    apt clean && \
-    apt autoclean && \
-    apt autoremove -y && \
+    apt-get remove -y \
+            libssl-dev \
+            libffi-dev \
+            libxml2-dev \
+            libxslt1-dev \
+            python3-dev \
+            wget && \
+    apt-get clean && \
+    apt-get autoclean && \
+    apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* /tmp/* > /dev/null 2>&1
 
 # Copy source code

--- a/scripts/install_java_wkhtmltopdf.sh
+++ b/scripts/install_java_wkhtmltopdf.sh
@@ -3,7 +3,7 @@ if [ "$TARGETPLATFORM" == "linux/arm64" ]
 then
     WKH_FILE=$WKH_FILE_ARM
     JDK_FILE=$JDK_FILE_ARM
-    apt install -y git
+    apt-get install -y git
     pip3 install --no-cache-dir wheel
     pip3 wheel --wheel-dir=yara-python-dex git+https://github.com/MobSF/yara-python-dex.git
     pip3 install --no-cache-dir --no-index --find-links=yara-python-dex yara-python-dex


### PR DESCRIPTION
### Describe the Pull Request
Taken from man apt:
```
apt provides a high-level commandline interface for the package management system. It is intended as an end user interface and enables some options better suited for interactive usage by default compared to more specialized APT tools like apt-get(8) and apt-cache(8).
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)