### PR TITLE
Remove RELRO from MobSF shared object scan for Android binaries

### DIFF
--- a/mobsf/templates/pdf/android_report.html
+++ b/mobsf/templates/pdf/android_report.html
@@ -581,7 +581,6 @@
                         <th>SHARED OBJECT</th>
                         <th>NX</th>
                         <th>STACK CANARY</th>
-                        <th>RELRO</th>
                         <th>RPATH</th>
                         <th>RUNPATH</th>
                         <th>FORTIFY</th>
@@ -604,10 +603,6 @@
                             <br/>
                             <span class="{% if so.stack_canary.severity == 'high' %}danger{% elif so.stack_canary.severity == 'warning' %}warning{% else %}info{% endif %}">{{so.stack_canary.severity}}</span>
                             <br/>{{so.stack_canary.description}}</td>
-                        <td style="vertical-align: top;"><b>{{so.relocation_readonly.relro}}</b>
-                          <br/>
-                          <span class="{% if so.relocation_readonly.severity == 'high' %}danger{% elif so.relocation_readonly.severity == 'warning' %}warning{% else %}info{% endif %}">{{so.relocation_readonly.severity}}</span>
-                          <br/>{{so.relocation_readonly.description}}</td>
                         <td style="vertical-align: top;"><b>{{so.rpath.rpath}}</b>
                           <br/>
                           <span class="{% if so.rpath.severity == 'high' %}danger{% elif so.rpath.severity == 'warning' %}warning{% else %}info{% endif %}">{{so.rpath.severity}}</span>

--- a/mobsf/templates/static_analysis/android_binary_analysis.html
+++ b/mobsf/templates/static_analysis/android_binary_analysis.html
@@ -1099,7 +1099,6 @@
                           <th>SHARED OBJECT</th>
                           <th>NX</th>
                           <th>STACK CANARY</th>
-                          <th>RELRO</th>
                           <th>RPATH</th>
                           <th>RUNPATH</th>
                           <th>FORTIFY</th>
@@ -1122,10 +1121,6 @@
                   <br/>
                   <span class="badge bg-{% if so.stack_canary.severity == 'high' %}danger{% elif so.stack_canary.severity == 'warning' %}warning{% else %}info{% endif %}">{{so.stack_canary.severity}}</span>
                   <br/>{{so.stack_canary.description}}</td>
-              <td><b>{{so.relocation_readonly.relro}}</b>
-                <br/>
-                <span class="badge bg-{% if so.relocation_readonly.severity == 'high' %}danger{% elif so.relocation_readonly.severity == 'warning' %}warning{% else %}info{% endif %}">{{so.relocation_readonly.severity}}</span>
-                <br/>{{so.relocation_readonly.description}}</td>
               <td><b>{{so.rpath.rpath}}</b>
                 <br/>
                 <span class="badge bg-{% if so.rpath.severity == 'high' %}danger{% elif so.rpath.severity == 'warning' %}warning{% else %}info{% endif %}">{{so.rpath.severity}}</span>


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

RELRO is causing false positives. Removing it from MobSF binary analysis.

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
