### PR TITLE
New Android Manifest Rule: App support vulnerable android versions

### DIFF
--- a/.github/workflows/mobsf-test.yml
+++ b/.github/workflows/mobsf-test.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Lint
+      if: startsWith(matrix.os, 'ubuntu')
       run: |
         python -m pip install --upgrade pip tox
         tox -e lint

--- a/.github/workflows/mobsf-test.yml
+++ b/.github/workflows/mobsf-test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.9, '3.10']
         # exclude:
           # excludes py38, py39 on Windows
           # - os: windows-latest

--- a/mobsf/StaticAnalyzer/views/android/android_manifest_desc.py
+++ b/mobsf/StaticAnalyzer/views/android/android_manifest_desc.py
@@ -41,6 +41,17 @@ MANIFEST_DESC = {
         'name': ('App has a Network Security Configuration '
                  '[android:networkSecurityConfig=%s]'),
     },
+    'vulnerable_os_version': {
+        'title': ('App can be installed on a vulnerable Android version'
+                  '<br>[minSdk=%s]'),
+        'level': 'info',
+        'description': ('This application can be installed on an older version'
+                        ' of android that has multiple unfixed '
+                        'vulnerabilities. Support an Android version > 8, '
+                        'API 26 to receive reasonable security updates.'),
+        'name': ('App can be installed on a vulnerable Android version'
+                 '[minSdk=%s]'),
+    },
     'app_is_debuggable': {
         'title': 'Debug Enabled For App<br>[android:debuggable=true]',
         'level': 'high',

--- a/mobsf/StaticAnalyzer/views/android/android_manifest_desc.py
+++ b/mobsf/StaticAnalyzer/views/android/android_manifest_desc.py
@@ -44,7 +44,7 @@ MANIFEST_DESC = {
     'vulnerable_os_version': {
         'title': ('App can be installed on a vulnerable Android version'
                   '<br>[minSdk=%s]'),
-        'level': 'info',
+        'level': 'warning',
         'description': ('This application can be installed on an older version'
                         ' of android that has multiple unfixed '
                         'vulnerabilities. Support an Android version > 8, '

--- a/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 ANDROID_4_2_LEVEL = 17
 ANDROID_5_0_LEVEL = 21
-
+ANDROID_8_0_LEVEL = 26
 
 def get_manifest(app_path, app_dir, tools_dir, typ, binary):
     """Get the manifest file."""
@@ -294,7 +294,10 @@ def manifest_analysis(mfxml, man_data_dic, src_type, app_dir):
             elif permission.getAttribute('android:name'):
                 permission_dict[permission.getAttribute(
                     'android:name')] = 'normal'
-
+        # GENERAL
+        if man_data_dic['min_sdk'] int(man_data_dic['min_sdk']) < ANDROID_8_0_LEVEL:
+            minsdk = man_data_dic.get('min_sdk')
+            ret_list.append(('vulnerable_os_version', (minsdk,), ()))
         # APPLICATIONS
         for application in applications:
             # Esteve 23.07.2016 - begin - identify permission at the

--- a/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
@@ -295,7 +295,7 @@ def manifest_analysis(mfxml, man_data_dic, src_type, app_dir):
                 permission_dict[permission.getAttribute(
                     'android:name')] = 'normal'
         # GENERAL
-        if man_data_dic['min_sdk'] int(man_data_dic['min_sdk']) < ANDROID_8_0_LEVEL:
+        if man_data_dic['min_sdk'] and int(man_data_dic['min_sdk']) < ANDROID_8_0_LEVEL:
             minsdk = man_data_dic.get('min_sdk')
             ret_list.append(('vulnerable_os_version', (minsdk,), ()))
         # APPLICATIONS

--- a/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
@@ -29,6 +29,7 @@ ANDROID_4_2_LEVEL = 17
 ANDROID_5_0_LEVEL = 21
 ANDROID_8_0_LEVEL = 26
 
+
 def get_manifest(app_path, app_dir, tools_dir, typ, binary):
     """Get the manifest file."""
     try:

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
     codespell
 commands =
     flake8 {posargs}
-    codespell --ignore-words-list="doubleclick,dout,ne,upto" --skip="./mobsf/signatures/*,*.map,*.js,*.svg,./.tox/*,./venv/*,./.git/*"
+    codespell --ignore-words-list="doubleclick,dout,ne,upto" --skip="./mobsf/StaticAnalyzer/tools/*,./mobsf/signatures/*,*.map,*.js,*.svg,./.tox/*,./venv/*,./.git/*"
 
 [testenv:clean]
 deps =


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request
<img width="1300" alt="Screenshot 2023-01-10 at 6 15 19 PM" src="https://user-images.githubusercontent.com/4301109/211702252-d10187ee-70ff-413e-8591-de95671e7463.png">

```
Manifest check on minSDK version for android
Test Runner QA
```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=newrule)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
