### PR TITLE
fix res directory not exist

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/static_analyzer.py
+++ b/mobsf/StaticAnalyzer/views/android/static_analyzer.py
@@ -187,6 +187,12 @@ def static_analyzer(request, api=False):
                     app_dic['icon_path'] = ''
                     # TODO: Check for possible different names for resource
                     # folder?
+                    if not os.path.exists(res_path):
+                        import shutil
+                         try:
+                            shutil.copy(os.path.join(app_dic['app_dir'], 'apktool_out', 'res'), res_path)
+                        except:
+                            pass
                     if os.path.exists(res_path):
                         icon_dic = get_icon(
                             app_dic['app_path'], res_path)


### PR DESCRIPTION
Fix the problem that the res resource folder does not exist, the solution is to copy from the apktool_out directory

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
DESCRIBE THE DETAILS OF PULL REQUEST HERE
```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
