### PR TITLE
Fix for filenames containing ampersand

### DIFF
--- a/mobsf/templates/general/recent.html
+++ b/mobsf/templates/general/recent.html
@@ -59,7 +59,7 @@
                                   <br/><strong>{{ e.APP_NAME }} {% if e.VERSION_NAME %} - {{ e.VERSION_NAME }} {% endif %}</strong>
                                   </br>{{ e.PACKAGE_NAME }}
                                   <p> <a href="../appsec_dashboard/{{ e.MD5 }}/" class="btn btn-sm btn-outline-primary" role="button"><i class="fas fa-user-shield"></i> MobSF Scorecard</a></p>
-                                  <p><a class="btn btn-primary btn-sm" href="../{{ e.ANALYZER }}/?name={{e.FILE_NAME}}&amp;checksum={{e.MD5}}&amp;type={{e.SCAN_TYPE}}"><i class="fas fa-eye"></i> Static Report</a>
+                                  <p><a class="btn btn-primary btn-sm" href="../{{ e.ANALYZER }}/?name={{e.FILE_NAME | urlencode}}&amp;checksum={{e.MD5}}&amp;type={{e.SCAN_TYPE}}"><i class="fas fa-eye"></i> Static Report</a>
                                   {% if '.apk' == e.FILE_NAME|slice:"-4:" or '.xapk' == e.FILE_NAME|slice:"-5:" or '.apks' == e.FILE_NAME|slice:"-5:"%}
                                     <a  class="btn btn-success btn-sm {% if not e.DYNAMIC_REPORT_EXISTS %}disabled{% endif %}" href="../dynamic_report/{{ e.MD5  }}"><i class="fa fa-mobile"></i> Dynamic Report</a>
                                   {% endif %}
@@ -83,7 +83,7 @@
                             <td>{{ e.TIMESTAMP }}</td>
                             <td><p>
                                    <a class="btn btn-outline-primary btn-sm" href="../pdf/?md5={{ e.MD5 }}"><i class="fas fa-file-pdf"></i></a>
-                                   <a class="btn btn-outline-info btn-sm" href="../{{ e.ANALYZER }}/?name={{e.FILE_NAME}}&amp;checksum={{e.MD5}}&amp;type={{e.SCAN_TYPE}}&amp;rescan=1"><i class="fas fa-sync-alt"></i></a>
+                                   <a class="btn btn-outline-info btn-sm" href="../{{ e.ANALYZER }}/?name={{e.FILE_NAME | urlencode}}&amp;checksum={{e.MD5}}&amp;type={{e.SCAN_TYPE}}&amp;rescan=1"><i class="fas fa-sync-alt"></i></a>
                                 </p>
                             {% if '.apk' == e.FILE_NAME|slice:"-4:" or '.xapk' == e.FILE_NAME|slice:"-5:" or '.apks' == e.FILE_NAME|slice:"-5:"%}
                                 <p><a class="diffButton btn btn-warning btn-sm" id="{{ e.MD5 }}_{{ e.FILE_NAME }}"><i class="fas fa-not-equal"></i> Diff or Compare</a>


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request


```
Filename in static report button link or in the re-scan button is not properly urlencoded. 
When clicking on static report button or re-scan button on the recent scans page you will get an error  if a scanned APK contains an ampersand in the filename.

How to test: Upload an APK with an ampersand in the filename
After the APK has been scanned, go to recent scans and click static report button.
What happens: Error page is displayed (Hash match failed or Invalid file extension or file type)

Example: Xender - Share Music   &    Transfer_12.5.1.Prime_Apkpure.apk

Before fix:
http://0.0.0.0:8000/static_analyzer/?name=Xender%20-%20Share%20Music%20%20%20&%20%20%20%20Transfer_12.5.1.Prime_Apkpure.apk&checksum=f28edeb8c6c07ee9c6500f3c37784817&type=apk

Properly urlencoded:
http://0.0.0.0:8000/static_analyzer/?name=Xender%20-%20Share%20Music%20%20%20%26%20%20%20%20Transfer_12.5.1.Prime_Apkpure.apk&checksum=f28edeb8c6c07ee9c6500f3c37784817&type=apk
```


### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
