### PR TITLE
Fix bug #1917 where checking for stripped debugging symbols produces false positives in iOS.

### DIFF
--- a/mobsf/StaticAnalyzer/views/ios/macho_analysis.py
+++ b/mobsf/StaticAnalyzer/views/ios/macho_analysis.py
@@ -224,8 +224,9 @@ class Checksec:
         return bool(self.macho.encryption_info.crypt_id)
 
     def is_symbols_stripped(self):
+        filter_symbol = 'radr://5614542'
         for i in self.macho.symbols:
-            if i:
+            if (i.type & 0xe0) > 0 and i.name.lower().strip() != filter_symbol:
                 return False
         return True
 


### PR DESCRIPTION
### Describe the Pull Request

```
Fix bug #1917. All details required to understand the changes can be found at: https://github.com/MobSF/Mobile-Security-Framework-MobSF/issues/1917
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
Lint tests are failing with a fresh fork for other reasons than this commit
```
