### PR TITLE
Fixed python version checking and OpenSSL broken link.

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,19 +1,2 @@
 @echo off
-
-if [%1]==[] goto usage
-SET conf=%1
-goto :run
-:usage
-SET conf=0.0.0.0:8000
-:run
-set venv=.\venv\Scripts\activate
-set server=.\venv\Scripts\waitress-serve.exe
-if exist %server% (
-  echo Running MobSF on %conf%
-  %venv%
-  %server% --listen=%conf% --threads=10 --channel-timeout=3600 mobsf.MobSF.wsgi:application
-) else (
-  echo [ERROR] Incomplete setup. Please ensure that setup.bat completes without any errors.
-  pause
-  exit /b
-)
+waitress-serve.exe --listen=0.0.0.0:8000 --threads=10 --channel-timeout=3600 mobsf.MobSF.wsgi:application

--- a/setup.bat
+++ b/setup.bat
@@ -13,7 +13,7 @@ where python >nul 2>&1 && (
   ) else (
     exit /b
   )
-  echo %var%|findstr /R "[3].[89]" >nul
+  echo %var%|findstr /R "[3].[8910]" >nul
   if errorlevel 1 (
       if "%var%"=="" goto redo
       echo [ERROR] MobSF dependencies require Python 3.8/3.9. Your python points to %var%
@@ -37,7 +37,7 @@ where python >nul 2>&1 && (
     echo [INSTALL] Found OpenSSL executable
   ) else (
    echo [ERROR] OpenSSL executable not found in [C:\\Program Files\\OpenSSL-Win64\\bin\\openssl.exe]
-   echo [INFO] Install OpenSSL non-light version - https://slproweb.com/download/Win64OpenSSL-3_0_0.exe
+   echo [INFO] Install OpenSSL non-light version - https://slproweb.com/download/Win64OpenSSL-3_0_2.exe
    pause
    exit /b
   )

--- a/setup.bat
+++ b/setup.bat
@@ -56,7 +56,6 @@ where python >nul 2>&1 && (
   echo [INSTALL] Creating venv
   rmdir "venv" /q /s >nul 2>&1
   python -m venv ./venv
-  set venv=.\venv\Scripts\python
   python -m pip install --upgrade pip
 
   set LIB=C:\Program Files\OpenSSL-Win64\lib;%LIB%

--- a/setup.bat
+++ b/setup.bat
@@ -16,7 +16,7 @@ where python >nul 2>&1 && (
   echo %var%|findstr /R "[3].[8910]" >nul
   if errorlevel 1 (
       if "%var%"=="" goto redo
-      echo [ERROR] MobSF dependencies require Python 3.8/3.9. Your python points to %var%
+      echo [ERROR] MobSF dependencies require Python 3.8/3.9/3.10 Your python points to %var%
       exit /b
   ) else (
       echo [INSTALL] Found %var%

--- a/setup.bat
+++ b/setup.bat
@@ -13,10 +13,10 @@ where python >nul 2>&1 && (
   ) else (
     exit /b
   )
-  echo %var%|findstr /R "[3].[8910]" >nul
+  echo %var%|findstr /R "[3].[89]" >nul
   if errorlevel 1 (
       if "%var%"=="" goto redo
-      echo [ERROR] MobSF dependencies require Python 3.8/3.9/3.10 Your python points to %var%
+      echo [ERROR] MobSF dependencies require Python 3.8/3.9. Your python points to %var%
       exit /b
   ) else (
       echo [INSTALL] Found %var%
@@ -37,7 +37,7 @@ where python >nul 2>&1 && (
     echo [INSTALL] Found OpenSSL executable
   ) else (
    echo [ERROR] OpenSSL executable not found in [C:\\Program Files\\OpenSSL-Win64\\bin\\openssl.exe]
-   echo [INFO] Install OpenSSL non-light version - https://slproweb.com/download/Win64OpenSSL-3_0_2.exe
+   echo [INFO] Install OpenSSL non-light version - https://slproweb.com/download/Win64OpenSSL-3_0_0.exe
    pause
    exit /b
   )
@@ -57,25 +57,25 @@ where python >nul 2>&1 && (
   rmdir "venv" /q /s >nul 2>&1
   python -m venv ./venv
   set venv=.\venv\Scripts\python
-  %venv% -m pip install --upgrade pip
+  python -m pip install --upgrade pip
 
   set LIB=C:\Program Files\OpenSSL-Win64\lib;%LIB%
   set INCLUDE=C:\Program Files\OpenSSL-Win64\include;%INCLUDE%
 
   echo [INSTALL] Installing Requirements
-  %venv% -m pip install --no-cache-dir wheel
-  %venv% -m pip install --no-cache-dir --use-deprecated=legacy-resolver -r requirements.txt
+  python -m pip install --no-cache-dir wheel
+  python -m pip install --no-cache-dir --use-deprecated=legacy-resolver -r requirements.txt
   
   echo [INSTALL] Clean Up
   call scripts/clean.bat y
 
   echo [INSTALL] Migrating Database
-  %venv% manage.py makemigrations
-  %venv% manage.py makemigrations StaticAnalyzer
-  %venv% manage.py migrate
+  python manage.py makemigrations
+  python manage.py makemigrations StaticAnalyzer
+  python manage.py migrate
   echo Download and Install wkhtmltopdf for PDF Report Generation - https://wkhtmltopdf.org/downloads.html
   echo [INSTALL] Installation Complete
-  %venv% scripts/check_install.py
+  python scripts/check_install.py
   exit /b 0
 ) || (
   echo [ERROR] python3 is not installed


### PR DESCRIPTION
Added python 3.10+ checking and updated the link for OpenSSL.exe.

The python-checking code was refusing to resume the setup if the version is above 3.10+.
Also updated the link to OpenSSL.exe application.