### PR TITLE
Fixed python version checking and OpenSSL broken link.

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -13,7 +13,7 @@ where python >nul 2>&1 && (
   ) else (
     exit /b
   )
-  echo %var%|findstr /R "[3].[89]" >nul
+  echo %var%|findstr /R "[3].[8910]" >nul
   if errorlevel 1 (
       if "%var%"=="" goto redo
       echo [ERROR] MobSF dependencies require Python 3.8/3.9. Your python points to %var%
@@ -37,7 +37,7 @@ where python >nul 2>&1 && (
     echo [INSTALL] Found OpenSSL executable
   ) else (
    echo [ERROR] OpenSSL executable not found in [C:\\Program Files\\OpenSSL-Win64\\bin\\openssl.exe]
-   echo [INFO] Install OpenSSL non-light version - https://slproweb.com/download/Win64OpenSSL-3_0_0.exe
+   echo [INFO] Install OpenSSL non-light version - https://slproweb.com/download/Win64OpenSSL-3_0_2.exe
    pause
    exit /b
   )

--- a/setup.bat
+++ b/setup.bat
@@ -16,7 +16,7 @@ where python >nul 2>&1 && (
   echo %var%|findstr /R "[3].[8910]" >nul
   if errorlevel 1 (
       if "%var%"=="" goto redo
-      echo [ERROR] MobSF dependencies require Python 3.8/3.9. Your python points to %var%
+      echo [ERROR] MobSF dependencies require Python 3.8/3.9/3.10 Your python points to %var%
       exit /b
   ) else (
       echo [INSTALL] Found %var%


### PR DESCRIPTION
Added python 3.10+ checking and updated the link for OpenSSL.exe.

The python-checking code was refusing to resume the setup if the version is above 3.10+.
Also updated the link to OpenSSL.exe application.