### PR TITLE
Fix Scorecard Severity Distribution chart data

### DIFF
--- a/mobsf/templates/static_analysis/appsec_dashboard.html
+++ b/mobsf/templates/static_analysis/appsec_dashboard.html
@@ -503,10 +503,11 @@ sidebar-collapse
     const warn = {{warning | length}};
     const info = {{ info | length}};
     const secure = {{ secure | length}};
-    const hp = Math.floor(high/ (high + warn + info + secure) * 100)
-    const wp = Math.floor(warn/ (high + warn + info + secure) * 100)
-    const ip = Math.floor(info/ (warn + warn + info + secure) * 100)
-    const sp = Math.floor(secure/ (warn + warn + info + secure) * 100)
+    const total = Math.max(1, high + warn + info + secure);
+    const hp = Math.floor(high/ total * 100)
+    const wp = Math.floor(warn/ total * 100)
+    const ip = Math.floor(info/ total * 100)
+    const sp = Math.floor(secure/ total * 100)
     var ctx = document.getElementById("severity").getContext('2d');
     var myChart = new Chart(ctx, {
     type: 'pie',


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
The percentage for Info and Secure categories was incorrect. Info and Secure were divided by a total counting two times Warn and zero times High categories.
Fixes also a possible null division.
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
No additional comments.
```
