### PR TITLE
Fix dynamic report_json api bug

### DIFF
--- a/mobsf/DynamicAnalyzer/views/android/report.py
+++ b/mobsf/DynamicAnalyzer/views/android/report.py
@@ -100,7 +100,7 @@ def view_report(request, checksum, api=False):
                    'base64_strings': b64_strings,
                    'trackers': trackers,
                    'frida_logs': is_file_exists(fd_log),
-                   'runtime_dependencies': deps,
+                   'runtime_dependencies': list(deps),
                    'package': package,
                    'version': settings.MOBSF_VER,
                    'title': 'Dynamic Analysis'}


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
Fix dynamic report_json api bug, JsonResponse cannot serialize it because runtime_dependencies is set type.
```

### Checklist for PR

- [] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
  File "/home/mobsf/Coding/Mobile-Security-Framework-MobSF/venv/lib/python3.8/site-packages/django/core/serializers/json.py", line 106, in default
    return super().default(o)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type set is not JSON serializable
```
