### PR TITLE
Revert "Add the checking of the parent element of the permission-related elements to manifest analysis"

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/android_manifest_desc.py
+++ b/mobsf/StaticAnalyzer/views/android/android_manifest_desc.py
@@ -744,13 +744,4 @@ MANIFEST_DESC = {
                         'overrides other requests.'),
         'name': 'High Action Priority [android:priority]',
     },
-    'a_error_subelement': {
-        'title': ('<strong>%s</strong> is not a subelement '
-                  'of the <Manifest>. These elements would not take effect'),
-        'level': 'warning',
-        'description': ('The parent element of <permission>'
-                        'can only be <manifest>, or these definition '
-                        'and declearation would not take effect.'),
-        'name': 'is not placed as a direct subelement of <manifest>',
-    },
 }

--- a/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
@@ -275,25 +275,8 @@ def manifest_analysis(mfxml, man_data_dic, src_type, app_dir):
         icon_hidden = True
         do_netsec = False
         debuggable = False
-        # USES-PERMISSION
-        uses_permissions = mfxml.getElementsByTagName('uses-permission')
-        for uses_permission in uses_permissions:
-            parent_node = uses_permission.parentNode
-            if parent_node != "manifest":
-                item = uses_permission.getAttribute('android:name')
-                ret_list.append(('a_error_subelement', (item,), ()))
-        uses_sdk_23_permissions = mfxml.getElementsByTagName('uses-permission-sdk-23')
-        for uses_permission in uses_sdk_23_permissions:
-            parent_node = uses_permission.parentNode
-            if parent_node != "manifest":
-                item = uses_permission.getAttribute('android:name')
-                ret_list.append(('a_error_subelement', (item,), ()))
         # PERMISSION
         for permission in permissions:
-            parent_node = permission.parentNode
-            if parent_node != "manifest":
-                item = permission.getAttribute('android:name')
-                ret_list.append(('a_error_subelement', (item,), ()))
             if permission.getAttribute('android:protectionLevel'):
                 protectionlevel = permission.getAttribute(
                     'android:protectionLevel')


### PR DESCRIPTION
Reverts MobSF/Mobile-Security-Framework-MobSF#1905

Causing a lot of false positives