### PR TITLE
[Enterprise Feature Request EFR02] Support summary of severity in each section.

### DIFF
--- a/mobsf/MobSF/init.py
+++ b/mobsf/MobSF/init.py
@@ -10,7 +10,7 @@ from mobsf.install.windows.setup import windows_config_local
 
 logger = logging.getLogger(__name__)
 
-VERSION = '3.6.4'
+VERSION = '3.6.5'
 BANNER = """
   __  __       _    ____  _____       _____  __   
  |  \/  | ___ | |__/ ___||  ___|_   _|___ / / /_  

--- a/mobsf/StaticAnalyzer/views/android/cert_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/cert_analysis.py
@@ -19,6 +19,9 @@ from django.utils.html import escape
 logger = logging.getLogger(__name__)
 logging.getLogger('androguard').setLevel(logging.ERROR)
 ANDROID_8_1_LEVEL = 27
+HIGH = 'high'
+WARNING = 'warning'
+INFO = 'info'
 
 
 def get_hardcoded_cert_keystore(files):
@@ -55,7 +58,7 @@ def cert_info(app_dir, app_file, man_dict):
         manidat = ''
         cert_info = ''
         certlist = []
-        summary = {'high': 0, 'warning': 0, 'info': 0}
+        summary = {HIGH: 0, WARNING: 0, INFO: 0}
         cert_path = os.path.join(app_dir, 'META-INF/')
 
         apk_file = os.path.join(app_dir, app_file)
@@ -118,27 +121,27 @@ def cert_info(app_dir, app_file, man_dict):
         sha256_digest = bool(re.findall(r'SHA-256-Digest', manidat))
         findings = []
         if a.is_signed():
-            summary['info'] += 1
+            summary[INFO] += 1
             findings.append((
-                'info',
+                INFO,
                 'Application is signed with a code '
                 'signing certificate',
                 'Signed Application'))
         else:
-            summary['high'] += 1
+            summary[HIGH] += 1
             findings.append((
-                'high',
+                HIGH,
                 'Code signing certificate not found',
                 'Missing Code Signing certificate'))
         if a.is_signed_v1():
-            status = 'high'
-            summary['high'] += 1
+            status = HIGH
+            summary[HIGH] += 1
             api_level = int(man_dict['min_sdk'])
             if ((a.is_signed_v2() or a.is_signed_v3())
                     and api_level < ANDROID_8_1_LEVEL):
-                status = 'warning'
-                summary['high'] -= 1
-                summary['warning'] += 1
+                status = WARNING
+                summary[HIGH] -= 1
+                summary[WARNING] += 1
             findings.append((
                 status,
                 'Application is signed with v1 signature scheme, '
@@ -149,25 +152,25 @@ def cert_info(app_dir, app_file, man_dict):
                 'scheme is also vulnerable.',
                 'Application vulnerable to Janus Vulnerability'))
         if re.findall(r'CN=Android Debug', cert_info):
-            summary['high'] += 1
+            summary[HIGH] += 1
             findings.append((
-                'high',
+                HIGH,
                 'Application signed with a debug certificate. '
                 'Production application must not be shipped '
                 'with a debug certificate.',
                 'Application signed with debug certificate'))
         if re.findall(r'Hash Algorithm: sha1', cert_info):
-            status = 'high'
-            summary['high'] += 1
+            status = HIGH
+            summary[HIGH] += 1
             desc = (
                 'Application is signed with SHA1withRSA. '
                 'SHA1 hash algorithm is known to have '
                 'collision issues.')
             title = 'Certificate algorithm vulnerable to hash collision'
             if sha256_digest:
-                status = 'warning'
-                summary['high'] -= 1
-                summary['warning'] += 1
+                status = WARNING
+                summary[HIGH] -= 1
+                summary[WARNING] += 1
                 desc += (
                     ' The manifest file indicates SHA256withRSA'
                     ' is in use.')
@@ -175,8 +178,8 @@ def cert_info(app_dir, app_file, man_dict):
                          'vulnerable to hash collision')
             findings.append((status, desc, title))
         if re.findall(r'Hash Algorithm: md5', cert_info):
-            status = 'high'
-            summary['high'] += 1
+            status = HIGH
+            summary[HIGH] += 1
             desc = (
                 'Application is signed with MD5. '
                 'MD5 hash algorithm is known to have '

--- a/mobsf/StaticAnalyzer/views/android/cert_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/cert_analysis.py
@@ -55,6 +55,7 @@ def cert_info(app_dir, app_file, man_dict):
         manidat = ''
         cert_info = ''
         certlist = []
+        summary = {'high': 0, 'warning': 0, 'info': 0}
         cert_path = os.path.join(app_dir, 'META-INF/')
 
         apk_file = os.path.join(app_dir, app_file)
@@ -117,22 +118,27 @@ def cert_info(app_dir, app_file, man_dict):
         sha256_digest = bool(re.findall(r'SHA-256-Digest', manidat))
         findings = []
         if a.is_signed():
+            summary['info'] += 1
             findings.append((
                 'info',
                 'Application is signed with a code '
                 'signing certificate',
                 'Signed Application'))
         else:
+            summary['high'] += 1
             findings.append((
                 'high',
                 'Code signing certificate not found',
                 'Missing Code Signing certificate'))
         if a.is_signed_v1():
             status = 'high'
+            summary['high'] += 1
             api_level = int(man_dict['min_sdk'])
             if ((a.is_signed_v2() or a.is_signed_v3())
                     and api_level < ANDROID_8_1_LEVEL):
                 status = 'warning'
+                summary['high'] -= 1
+                summary['warning'] += 1
             findings.append((
                 status,
                 'Application is signed with v1 signature scheme, '
@@ -143,6 +149,7 @@ def cert_info(app_dir, app_file, man_dict):
                 'scheme is also vulnerable.',
                 'Application vulnerable to Janus Vulnerability'))
         if re.findall(r'CN=Android Debug', cert_info):
+            summary['high'] += 1
             findings.append((
                 'high',
                 'Application signed with a debug certificate. '
@@ -151,6 +158,7 @@ def cert_info(app_dir, app_file, man_dict):
                 'Application signed with debug certificate'))
         if re.findall(r'Hash Algorithm: sha1', cert_info):
             status = 'high'
+            summary['high'] += 1
             desc = (
                 'Application is signed with SHA1withRSA. '
                 'SHA1 hash algorithm is known to have '
@@ -158,6 +166,8 @@ def cert_info(app_dir, app_file, man_dict):
             title = 'Certificate algorithm vulnerable to hash collision'
             if sha256_digest:
                 status = 'warning'
+                summary['high'] -= 1
+                summary['warning'] += 1
                 desc += (
                     ' The manifest file indicates SHA256withRSA'
                     ' is in use.')
@@ -166,17 +176,18 @@ def cert_info(app_dir, app_file, man_dict):
             findings.append((status, desc, title))
         if re.findall(r'Hash Algorithm: md5', cert_info):
             status = 'high'
+            summary['high'] += 1
             desc = (
                 'Application is signed with MD5. '
                 'MD5 hash algorithm is known to have '
                 'collision issues.')
             title = 'Certificate algorithm vulnerable to hash collision'
             findings.append((status, desc, title))
-        cert_dic = {
+        return {
             'certificate_info': cert_info,
             'certificate_findings': findings,
+            'certificate_summary': summary,
         }
-        return cert_dic
     except Exception:
         logger.exception('Reading Code Signing Certificate')
         return {}

--- a/mobsf/StaticAnalyzer/views/android/db_interaction.py
+++ b/mobsf/StaticAnalyzer/views/android/db_interaction.py
@@ -60,7 +60,7 @@ def get_context_from_db_entry(db_entry: QuerySet) -> dict:
             'certificate_analysis': python_dict(
                 db_entry[0].CERTIFICATE_ANALYSIS),
             'manifest_analysis': manifest_analysis,
-            'network_security': python_list(db_entry[0].NETWORK_SECURITY),
+            'network_security': python_dict(db_entry[0].NETWORK_SECURITY),
             'binary_analysis': python_list(db_entry[0].BINARY_ANALYSIS),
             'file_analysis': python_list(db_entry[0].FILE_ANALYSIS),
             'android_api': python_dict(db_entry[0].ANDROID_API),

--- a/mobsf/StaticAnalyzer/views/android/network_security.py
+++ b/mobsf/StaticAnalyzer/views/android/network_security.py
@@ -259,10 +259,8 @@ def analysis(app_dir, config, is_debuggable, src_type):
                             'severity': 'high',
                         })
                         summary['high'] += 1
-        return {
-            'network_findings': finds,
-            'network_summary': summary,
-        }
+        netsec['network_findings'] = finds
+        netsec['network_summary'] = summary
     except Exception:
         logger.exception('Performing Network Security Analysis')
-    return {}
+    return netsec

--- a/mobsf/StaticAnalyzer/views/android/network_security.py
+++ b/mobsf/StaticAnalyzer/views/android/network_security.py
@@ -5,6 +5,10 @@ from xml.dom import minidom
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+HIGH = 'high'
+WARNING = 'warning'
+INFO = 'info'
+SECURE = 'secure'
 
 
 def read_netsec_config(app_dir, config, src_type):
@@ -49,7 +53,7 @@ def analysis(app_dir, config, is_debuggable, src_type):
         logger.info('Parsing Network Security Config')
         parsed = minidom.parseString(netsec_conf)
         finds = []
-        summary = {'high': 0, 'warning': 0, 'info': 0, 'secure': 0}
+        summary = {HIGH: 0, WARNING: 0, INFO: 0, SECURE: 0}
         # Base Config
         b_cfg = parsed.getElementsByTagName('base-config')
         # 0 or 1 of <base-config>
@@ -60,18 +64,18 @@ def analysis(app_dir, config, is_debuggable, src_type):
                     'description': (
                         'Base config is insecurely configured'
                         ' to permit clear text traffic to all domains.'),
-                    'severity': 'high',
+                    'severity': HIGH,
                 })
-                summary['high'] += 1
+                summary[HIGH] += 1
             if b_cfg[0].getAttribute('cleartextTrafficPermitted') == 'false':
                 finds.append({
                     'scope': ['*'],
                     'description': (
                         'Base config is configured to disallow '
                         'clear text traffic to all domains.'),
-                    'severity': 'secure',
+                    'severity': SECURE,
                 })
-                summary['secure'] += 1
+                summary[SECURE] += 1
             trst_anch = b_cfg[0].getElementsByTagName('trust-anchors')
             if trst_anch:
                 certs = trst_anch[0].getElementsByTagName('certificates')
@@ -84,36 +88,36 @@ def analysis(app_dir, config, is_debuggable, src_type):
                             'description': (
                                 'Base config is configured to trust'
                                 f'bundled certs {loc}.'),
-                            'severity': 'info',
+                            'severity': INFO,
                         })
-                        summary['info'] += 1
+                        summary[INFO] += 1
                     elif loc == 'system':
                         finds.append({
                             'scope': ['*'],
                             'description': (
                                 'Base config is configured to trust'
                                 ' system certificates.'),
-                            'severity': 'warning',
+                            'severity': WARNING,
                         })
-                        summary['warning'] += 1
+                        summary[WARNING] += 1
                     elif loc == 'user':
                         finds.append({
                             'scope': ['*'],
                             'description': (
                                 'Base config is configured to trust'
                                 ' user installed certificates.'),
-                            'severity': 'high',
+                            'severity': HIGH,
                         })
-                        summary['high'] += 1
+                        summary[HIGH] += 1
                     if override == 'true':
                         finds.append({
                             'scope': ['*'],
                             'description': (
                                 'Base config is configured to '
                                 'bypass certificate pinning.'),
-                            'severity': 'high',
+                            'severity': HIGH,
                         })
-                        summary['high'] += 1
+                        summary[HIGH] += 1
         # Domain Config
         dom_cfg = parsed.getElementsByTagName('domain-config')
         # Any number of <domain-config>
@@ -129,9 +133,9 @@ def analysis(app_dir, config, is_debuggable, src_type):
                         'Domain config is insecurely configured'
                         ' to permit clear text traffic to these '
                         'domains in scope.'),
-                    'severity': 'high',
+                    'severity': HIGH,
                 })
-                summary['high'] += 1
+                summary[HIGH] += 1
             elif cfg.getAttribute('cleartextTrafficPermitted') == 'false':
                 finds.append({
                     'scope': domain_list,
@@ -139,9 +143,9 @@ def analysis(app_dir, config, is_debuggable, src_type):
                         'Domain config is securely configured'
                         ' to disallow clear text traffic to these '
                         'domains in scope.'),
-                    'severity': 'secure',
+                    'severity': SECURE,
                 })
-                summary['secure'] += 1
+                summary[SECURE] += 1
             dtrust = cfg.getElementsByTagName('trust-anchors')
             if dtrust:
                 certs = dtrust[0].getElementsByTagName('certificates')
@@ -154,36 +158,36 @@ def analysis(app_dir, config, is_debuggable, src_type):
                             'description': (
                                 'Domain config is configured to trust '
                                 f'bundled certs {loc}.'),
-                            'severity': 'info',
+                            'severity': INFO,
                         })
-                        summary['info'] += 1
+                        summary[INFO] += 1
                     elif loc == 'system':
                         finds.append({
                             'scope': domain_list,
                             'description': (
                                 'Domain config is configured to trust'
                                 ' system certificates.'),
-                            'severity': 'warning',
+                            'severity': WARNING,
                         })
-                        summary['warning'] += 1
+                        summary[WARNING] += 1
                     elif loc == 'user':
                         finds.append({
                             'scope': domain_list,
                             'description': (
                                 'Domain config is configured to trust'
                                 ' user installed certificates.'),
-                            'severity': 'high',
+                            'severity': HIGH,
                         })
-                        summary['high'] += 1
+                        summary[HIGH] += 1
                     if override == 'true':
                         finds.append({
                             'scope': domain_list,
                             'description': (
                                 'Domain config is configured to '
                                 'bypass certificate pinning.'),
-                            'severity': 'high',
+                            'severity': HIGH,
                         })
-                        summary['high'] += 1
+                        summary[HIGH] += 1
             pinsets = cfg.getElementsByTagName('pin-set')
             if pinsets:
                 exp = pinsets[0].getAttribute('expiration')
@@ -206,9 +210,9 @@ def analysis(app_dir, config, is_debuggable, src_type):
                             f'on {exp}. After this date '
                             'pinning will be disabled. '
                             f'[{pins_list}]'),
-                        'severity': 'info',
+                        'severity': INFO,
                     })
-                    summary['info'] += 1
+                    summary[INFO] += 1
                 else:
                     finds.append({
                         'scope': domain_list,
@@ -218,9 +222,9 @@ def analysis(app_dir, config, is_debuggable, src_type):
                             'that pins are updated before '
                             'certificate expire. '
                             f'[{pins_list}]'),
-                        'severity': 'secure',
+                        'severity': SECURE,
                     })
-                    summary['secure'] += 1
+                    summary[SECURE] += 1
         # Debug Overrides
         de_over = parsed.getElementsByTagName('debug-overrides')
         # 0 or 1 of <debug-overrides>
@@ -232,9 +236,9 @@ def analysis(app_dir, config, is_debuggable, src_type):
                         'Debug override is configured to permit clear '
                         'text traffic to all domains and the app '
                         'is debuggable.'),
-                    'severity': 'high',
+                    'severity': HIGH,
                 })
-                summary['high'] += 1
+                summary[HIGH] += 1
             otrst_anch = de_over[0].getElementsByTagName('trust-anchors')
             if otrst_anch:
                 certs = otrst_anch[0].getElementsByTagName('certificates')
@@ -247,18 +251,18 @@ def analysis(app_dir, config, is_debuggable, src_type):
                             'description': (
                                 'Debug override is configured to trust '
                                 f'bundled debug certs {loc}.'),
-                            'severity': 'high',
+                            'severity': HIGH,
                         })
-                        summary['high'] += 1
+                        summary[HIGH] += 1
                     if override == 'true':
                         finds.append({
                             'scope': ['*'],
                             'description': (
                                 'Debug override is configured to '
                                 'bypass certificate pinning.'),
-                            'severity': 'high',
+                            'severity': HIGH,
                         })
-                        summary['high'] += 1
+                        summary[HIGH] += 1
         netsec['network_findings'] = finds
         netsec['network_summary'] = summary
     except Exception:

--- a/mobsf/StaticAnalyzer/views/common/appsec.py
+++ b/mobsf/StaticAnalyzer/views/common/appsec.py
@@ -251,7 +251,8 @@ def get_ios_dashboard(context, from_ctx=False):
     else:
         data = idb(context)
     # Transport Security
-    if 'ats_findings' in data['ats_analysis']:
+    if (data.get('ats_analysis')
+            and 'ats_findings' in data['ats_analysis']):
         for n in data['ats_analysis']['ats_findings']:
             findings[n['severity']].append({
                 'title': n['issue'],
@@ -259,7 +260,8 @@ def get_ios_dashboard(context, from_ctx=False):
                 'section': 'network',
             })
     # Binary Code Analysis
-    if 'findings' in data['binary_analysis']:
+    if (data.get('binary_analysis')
+            and 'findings' in data['binary_analysis']):
         for issue, cd in data['binary_analysis']['findings'].items():
             if cd['severity'] == 'good':
                 sev = 'secure'

--- a/mobsf/StaticAnalyzer/views/common/suppression.py
+++ b/mobsf/StaticAnalyzer/views/common/suppression.py
@@ -30,6 +30,13 @@ from mobsf.StaticAnalyzer.models import (
 
 logger = logging.getLogger(__name__)
 
+HIGH = 'high'
+WARNING = 'warning'
+INFO = 'info'
+SECURE = 'secure'
+GOOD = 'good'
+SUPPRESSED = 'suppressed'
+
 
 def get_package(checksum):
     """Get package from checksum."""
@@ -233,8 +240,8 @@ def delete_suppression(request, api=False):
 def process_suppression(data, package):
     """Process all suppression for code."""
     filtered = {}
-    summary = {'high': 0, 'warning': 0, 'info': 0,
-               'secure': 0, 'suppressed': 0}
+    summary = {HIGH: 0, WARNING: 0, INFO: 0,
+               SECURE: 0, SUPPRESSED: 0}
     if len(data) == 0:
         return {
             'findings': data,
@@ -253,7 +260,7 @@ def process_suppression(data, package):
                 if k not in filter_rules:
                     filtered[k] = data[k]
                 else:
-                    summary['suppressed'] += 1
+                    summary[SUPPRESSED] += 1
         else:
             filtered = deepcopy(data)
 
@@ -267,8 +274,8 @@ def process_suppression(data, package):
                 for rem_file in filter_files[k]:
                     if rem_file in filtered[k]['files']:
                         del filtered[k]['files'][rem_file]
-                        summary['suppressed'] += 1
-                # Remove rule_id with not files
+                        summary[SUPPRESSED] += 1
+                # Remove rule_id with no files
                 if len(filtered[k]['files']) == 0:
                     del cleaned[k]
     for v in cleaned.values():
@@ -277,14 +284,14 @@ def process_suppression(data, package):
             sev = v['severity']
         else:
             sev = v['metadata']['severity']
-        if sev == 'high':
-            summary['high'] += 1
-        elif sev == 'warning':
-            summary['warning'] += 1
-        elif sev == 'info':
-            summary['info'] += 1
-        elif sev == 'good' or sev == 'secure':
-            summary['secure'] += 1
+        if sev == HIGH:
+            summary[HIGH] += 1
+        elif sev == WARNING:
+            summary[WARNING] += 1
+        elif sev == INFO:
+            summary[INFO] += 1
+        elif sev == GOOD or sev == SECURE:
+            summary[SECURE] += 1
     return {
         'findings': cleaned,
         'summary': summary,
@@ -294,7 +301,7 @@ def process_suppression(data, package):
 def process_suppression_manifest(data, package):
     """Process all suppression for manifest."""
     filtered = []
-    summary = {'high': 0, 'warning': 0, 'info': 0, 'suppressed': 0}
+    summary = {HIGH: 0, WARNING: 0, INFO: 0, SUPPRESSED: 0}
     filters = SuppressFindings.objects.filter(
         PACKAGE_NAME=package,
         SUPPRESS_TYPE='manifest')
@@ -310,16 +317,16 @@ def process_suppression_manifest(data, package):
                 if dynamic_rule not in filter_rules:
                     filtered.append(k)
                 else:
-                    summary['suppressed'] += 1
+                    summary[SUPPRESSED] += 1
         else:
             filtered = data
     for i in filtered:
-        if i['severity'] == 'high':
-            summary['high'] += 1
-        elif i['severity'] == 'warning':
-            summary['warning'] += 1
-        elif ['severity'] == 'info':
-            summary['info'] += 1
+        if i['severity'] == HIGH:
+            summary[HIGH] += 1
+        elif i['severity'] == WARNING:
+            summary[WARNING] += 1
+        elif ['severity'] == INFO:
+            summary[INFO] += 1
     return {
         'manifest_findings': filtered,
         'manifest_summary': summary,

--- a/mobsf/StaticAnalyzer/views/ios/db_interaction.py
+++ b/mobsf/StaticAnalyzer/views/ios/db_interaction.py
@@ -45,7 +45,7 @@ def get_context_from_db_entry(db_entry):
             'info_plist': db_entry[0].INFO_PLIST,
             'binary_info': python_dict(db_entry[0].BINARY_INFO),
             'permissions': python_dict(db_entry[0].PERMISSIONS),
-            'ats_analysis': python_list(db_entry[0].ATS_ANALYSIS),
+            'ats_analysis': python_dict(db_entry[0].ATS_ANALYSIS),
             'binary_analysis': binary,
             'macho_analysis': python_dict(db_entry[0].MACHO_ANALYSIS),
             'ios_api': python_dict(db_entry[0].IOS_API),

--- a/mobsf/StaticAnalyzer/views/ios/plist_analysis.py
+++ b/mobsf/StaticAnalyzer/views/ios/plist_analysis.py
@@ -35,6 +35,10 @@ from mobsf.StaticAnalyzer.views.common.shared_func import (
 
 logger = logging.getLogger(__name__)
 SKIP_PATH = {'__MACOSX', 'Pods'}
+HIGH = 'high'
+WARNING = 'warning'
+INFO = 'info'
+SECURE = 'secure'
 
 
 def get_bundle_id(pobj, src):
@@ -206,16 +210,16 @@ def get_summary(ats):
     """Get ATS finding summary."""
     if len(ats) == 0:
         return {}
-    summary = {'high': 0, 'warning': 0, 'info': 0, 'secure': 0}
+    summary = {HIGH: 0, WARNING: 0, INFO: 0, SECURE: 0}
     for i in ats:
-        if i['severity'] == 'high':
-            summary['high'] += 1
-        elif i['severity'] == 'warning':
-            summary['warning'] += 1
-        elif i['severity'] == 'info':
-            summary['info'] += 1
-        elif i['severity'] == 'secure':
-            summary['secure'] += 1
+        if i['severity'] == HIGH:
+            summary[HIGH] += 1
+        elif i['severity'] == WARNING:
+            summary[WARNING] += 1
+        elif i['severity'] == INFO:
+            summary[INFO] += 1
+        elif i['severity'] == SECURE:
+            summary[SECURE] += 1
     return summary
 
 

--- a/mobsf/templates/pdf/android_report.html
+++ b/mobsf/templates/pdf/android_report.html
@@ -402,6 +402,16 @@
       {% endif %}
 
      <h2><i class="fas fa-lock"></i> NETWORK SECURITY</h2>
+     {% if network_security and 'network_summary' in network_security and network_security.network_summary|length > 0 %}
+     <span class="danger">HIGH: </span>
+     <h5 class="description-header">{{ network_security.network_summary.high }}</h5> | 
+     <span class="warning"></i> WARNING: </span>
+     <h5 class="description-header">{{ network_security.network_summary.warning }}</h5> |
+     <span class="info">INFO: </span>
+     <h5 class="description-header">{{ network_security.network_summary.info }}</h5> |
+     <span class="success">SECURE: </span>
+     <h5 class="description-header">{{ network_security.network_summary.secure }}</h5>
+   {% endif %}</br>
      <table class="basic">
         <thead>
             <tr>
@@ -440,17 +450,16 @@
           {% endif %}
         </tbody>
         </table>
-        {% if network_security and 'network_summary' in network_security and network_security.network_summary|length > 0 %}
-        <span class="danger">HIGH: </span>
-        <h5 class="description-header">{{ network_security.network_summary.high }}</h5> | 
-        <span class="warning"></i> WARNING: </span>
-        <h5 class="description-header">{{ network_security.network_summary.warning }}</h5> |
-        <span class="info">INFO: </span>
-        <h5 class="description-header">{{ network_security.network_summary.info }}</h5> |
-        <span class="success">SECURE: </span>
-        <h5 class="description-header">{{ network_security.network_summary.secure }}</h5>
-      {% endif %}
+       
       <h2><i class="fas fa fa-id-card"></i> CERTIFICATE ANALYSIS</h2>
+      {% if certificate_analysis and 'certificate_summary' in certificate_analysis and certificate_analysis.certificate_summary|length > 0 %}
+      <span class="danger">HIGH: </span>
+      <h5 class="description-header">{{ certificate_analysis.certificate_summary.high }}</h5> | 
+      <span class="warning"></i> WARNING: </span>
+      <h5 class="description-header">{{ certificate_analysis.certificate_summary.warning }}</h5> |
+      <span class="info">INFO: </span>
+      <h5 class="description-header">{{ certificate_analysis.certificate_summary.info }}</h5>
+    {% endif %}</br>
       <table class="basic">
         <thead>
             <tr>
@@ -481,15 +490,18 @@
           {% endif %}
         </tbody>
     </table>
-    {% if certificate_analysis and 'certificate_summary' in certificate_analysis and certificate_analysis.certificate_summary|length > 0 %}
-      <span class="danger">HIGH: </span>
-      <h5 class="description-header">{{ certificate_analysis.certificate_summary.high }}</h5> | 
-      <span class="warning"></i> WARNING: </span>
-      <h5 class="description-header">{{ certificate_analysis.certificate_summary.warning }}</h5> |
-      <span class="info">INFO: </span>
-      <h5 class="description-header">{{ certificate_analysis.certificate_summary.info }}</h5>
-    {% endif %}
+   
     <h2><i class="fas fa-search"></i> MANIFEST ANALYSIS</h2>
+    {% if manifest_analysis and 'manifest_summary' in manifest_analysis and manifest_analysis.manifest_summary|length > 0 %}
+    <span class="danger">HIGH: </span>
+    <h5 class="description-header">{{ manifest_analysis.manifest_summary.high }}</h5> | 
+    <span class="warning"></i> WARNING: </span>
+    <h5 class="description-header">{{ manifest_analysis.manifest_summary.warning }}</h5> |
+    <span class="info">INFO: </span>
+    <h5 class="description-header">{{ manifest_analysis.manifest_summary.info }}</h5> |
+    <span class="disabled">SUPPRESSED: </span>
+    <h5 class="description-header">{{ manifest_analysis.manifest_summary.suppressed }}</h5>
+  {% endif %}</br>
      <table class="basic">
                     <thead>
                         <tr>
@@ -528,17 +540,20 @@
 
 										</tbody>
 										</table>
-                    {% if manifest_analysis and 'manifest_summary' in manifest_analysis and manifest_analysis.manifest_summary|length > 0 %}
-                    <span class="danger">HIGH: </span>
-                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.high }}</h5> | 
-                    <span class="warning"></i> WARNING: </span>
-                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.warning }}</h5> |
-                    <span class="info">INFO: </span>
-                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.info }}</h5> |
-                    <span class="disabled">SUPPRESSED: </span>
-                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.suppressed }}</h5>
-                  {% endif %}
+                   
       <h2><i class="fas fa-code"></i> CODE ANALYSIS</h2>
+      {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
+      <span class="danger">HIGH: </span>
+      <h5 class="description-header">{{ code_analysis.summary.high }}</h5> | 
+      <span class="warning"></i> WARNING: </span>
+      <h5 class="description-header">{{ code_analysis.summary.warning }}</h5> |
+      <span class="info">INFO: </span>
+      <h5 class="description-header">{{ code_analysis.summary.info }}</h5> |
+      <span class="success">SECURE: </span>
+      <h5 class="description-header">{{ code_analysis.summary.secure }}</h5> |
+      <span class="disabled">SUPPRESSED: </span>
+      <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
+    {% endif %}</br>
        <table class="basic">
                 <thead>
                     <tr>
@@ -602,18 +617,7 @@
               {% endif %}
           </tbody>
           </table>
-          {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
-          <span class="danger">HIGH: </span>
-          <h5 class="description-header">{{ code_analysis.summary.high }}</h5> | 
-          <span class="warning"></i> WARNING: </span>
-          <h5 class="description-header">{{ code_analysis.summary.warning }}</h5> |
-          <span class="info">INFO: </span>
-          <h5 class="description-header">{{ code_analysis.summary.info }}</h5> |
-          <span class="success">SECURE: </span>
-          <h5 class="description-header">{{ code_analysis.summary.secure }}</h5> |
-          <span class="disabled">SUPPRESSED: </span>
-          <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
-        {% endif %}
+         
             
      {% if binary_analysis  %}
       <h2><i class="fa fa-flag"></i> SHARED LIBRARY BINARY ANALYSIS</h2>

--- a/mobsf/templates/pdf/android_report.html
+++ b/mobsf/templates/pdf/android_report.html
@@ -403,41 +403,53 @@
 
      <h2><i class="fas fa-lock"></i> NETWORK SECURITY</h2>
      <table class="basic">
-                    <thead>
-                        <tr>
-                          <th>NO</th>
-                          <th>SCOPE</th>
-                          <th>SEVERITY</th>
-                          <th>DESCRIPTION</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                    {% for item in network_security %}
-                      <tr>
-                        <td>{{ forloop.counter }}</td>
-                        <td>
-                         {% for url in item.scope %}
-                          {{ url }}</br>
-                        {% endfor %}
-                        </td>
-                        <td>
-                          {% if item.severity == "high" %}
-                            <span class="danger">high</span>
-                          {% elif item.severity == "secure" %}
-                            <span class="good">secure</span>
-                          {% elif item.severity == "info" %}
-                            <span class="info">info</span>
-                          {% elif item.severity == "warning" %}
-                             <span class="warning">warning</span>
-                          {% endif %}
-                        </td>
-                        <td>
-                        {{item.description }}
-                        </td>
-                       </tr>
-                     {% endfor %}
-										</tbody>
-										</table>
+        <thead>
+            <tr>
+              <th>NO</th>
+              <th>SCOPE</th>
+              <th>SEVERITY</th>
+              <th>DESCRIPTION</th>
+                    </tr>
+                </thead>
+                <tbody>
+        {% if network_security and 'network_findings' in network_security %}
+        {% for item in network_security.network_findings %}
+          <tr>
+            <td>{{ forloop.counter }}</td>
+            <td>
+              {% for url in item.scope %}
+              {{ url }}</br>
+            {% endfor %}
+            </td>
+            <td>
+              {% if item.severity == "high" %}
+                <span class="danger">high</span>
+              {% elif item.severity == "secure" %}
+                <span class="success">secure</span>
+              {% elif item.severity == "info" %}
+                <span class="info">info</span>
+              {% elif item.severity == "warning" %}
+                  <span class="warning">warning</span>
+              {% endif %}
+            </td>
+            <td>
+            {{item.description }}
+            </td>
+            </tr>
+          {% endfor %}
+          {% endif %}
+        </tbody>
+        </table>
+        {% if network_security and 'network_summary' in network_security and network_security.network_summary|length > 0 %}
+        <span class="danger">HIGH: </span>
+        <h5 class="description-header">{{ network_security.network_summary.high }}</h5> | 
+        <span class="warning"></i> WARNING: </span>
+        <h5 class="description-header">{{ network_security.network_summary.warning }}</h5> |
+        <span class="info">INFO: </span>
+        <h5 class="description-header">{{ network_security.network_summary.info }}</h5> |
+        <span class="success">SECURE: </span>
+        <h5 class="description-header">{{ network_security.network_summary.secure }}</h5>
+      {% endif %}
       <h2><i class="fas fa fa-id-card"></i> CERTIFICATE ANALYSIS</h2>
       <table class="basic">
         <thead>
@@ -448,7 +460,7 @@
             </tr>
         </thead>
         <tbody>
-          {% if 'certificate_findings' in certificate_analysis %}
+          {% if certificate_analysis and 'certificate_findings' in certificate_analysis %}
             {% for find in certificate_analysis.certificate_findings %}
             <tr>
             <td>{{ find.2 }}</td>
@@ -469,6 +481,14 @@
           {% endif %}
         </tbody>
     </table>
+    {% if certificate_analysis and 'certificate_summary' in certificate_analysis and certificate_analysis.certificate_summary|length > 0 %}
+      <span class="danger">HIGH: </span>
+      <h5 class="description-header">{{ certificate_analysis.certificate_summary.high }}</h5> | 
+      <span class="warning"></i> WARNING: </span>
+      <h5 class="description-header">{{ certificate_analysis.certificate_summary.warning }}</h5> |
+      <span class="info">INFO: </span>
+      <h5 class="description-header">{{ certificate_analysis.certificate_summary.info }}</h5>
+    {% endif %}
     <h2><i class="fas fa-search"></i> MANIFEST ANALYSIS</h2>
      <table class="basic">
                     <thead>
@@ -480,34 +500,44 @@
                                 </tr>
                             </thead>
                             <tbody>
-									  {% for item in manifest_analysis %}
-                      <tr>
-                        <td>{{ forloop.counter }}</td>
-                        <td>
-                        {{item|key:"title" | safe}}
-                        </td>
-                        <td>
+                    {% if manifest_analysis and 'manifest_findings' in manifest_analysis %}
+                    {% for item in manifest_analysis.manifest_findings %}
+                    <tr>
+                      <td>{{ forloop.counter }}</td>
+                      <td>
+                      {{item|key:"title" | safe}}
+                      </td>
+                      <td>
 
-                          {% if item|key:"severity" == "high" %}
-                            <span class="danger">high</span>
-                          {% elif item|key:"severity" == "info" %}
-                            <span class="info">info</span>
-                          {% elif item|key:"severity" == "warning" %}
-                            <span class="warning">warning</span>
-                          {% endif %}
-                         
-                        </td>
-                        <td>
-                        {{item|key:"description"}}
-                        </td>
-   
-                       </tr>
+                        {% if item|key:"severity" == "high" %}
+                          <span class="danger">high</span>
+                        {% elif item|key:"severity" == "info" %}
+                          <span class="info">info</span>
+                        {% elif item|key:"severity" == "warning" %}
+                          <span class="warning">warning</span>
+                        {% endif %}
+                       
+                      </td>
+                      <td>
+                      {{item|key:"description"}}
+                      </td>
+ 
+                     </tr>
                      {% endfor %}
-
+                     {% endif %}
 
 										</tbody>
 										</table>
-
+                    {% if manifest_analysis and 'manifest_summary' in manifest_analysis and manifest_analysis.manifest_summary|length > 0 %}
+                    <span class="danger">HIGH: </span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.high }}</h5> | 
+                    <span class="warning"></i> WARNING: </span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.warning }}</h5> |
+                    <span class="info">INFO: </span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.info }}</h5> |
+                    <span class="disabled">SUPPRESSED: </span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.suppressed }}</h5>
+                  {% endif %}
       <h2><i class="fas fa-code"></i> CODE ANALYSIS</h2>
        <table class="basic">
                 <thead>
@@ -520,7 +550,8 @@
                     </tr>
                 </thead>
                 <tbody>
-                   {% for rule, details in code_analysis.items %}
+                   {% if code_analysis and 'findings' in code_analysis %}
+                   {% for rule, details in code_analysis.findings.items %}
                   <tr>
                   <td>{{ forloop.counter }}</td>
                   <td width="25%">
@@ -568,8 +599,21 @@
                   </td>
                 </tr>    
               {% endfor %} 
-										</tbody>
-										</table>
+              {% endif %}
+          </tbody>
+          </table>
+          {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
+          <span class="danger">HIGH: </span>
+          <h5 class="description-header">{{ code_analysis.summary.high }}</h5> | 
+          <span class="warning"></i> WARNING: </span>
+          <h5 class="description-header">{{ code_analysis.summary.warning }}</h5> |
+          <span class="info">INFO: </span>
+          <h5 class="description-header">{{ code_analysis.summary.info }}</h5> |
+          <span class="success">SECURE: </span>
+          <h5 class="description-header">{{ code_analysis.summary.secure }}</h5> |
+          <span class="disabled">SUPPRESSED: </span>
+          <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
+        {% endif %}
             
      {% if binary_analysis  %}
       <h2><i class="fa fa-flag"></i> SHARED LIBRARY BINARY ANALYSIS</h2>

--- a/mobsf/templates/pdf/ios_report.html
+++ b/mobsf/templates/pdf/ios_report.html
@@ -182,7 +182,7 @@
       <h5>Min OS Version:</h5> {{ min_os_version }}</br>
       <h5>Supported Platforms:</h5> {% for pl in bundle_supported_platforms %} {{pl}}, {% endfor %}</br>
 
-     {% if binary_analysis %}
+     {% if binary_info %}
       <h2><i class="fas fa-ad"></i> BINARY INFORMATION </h2>
 
       <h5>Arch:</h5> {{ binary_info.arch }}</br>
@@ -270,8 +270,8 @@
                       </tr>
                   </thead>
                   <tbody>
-                    {% if ats_analysis|length > 0 %}
-                      {% for findings in ats_analysis %}
+                    {% if ats_analysis and 'ats_findings' in ats_analysis %}
+                      {% for findings in ats_analysis.ats_findings %}
                         <tr>
                           <td>{{ forloop.counter }}</td>
                           <td>
@@ -292,20 +292,19 @@
                           </td>
                         </tr>
                       {% endfor %}
-                    {% else %}
-                    <tr>
-                      <td>
-                        No ATS exceptions found.
-                      <td>
-                        <span class="success">secure</span>
-                      </td>
-                      <td>
-                        No insecure connections configured. App Transport Security (ATS) is enabled.
-                      </td>
-                    </tr>
                     {% endif %}
                   </tbody>
                     </table>
+                    {% if ats_analysis and 'ats_summary' in ats_analysis and ats_analysis.ats_summary|length > 0 %}
+                    <span class="danger">HIGH: </span>
+                    <h5 class="description-header">{{ ats_analysis.ats_summary.high }}</h5> | 
+                    <span class="warning"></i> WARNING: </span>
+                    <h5 class="description-header">{{ ats_analysis.ats_summary.warning }}</h5> |
+                    <span class="info">INFO: </span>
+                    <h5 class="description-header">{{ ats_analysis.ats_summary.info }}</h5> |
+                    <span class="success">SECURE: </span>
+                    <h5 class="description-header">{{ ats_analysis.ats_summary.secure }}</h5>
+                  {% endif %}
         {% endif %}
 
       
@@ -382,7 +381,8 @@
                       </tr>
                   </thead>
                      <tbody>
-                   {% for issue, details in binary_analysis.items %}
+                   {% if binary_analysis and 'findings' in binary_analysis %}
+                   {% for issue, details in binary_analysis.findings.items %}
                     <tr>
                       <td>{{ forloop.counter }}</td>
                       <td>
@@ -422,8 +422,21 @@
                       </td>
                     </tr>
                     {% endfor %}
+                    {% endif %}
                  </tbody>
                     </table>
+                {% if binary_analysis and 'summary' in binary_analysis and binary_analysis.summary|length > 0 %}
+                <span class="danger">HIGH: </span>
+                <h5 class="description-header">{{ binary_analysis.summary.high }}</h5> | 
+                <span class="warning"></i> WARNING: </span>
+                <h5 class="description-header">{{ binary_analysis.summary.warning }}</h5> |
+                <span class="info">INFO: </span>
+                <h5 class="description-header">{{ binary_analysis.summary.info }}</h5> |
+                <span class="success">SECURE: </span>
+                <h5 class="description-header">{{ binary_analysis.summary.secure }}</h5> |
+                <span class="disabled">SUPPRESSED: </span>
+                <h5 class="description-header">{{ binary_analysis.summary.suppressed }}</h5>
+              {% endif %}
         {% endif %}
         {% if macho_analysis  %}
       <h2><i class="fas fa-flag"></i> IPA BINARY ANALYSIS</h2>
@@ -505,7 +518,8 @@
                     </tr>
                 </thead>
                 <tbody>
-									 {% for rule, details in code_analysis.items %}
+                  {% if code_analysis and 'findings' in code_analysis %}
+									 {% for rule, details in code_analysis.findings.items %}
                   <tr>
                   <td>{{ forloop.counter }}</td>
                   <td width="25%">
@@ -551,9 +565,22 @@
                   {% endfor %}
                   </td>
                 </tr>    
-              {% endfor %} 
+              {% endfor %}
+              {% endif %}
 										</tbody>
 										</table>
+                    {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
+                    <span class="danger">HIGH: </span>
+                    <h5 class="description-header">{{ code_analysis.summary.high }}</h5> | 
+                    <span class="warning"></i> WARNING: </span>
+                    <h5 class="description-header">{{ code_analysis.summary.warning }}</h5> |
+                    <span class="info">INFO: </span>
+                    <h5 class="description-header">{{ code_analysis.summary.info }}</h5> |
+                    <span class="success">SECURE: </span>
+                    <h5 class="description-header">{{ code_analysis.summary.secure }}</h5> |
+                    <span class="disabled">SUPPRESSED: </span>
+                    <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
+                  {% endif %}
       {% endif %}
       {% if domains  %}
       <h2><i class="fab fa-searchengin"></i> DOMAIN MALWARE CHECK</h2>

--- a/mobsf/templates/pdf/ios_report.html
+++ b/mobsf/templates/pdf/ios_report.html
@@ -260,6 +260,16 @@
 
        {% if ats_analysis  %}
       <h2><i class="fas fa-lock"></i> APP TRANSPORT SECURITY (ATS)</h2>
+      {% if ats_analysis and 'ats_summary' in ats_analysis and ats_analysis.ats_summary|length > 0 %}
+      <span class="danger">HIGH: </span>
+      <h5 class="description-header">{{ ats_analysis.ats_summary.high }}</h5> | 
+      <span class="warning"></i> WARNING: </span>
+      <h5 class="description-header">{{ ats_analysis.ats_summary.warning }}</h5> |
+      <span class="info">INFO: </span>
+      <h5 class="description-header">{{ ats_analysis.ats_summary.info }}</h5> |
+      <span class="success">SECURE: </span>
+      <h5 class="description-header">{{ ats_analysis.ats_summary.secure }}</h5>
+    {% endif %}</br>
        <table class="basic">
                    <thead>
                       <tr>
@@ -295,16 +305,7 @@
                     {% endif %}
                   </tbody>
                     </table>
-                    {% if ats_analysis and 'ats_summary' in ats_analysis and ats_analysis.ats_summary|length > 0 %}
-                    <span class="danger">HIGH: </span>
-                    <h5 class="description-header">{{ ats_analysis.ats_summary.high }}</h5> | 
-                    <span class="warning"></i> WARNING: </span>
-                    <h5 class="description-header">{{ ats_analysis.ats_summary.warning }}</h5> |
-                    <span class="info">INFO: </span>
-                    <h5 class="description-header">{{ ats_analysis.ats_summary.info }}</h5> |
-                    <span class="success">SECURE: </span>
-                    <h5 class="description-header">{{ ats_analysis.ats_summary.secure }}</h5>
-                  {% endif %}
+                  
         {% endif %}
 
       
@@ -369,6 +370,18 @@
       
       {% if binary_analysis  %}
       <h2><i class="fas fa-code"></i> IPA BINARY CODE ANALYSIS</h2>
+      {% if binary_analysis and 'summary' in binary_analysis and binary_analysis.summary|length > 0 %}
+      <span class="danger">HIGH: </span>
+      <h5 class="description-header">{{ binary_analysis.summary.high }}</h5> | 
+      <span class="warning"></i> WARNING: </span>
+      <h5 class="description-header">{{ binary_analysis.summary.warning }}</h5> |
+      <span class="info">INFO: </span>
+      <h5 class="description-header">{{ binary_analysis.summary.info }}</h5> |
+      <span class="success">SECURE: </span>
+      <h5 class="description-header">{{ binary_analysis.summary.secure }}</h5> |
+      <span class="disabled">SUPPRESSED: </span>
+      <h5 class="description-header">{{ binary_analysis.summary.suppressed }}</h5>
+    {% endif %}</br>
        <table class="basic">
                   <thead>
                       <tr>
@@ -425,18 +438,7 @@
                     {% endif %}
                  </tbody>
                     </table>
-                {% if binary_analysis and 'summary' in binary_analysis and binary_analysis.summary|length > 0 %}
-                <span class="danger">HIGH: </span>
-                <h5 class="description-header">{{ binary_analysis.summary.high }}</h5> | 
-                <span class="warning"></i> WARNING: </span>
-                <h5 class="description-header">{{ binary_analysis.summary.warning }}</h5> |
-                <span class="info">INFO: </span>
-                <h5 class="description-header">{{ binary_analysis.summary.info }}</h5> |
-                <span class="success">SECURE: </span>
-                <h5 class="description-header">{{ binary_analysis.summary.secure }}</h5> |
-                <span class="disabled">SUPPRESSED: </span>
-                <h5 class="description-header">{{ binary_analysis.summary.suppressed }}</h5>
-              {% endif %}
+               
         {% endif %}
         {% if macho_analysis  %}
       <h2><i class="fas fa-flag"></i> IPA BINARY ANALYSIS</h2>
@@ -507,6 +509,18 @@
         {% endif %}
     {% if code_analysis  %}
       <h2><i class="fas fa-code"></i> CODE ANALYSIS</h2>
+      {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
+      <span class="danger">HIGH: </span>
+      <h5 class="description-header">{{ code_analysis.summary.high }}</h5> | 
+      <span class="warning"></i> WARNING: </span>
+      <h5 class="description-header">{{ code_analysis.summary.warning }}</h5> |
+      <span class="info">INFO: </span>
+      <h5 class="description-header">{{ code_analysis.summary.info }}</h5> |
+      <span class="success">SECURE: </span>
+      <h5 class="description-header">{{ code_analysis.summary.secure }}</h5> |
+      <span class="disabled">SUPPRESSED: </span>
+      <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
+    {% endif %}</br>
        <table class="basic">
                 <thead>
                     <tr>
@@ -567,20 +581,9 @@
                 </tr>    
               {% endfor %}
               {% endif %}
-										</tbody>
-										</table>
-                    {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
-                    <span class="danger">HIGH: </span>
-                    <h5 class="description-header">{{ code_analysis.summary.high }}</h5> | 
-                    <span class="warning"></i> WARNING: </span>
-                    <h5 class="description-header">{{ code_analysis.summary.warning }}</h5> |
-                    <span class="info">INFO: </span>
-                    <h5 class="description-header">{{ code_analysis.summary.info }}</h5> |
-                    <span class="success">SECURE: </span>
-                    <h5 class="description-header">{{ code_analysis.summary.secure }}</h5> |
-                    <span class="disabled">SUPPRESSED: </span>
-                    <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
-                  {% endif %}
+              </tbody>
+              </table>
+                   
       {% endif %}
       {% if domains  %}
       <h2><i class="fab fa-searchengin"></i> DOMAIN MALWARE CHECK</h2>

--- a/mobsf/templates/static_analysis/android_binary_analysis.html
+++ b/mobsf/templates/static_analysis/android_binary_analysis.html
@@ -879,6 +879,42 @@
              <strong><i class="fas fa-lock"></i> NETWORK SECURITY</strong>
              </p>
               <div class="table-responsive">
+                {% if network_security and 'network_summary' in network_security and network_security.network_summary|length > 0  %}
+                  <div class="row">
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-danger">HIGH</span>
+                    <h5 class="description-header">{{ network_security.network_summary.high }}</h5>
+                    </div>
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-warning"></i> WARNING</span>
+                    <h5 class="description-header">{{ network_security.network_summary.warning }}</h5>
+                    </div>
+                    
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-info">INFO</span>
+                    <h5 class="description-header">{{ network_security.network_summary.info }}</h5>
+                    </div>
+                    
+                    </div>
+
+                    <div class="col-sm-3 col-6">
+                      <div class="description-block">
+                      <span class="text-success">SECURE</span>
+                      <h5 class="description-header">{{ network_security.network_summary.secure }}</h5>
+                      </div>
+                      
+                      </div>
+                      
+                    
+                    </div>
+                    {% endif %}
                 <table id="table_network" class="table table-bordered table-hover table-striped">
                       <thead>
                       <tr>
@@ -917,42 +953,7 @@
                      {% endif %}
                     </tbody>
                   </table>
-                  {% if network_security and 'network_summary' in network_security and network_security.network_summary|length > 0  %}
-                  <div class="row">
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-danger">HIGH</span>
-                    <h5 class="description-header">{{ network_security.network_summary.high }}</h5>
-                    </div>
-                    </div>
-                    
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-warning"></i> WARNING</span>
-                    <h5 class="description-header">{{ network_security.network_summary.warning }}</h5>
-                    </div>
-                    
-                    </div>
-                    
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-info">INFO</span>
-                    <h5 class="description-header">{{ network_security.network_summary.info }}</h5>
-                    </div>
-                    
-                    </div>
-
-                    <div class="col-sm-3 col-6">
-                      <div class="description-block">
-                      <span class="text-success">SECURE</span>
-                      <h5 class="description-header">{{ network_security.network_summary.secure }}</h5>
-                      </div>
-                      
-                      </div>
-                      
-                    
-                    </div>
-                    {% endif %}
+                  
                     
                   </div>
           </div>
@@ -976,7 +977,33 @@
              <strong><i class="fa fa-id-card"></i> CERTIFICATE ANALYSIS</strong>
              </p>
               <div class="table-responsive">
-
+                {% if certificate_analysis and 'certificate_summary' in certificate_analysis and certificate_analysis.certificate_summary|length > 0  %}
+                <div class="row">
+                  <div class="col-sm-3 col-6">
+                  <div class="description-block border-right">
+                  <span class="text-danger">HIGH</span>
+                  <h5 class="description-header">{{ certificate_analysis.certificate_summary.high }}</h5>
+                  </div>
+                  </div>
+                  
+                  <div class="col-sm-3 col-6">
+                  <div class="description-block border-right">
+                  <span class="text-warning"></i> WARNING</span>
+                  <h5 class="description-header">{{ certificate_analysis.certificate_summary.warning }}</h5>
+                  </div>
+                  
+                  </div>
+                  
+                  <div class="col-sm-3 col-6">
+                  <div class="description-block">
+                  <span class="text-info">INFO</span>
+                  <h5 class="description-header">{{ certificate_analysis.certificate_summary.info }}</h5>
+                  </div>
+                  
+                  </div>
+                  
+                  </div>
+                  {% endif %}
                 <table id="table_cert" class="table table-bordered table-hover table-striped">
                   <thead>
                       <tr>
@@ -1007,33 +1034,7 @@
                     {% endif %}
                   </tbody>
               </table>
-              {% if certificate_analysis and 'certificate_summary' in certificate_analysis and certificate_analysis.certificate_summary|length > 0  %}
-              <div class="row">
-                <div class="col-sm-3 col-6">
-                <div class="description-block border-right">
-                <span class="text-danger">HIGH</span>
-                <h5 class="description-header">{{ certificate_analysis.certificate_summary.high }}</h5>
-                </div>
-                </div>
-                
-                <div class="col-sm-3 col-6">
-                <div class="description-block border-right">
-                <span class="text-warning"></i> WARNING</span>
-                <h5 class="description-header">{{ certificate_analysis.certificate_summary.warning }}</h5>
-                </div>
-                
-                </div>
-                
-                <div class="col-sm-3 col-6">
-                <div class="description-block">
-                <span class="text-info">INFO</span>
-                <h5 class="description-header">{{ certificate_analysis.certificate_summary.info }}</h5>
-                </div>
-                
-                </div>
-                
-                </div>
-                {% endif %}
+              
               </div>
           </div>
         </div><!-- /.card -->
@@ -1054,6 +1055,42 @@
              <strong><i class="fas fa-search"></i> MANIFEST ANALYSIS</strong>
              </p>
               <div class="table-responsive">
+                {% if manifest_analysis and 'manifest_summary' in manifest_analysis and manifest_analysis.manifest_summary|length > 0%}
+                  <div class="row">
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-danger">HIGH</span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.high }}</h5>
+                    </div>
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-warning"></i> WARNING</span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.warning }}</h5>
+                    </div>
+                    
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-info">INFO</span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.info }}</h5>
+                    </div>
+                    
+                    </div>
+
+                    <div class="col-sm-3 col-6">
+                      <div class="description-block">
+                      <span class="text-disabled">SUPPRESSED</span>
+                      <h5 class="description-header">{{ manifest_analysis.manifest_summary.suppressed }}</h5>
+                      </div>
+                      
+                      </div>
+                      
+                    
+                    </div>
+                    {% endif %}
                 <table id="table_manifest" class="table table-bordered table-hover table-striped">
                       <thead>
                       <tr>
@@ -1102,42 +1139,7 @@
                      {% endif %}
                     </tbody>
                   </table>
-                  {% if manifest_analysis and 'manifest_summary' in manifest_analysis and manifest_analysis.manifest_summary|length > 0%}
-                  <div class="row">
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-danger">HIGH</span>
-                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.high }}</h5>
-                    </div>
-                    </div>
-                    
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-warning"></i> WARNING</span>
-                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.warning }}</h5>
-                    </div>
-                    
-                    </div>
-                    
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-info">INFO</span>
-                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.info }}</h5>
-                    </div>
-                    
-                    </div>
-
-                    <div class="col-sm-3 col-6">
-                      <div class="description-block">
-                      <span class="text-disabled">SUPPRESSED</span>
-                      <h5 class="description-header">{{ manifest_analysis.manifest_summary.suppressed }}</h5>
-                      </div>
-                      
-                      </div>
-                      
-                    
-                    </div>
-                    {% endif %}
+                  
 
                   </div>
           </div>
@@ -1159,6 +1161,50 @@
              <strong><i class="fas fa-code"></i> CODE ANALYSIS</strong>
              </p>
               <div class="table-responsive">
+                {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0  %}
+            <div class="row">
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-danger">HIGH</span>
+              <h5 class="description-header">{{ code_analysis.summary.high }}</h5>
+              </div>
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-warning"></i> WARNING</span>
+              <h5 class="description-header">{{ code_analysis.summary.warning }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-info">INFO</span>
+              <h5 class="description-header">{{ code_analysis.summary.info }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+                <div class="description-block border-right">
+                <span class="text-success">SECURE</span>
+                <h5 class="description-header">{{ code_analysis.summary.secure }}</h5>
+                </div>
+                
+                </div>
+
+              <div class="col-sm-2 col-6">
+                <div class="description-block">
+                <span class="text-disabled">SUPPRESSED</span>
+                <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
+                </div>
+                
+                </div>
+                
+              
+              </div>
+              {% endif %}
                 <table id="table_code" class="table table-bordered table-hover table-striped">
                     <thead>
                     <tr>
@@ -1237,50 +1283,7 @@
               {% endif %}
               </tbody>
             </table>
-            {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0  %}
-            <div class="row">
-              <div class="col-sm-2 col-6">
-              <div class="description-block border-right">
-              <span class="text-danger">HIGH</span>
-              <h5 class="description-header">{{ code_analysis.summary.high }}</h5>
-              </div>
-              </div>
-              
-              <div class="col-sm-2 col-6">
-              <div class="description-block border-right">
-              <span class="text-warning"></i> WARNING</span>
-              <h5 class="description-header">{{ code_analysis.summary.warning }}</h5>
-              </div>
-              
-              </div>
-              
-              <div class="col-sm-2 col-6">
-              <div class="description-block border-right">
-              <span class="text-info">INFO</span>
-              <h5 class="description-header">{{ code_analysis.summary.info }}</h5>
-              </div>
-              
-              </div>
-              
-              <div class="col-sm-2 col-6">
-                <div class="description-block border-right">
-                <span class="text-success">SECURE</span>
-                <h5 class="description-header">{{ code_analysis.summary.secure }}</h5>
-                </div>
-                
-                </div>
-
-              <div class="col-sm-2 col-6">
-                <div class="description-block">
-                <span class="text-disabled">SUPPRESSED</span>
-                <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
-                </div>
-                
-                </div>
-                
-              
-              </div>
-              {% endif %}
+            
 
             </div>
           </div>

--- a/mobsf/templates/static_analysis/android_binary_analysis.html
+++ b/mobsf/templates/static_analysis/android_binary_analysis.html
@@ -889,7 +889,8 @@
                         </tr>
                     </thead>
                     <tbody>
-                    {% for item in network_security %}
+                    {% if network_security and 'network_findings' in network_security %}
+                    {% for item in network_security.network_findings %}
                       <tr>
                         <td>{{ forloop.counter }}</td>
                         <td>
@@ -913,8 +914,46 @@
                         </td>
                        </tr>
                      {% endfor %}
+                     {% endif %}
                     </tbody>
                   </table>
+                  {% if network_security and 'network_summary' in network_security and network_security.network_summary|length > 0  %}
+                  <div class="row">
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-danger">HIGH</span>
+                    <h5 class="description-header">{{ network_security.network_summary.high }}</h5>
+                    </div>
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-warning"></i> WARNING</span>
+                    <h5 class="description-header">{{ network_security.network_summary.warning }}</h5>
+                    </div>
+                    
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-info">INFO</span>
+                    <h5 class="description-header">{{ network_security.network_summary.info }}</h5>
+                    </div>
+                    
+                    </div>
+
+                    <div class="col-sm-3 col-6">
+                      <div class="description-block">
+                      <span class="text-success">SECURE</span>
+                      <h5 class="description-header">{{ network_security.network_summary.secure }}</h5>
+                      </div>
+                      
+                      </div>
+                      
+                    
+                    </div>
+                    {% endif %}
+                    
                   </div>
           </div>
         </div><!-- /.card -->
@@ -947,7 +986,7 @@
                       </tr>
                   </thead>
                   <tbody>
-                    {% if certificate_analysis %}
+                    {% if certificate_analysis and 'certificate_findings' in certificate_analysis %}
                       {% for find in certificate_analysis.certificate_findings %}
                       <tr>
                       <td>{{ find.2 }}</td>
@@ -968,6 +1007,33 @@
                     {% endif %}
                   </tbody>
               </table>
+              {% if certificate_analysis and 'certificate_summary' in certificate_analysis and certificate_analysis.certificate_summary|length > 0  %}
+              <div class="row">
+                <div class="col-sm-3 col-6">
+                <div class="description-block border-right">
+                <span class="text-danger">HIGH</span>
+                <h5 class="description-header">{{ certificate_analysis.certificate_summary.high }}</h5>
+                </div>
+                </div>
+                
+                <div class="col-sm-3 col-6">
+                <div class="description-block border-right">
+                <span class="text-warning"></i> WARNING</span>
+                <h5 class="description-header">{{ certificate_analysis.certificate_summary.warning }}</h5>
+                </div>
+                
+                </div>
+                
+                <div class="col-sm-3 col-6">
+                <div class="description-block">
+                <span class="text-info">INFO</span>
+                <h5 class="description-header">{{ certificate_analysis.certificate_summary.info }}</h5>
+                </div>
+                
+                </div>
+                
+                </div>
+                {% endif %}
               </div>
           </div>
         </div><!-- /.card -->
@@ -999,8 +1065,8 @@
                         </tr>
                     </thead>
                     <tbody>
-                                      
-                    {% for item in manifest_analysis %}
+                    {% if manifest_analysis and 'manifest_findings' in manifest_analysis %}
+                    {% for item in manifest_analysis.manifest_findings %}
                       <tr>
                         <td>{{ forloop.counter }}</td>
                         <td>
@@ -1033,8 +1099,46 @@
                         </td>
                        </tr>
                      {% endfor %}
+                     {% endif %}
                     </tbody>
                   </table>
+                  {% if manifest_analysis and 'manifest_summary' in manifest_analysis and manifest_analysis.manifest_summary|length > 0%}
+                  <div class="row">
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-danger">HIGH</span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.high }}</h5>
+                    </div>
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-warning"></i> WARNING</span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.warning }}</h5>
+                    </div>
+                    
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-info">INFO</span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.info }}</h5>
+                    </div>
+                    
+                    </div>
+
+                    <div class="col-sm-3 col-6">
+                      <div class="description-block">
+                      <span class="text-disabled">SUPPRESSED</span>
+                      <h5 class="description-header">{{ manifest_analysis.manifest_summary.suppressed }}</h5>
+                      </div>
+                      
+                      </div>
+                      
+                    
+                    </div>
+                    {% endif %}
+
                   </div>
           </div>
         </div><!-- /.card -->
@@ -1067,7 +1171,8 @@
                   </tr>
                     </thead>
                       <tbody>
-               {% for rule, details in code_analysis.items %}
+               {% if code_analysis and 'findings' in code_analysis %}
+               {% for rule, details in code_analysis.findings.items %}
                   <tr>
                   <td>{{ forloop.counter }}</td>
                   <td>
@@ -1128,9 +1233,55 @@
 
                   </td>
                 </tr>    
-              {% endfor %} 
+              {% endfor %}
+              {% endif %}
               </tbody>
             </table>
+            {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0  %}
+            <div class="row">
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-danger">HIGH</span>
+              <h5 class="description-header">{{ code_analysis.summary.high }}</h5>
+              </div>
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-warning"></i> WARNING</span>
+              <h5 class="description-header">{{ code_analysis.summary.warning }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-info">INFO</span>
+              <h5 class="description-header">{{ code_analysis.summary.info }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+                <div class="description-block border-right">
+                <span class="text-success">SECURE</span>
+                <h5 class="description-header">{{ code_analysis.summary.secure }}</h5>
+                </div>
+                
+                </div>
+
+              <div class="col-sm-2 col-6">
+                <div class="description-block">
+                <span class="text-disabled">SUPPRESSED</span>
+                <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
+                </div>
+                
+                </div>
+                
+              
+              </div>
+              {% endif %}
+
             </div>
           </div>
         </div><!-- /.card -->

--- a/mobsf/templates/static_analysis/android_source_analysis.html
+++ b/mobsf/templates/static_analysis/android_source_analysis.html
@@ -744,8 +744,8 @@
                         </tr>
                     </thead>
                     <tbody>
-                                      
-                    {% for item in network_security %}
+                    {% if network_security and 'network_findings' in network_security %}
+                    {% for item in network_security.network_findings %}
                       <tr>
                         <td>{{ forloop.counter }}</td>
                         <td>
@@ -770,8 +770,46 @@
    
                        </tr>
                      {% endfor %}
+                     {% endif %}
                     </tbody>
                   </table>
+                  {% if network_security and 'network_summary' in network_security and network_security.network_summary|length > 0%}
+                  <div class="row">
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-danger">HIGH</span>
+                    <h5 class="description-header">{{ network_security.network_summary.high }}</h5>
+                    </div>
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-warning"></i> WARNING</span>
+                    <h5 class="description-header">{{ network_security.network_summary.warning }}</h5>
+                    </div>
+                    
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-info">INFO</span>
+                    <h5 class="description-header">{{ network_security.network_summary.info }}</h5>
+                    </div>
+                    
+                    </div>
+
+                    <div class="col-sm-3 col-6">
+                      <div class="description-block">
+                      <span class="text-success">SECURE</span>
+                      <h5 class="description-header">{{ network_security.network_summary.secure }}</h5>
+                      </div>
+                      
+                      </div>
+                      
+                    
+                    </div>
+                    {% endif %}
+                    
                   </div>
           </div>
         </div><!-- /.card -->
@@ -803,8 +841,8 @@
                         </tr>
                     </thead>
                     <tbody>
-                                      
-                    {% for item in manifest_analysis %}
+                      {% if manifest_analysis and 'manifest_findings' in manifest_analysis %}
+                      {% for item in manifest_analysis.manifest_findings %}
                       <tr>
                         <td>{{ forloop.counter }}</td>
                         <td>
@@ -837,8 +875,46 @@
                         </td>
                        </tr>
                      {% endfor %}
+                     {% endif %}
                     </tbody>
                   </table>
+                  {% if manifest_analysis and 'manifest_summary' in manifest_analysis and manifest_analysis.manifest_summary|length > 0%}
+                  <div class="row">
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-danger">HIGH</span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.high }}</h5>
+                    </div>
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-warning"></i> WARNING</span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.warning }}</h5>
+                    </div>
+                    
+                    </div>
+                    
+                    <div class="col-sm-3 col-6">
+                    <div class="description-block border-right">
+                    <span class="text-info">INFO</span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.info }}</h5>
+                    </div>
+                    
+                    </div>
+
+                    <div class="col-sm-3 col-6">
+                      <div class="description-block">
+                      <span class="text-disabled">SUPPRESSED</span>
+                      <h5 class="description-header">{{ manifest_analysis.manifest_summary.suppressed }}</h5>
+                      </div>
+                      
+                      </div>
+                      
+                    
+                    </div>
+                    {% endif %}
+
                   </div>
           </div>
         </div><!-- /.card -->
@@ -871,7 +947,8 @@
                   </tr>
                     </thead>
                     <tbody>
-               {% for rule, details in code_analysis.items %}
+                  {% if code_analysis and 'findings' in code_analysis %}
+                  {% for rule, details in code_analysis.findings.items %}
                   <tr>
                   <td>{{ forloop.counter }}</td>
                   <td>
@@ -933,8 +1010,54 @@
                   </td>
                 </tr>    
               {% endfor %} 
+              {% endif %}
               </tbody>
             </table>
+            {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
+            <div class="row">
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-danger">HIGH</span>
+              <h5 class="description-header">{{ code_analysis.summary.high }}</h5>
+              </div>
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-warning"></i> WARNING</span>
+              <h5 class="description-header">{{ code_analysis.summary.warning }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-info">INFO</span>
+              <h5 class="description-header">{{ code_analysis.summary.info }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+                <div class="description-block border-right">
+                <span class="text-success">SECURE</span>
+                <h5 class="description-header">{{ code_analysis.summary.secure }}</h5>
+                </div>
+                
+                </div>
+
+              <div class="col-sm-2 col-6">
+                <div class="description-block">
+                <span class="text-disabled">SUPPRESSED</span>
+                <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
+                </div>
+                
+                </div>
+                
+              
+              </div>
+              {% endif %}
+
             </div>
           </div>
         </div><!-- /.card -->

--- a/mobsf/templates/static_analysis/android_source_analysis.html
+++ b/mobsf/templates/static_analysis/android_source_analysis.html
@@ -734,6 +734,42 @@
              <strong><i class="fas fa-lock"></i> NETWORK SECURITY</strong>
              </p>
               <div class="table-responsive">
+                {% if network_security and 'network_summary' in network_security and network_security.network_summary|length > 0%}
+                <div class="row">
+                  <div class="col-sm-3 col-6">
+                  <div class="description-block border-right">
+                  <span class="text-danger">HIGH</span>
+                  <h5 class="description-header">{{ network_security.network_summary.high }}</h5>
+                  </div>
+                  </div>
+                  
+                  <div class="col-sm-3 col-6">
+                  <div class="description-block border-right">
+                  <span class="text-warning"></i> WARNING</span>
+                  <h5 class="description-header">{{ network_security.network_summary.warning }}</h5>
+                  </div>
+                  
+                  </div>
+                  
+                  <div class="col-sm-3 col-6">
+                  <div class="description-block border-right">
+                  <span class="text-info">INFO</span>
+                  <h5 class="description-header">{{ network_security.network_summary.info }}</h5>
+                  </div>
+                  
+                  </div>
+
+                  <div class="col-sm-3 col-6">
+                    <div class="description-block">
+                    <span class="text-success">SECURE</span>
+                    <h5 class="description-header">{{ network_security.network_summary.secure }}</h5>
+                    </div>
+                    
+                    </div>
+                    
+                  
+                  </div>
+                  {% endif %}
                 <table id="table_network" class="table table-bordered table-hover table-striped">
                       <thead>
                       <tr>
@@ -773,42 +809,7 @@
                      {% endif %}
                     </tbody>
                   </table>
-                  {% if network_security and 'network_summary' in network_security and network_security.network_summary|length > 0%}
-                  <div class="row">
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-danger">HIGH</span>
-                    <h5 class="description-header">{{ network_security.network_summary.high }}</h5>
-                    </div>
-                    </div>
-                    
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-warning"></i> WARNING</span>
-                    <h5 class="description-header">{{ network_security.network_summary.warning }}</h5>
-                    </div>
-                    
-                    </div>
-                    
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-info">INFO</span>
-                    <h5 class="description-header">{{ network_security.network_summary.info }}</h5>
-                    </div>
-                    
-                    </div>
-
-                    <div class="col-sm-3 col-6">
-                      <div class="description-block">
-                      <span class="text-success">SECURE</span>
-                      <h5 class="description-header">{{ network_security.network_summary.secure }}</h5>
-                      </div>
-                      
-                      </div>
-                      
-                    
-                    </div>
-                    {% endif %}
+                 
                     
                   </div>
           </div>
@@ -830,6 +831,42 @@
              <strong><i class="fas fa-search"></i> MANIFEST ANALYSIS</strong>
              </p>
               <div class="table-responsive">
+                {% if manifest_analysis and 'manifest_summary' in manifest_analysis and manifest_analysis.manifest_summary|length > 0%}
+                <div class="row">
+                  <div class="col-sm-3 col-6">
+                  <div class="description-block border-right">
+                  <span class="text-danger">HIGH</span>
+                  <h5 class="description-header">{{ manifest_analysis.manifest_summary.high }}</h5>
+                  </div>
+                  </div>
+                  
+                  <div class="col-sm-3 col-6">
+                  <div class="description-block border-right">
+                  <span class="text-warning"></i> WARNING</span>
+                  <h5 class="description-header">{{ manifest_analysis.manifest_summary.warning }}</h5>
+                  </div>
+                  
+                  </div>
+                  
+                  <div class="col-sm-3 col-6">
+                  <div class="description-block border-right">
+                  <span class="text-info">INFO</span>
+                  <h5 class="description-header">{{ manifest_analysis.manifest_summary.info }}</h5>
+                  </div>
+                  
+                  </div>
+
+                  <div class="col-sm-3 col-6">
+                    <div class="description-block">
+                    <span class="text-disabled">SUPPRESSED</span>
+                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.suppressed }}</h5>
+                    </div>
+                    
+                    </div>
+                    
+                  
+                  </div>
+                  {% endif %}
                 <table id="table_manifest" class="table table-bordered table-hover table-striped">
                       <thead>
                       <tr>
@@ -878,42 +915,7 @@
                      {% endif %}
                     </tbody>
                   </table>
-                  {% if manifest_analysis and 'manifest_summary' in manifest_analysis and manifest_analysis.manifest_summary|length > 0%}
-                  <div class="row">
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-danger">HIGH</span>
-                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.high }}</h5>
-                    </div>
-                    </div>
-                    
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-warning"></i> WARNING</span>
-                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.warning }}</h5>
-                    </div>
-                    
-                    </div>
-                    
-                    <div class="col-sm-3 col-6">
-                    <div class="description-block border-right">
-                    <span class="text-info">INFO</span>
-                    <h5 class="description-header">{{ manifest_analysis.manifest_summary.info }}</h5>
-                    </div>
-                    
-                    </div>
-
-                    <div class="col-sm-3 col-6">
-                      <div class="description-block">
-                      <span class="text-disabled">SUPPRESSED</span>
-                      <h5 class="description-header">{{ manifest_analysis.manifest_summary.suppressed }}</h5>
-                      </div>
-                      
-                      </div>
-                      
-                    
-                    </div>
-                    {% endif %}
+                 
 
                   </div>
           </div>
@@ -935,6 +937,50 @@
              <strong><i class="fas fa-code"></i> CODE ANALYSIS</strong>
              </p>
               <div class="table-responsive">
+                {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
+            <div class="row">
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-danger">HIGH</span>
+              <h5 class="description-header">{{ code_analysis.summary.high }}</h5>
+              </div>
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-warning"></i> WARNING</span>
+              <h5 class="description-header">{{ code_analysis.summary.warning }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-info">INFO</span>
+              <h5 class="description-header">{{ code_analysis.summary.info }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+                <div class="description-block border-right">
+                <span class="text-success">SECURE</span>
+                <h5 class="description-header">{{ code_analysis.summary.secure }}</h5>
+                </div>
+                
+                </div>
+
+              <div class="col-sm-2 col-6">
+                <div class="description-block">
+                <span class="text-disabled">SUPPRESSED</span>
+                <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
+                </div>
+                
+                </div>
+                
+              
+              </div>
+              {% endif %}
                 <table id="table_code" class="table table-bordered table-hover table-striped">
                     <thead>
                     <tr>
@@ -1013,50 +1059,7 @@
               {% endif %}
               </tbody>
             </table>
-            {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
-            <div class="row">
-              <div class="col-sm-2 col-6">
-              <div class="description-block border-right">
-              <span class="text-danger">HIGH</span>
-              <h5 class="description-header">{{ code_analysis.summary.high }}</h5>
-              </div>
-              </div>
-              
-              <div class="col-sm-2 col-6">
-              <div class="description-block border-right">
-              <span class="text-warning"></i> WARNING</span>
-              <h5 class="description-header">{{ code_analysis.summary.warning }}</h5>
-              </div>
-              
-              </div>
-              
-              <div class="col-sm-2 col-6">
-              <div class="description-block border-right">
-              <span class="text-info">INFO</span>
-              <h5 class="description-header">{{ code_analysis.summary.info }}</h5>
-              </div>
-              
-              </div>
-              
-              <div class="col-sm-2 col-6">
-                <div class="description-block border-right">
-                <span class="text-success">SECURE</span>
-                <h5 class="description-header">{{ code_analysis.summary.secure }}</h5>
-                </div>
-                
-                </div>
-
-              <div class="col-sm-2 col-6">
-                <div class="description-block">
-                <span class="text-disabled">SUPPRESSED</span>
-                <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
-                </div>
-                
-                </div>
-                
-              
-              </div>
-              {% endif %}
+            
 
             </div>
           </div>

--- a/mobsf/templates/static_analysis/ios_binary_analysis.html
+++ b/mobsf/templates/static_analysis/ios_binary_analysis.html
@@ -550,6 +550,41 @@
              <strong><i class="fas fa-lock"></i> APP TRANSPORT SECURITY (ATS)</strong>
              </p>
               <div class="table-responsive">
+                {% if ats_analysis and 'ats_summary' in ats_analysis and ats_analysis.ats_summary|length > 0 %}
+                <div class="row">
+                  <div class="col-sm-2 col-6">
+                  <div class="description-block border-right">
+                  <span class="text-danger">HIGH</span>
+                  <h5 class="description-header">{{ ats_analysis.ats_summary.high }}</h5>
+                  </div>
+                  </div>
+                  
+                  <div class="col-sm-2 col-6">
+                  <div class="description-block border-right">
+                  <span class="text-warning"></i> WARNING</span>
+                  <h5 class="description-header">{{ ats_analysis.ats_summary.warning }}</h5>
+                  </div>
+                  
+                  </div>
+                  
+                  <div class="col-sm-2 col-6">
+                  <div class="description-block border-right">
+                  <span class="text-info">INFO</span>
+                  <h5 class="description-header">{{ ats_analysis.ats_summary.info }}</h5>
+                  </div>
+                  
+                  </div>
+                  
+                  <div class="col-sm-2 col-6">
+                    <div class="description-block">
+                    <span class="text-success">SECURE</span>
+                    <h5 class="description-header">{{ ats_analysis.ats_summary.secure }}</h5>
+                    </div>
+                    
+                    </div>
+      
+                  </div>
+                  {% endif %}
                <table class="table table-bordered table-hover table-striped">
 
                   <thead>
@@ -586,41 +621,7 @@
                     {% endif %}
                   </tbody>
               </table>
-              {% if ats_analysis and 'ats_summary' in ats_analysis and ats_analysis.ats_summary|length > 0 %}
-              <div class="row">
-                <div class="col-sm-2 col-6">
-                <div class="description-block border-right">
-                <span class="text-danger">HIGH</span>
-                <h5 class="description-header">{{ ats_analysis.ats_summary.high }}</h5>
-                </div>
-                </div>
-                
-                <div class="col-sm-2 col-6">
-                <div class="description-block border-right">
-                <span class="text-warning"></i> WARNING</span>
-                <h5 class="description-header">{{ ats_analysis.ats_summary.warning }}</h5>
-                </div>
-                
-                </div>
-                
-                <div class="col-sm-2 col-6">
-                <div class="description-block border-right">
-                <span class="text-info">INFO</span>
-                <h5 class="description-header">{{ ats_analysis.ats_summary.info }}</h5>
-                </div>
-                
-                </div>
-                
-                <div class="col-sm-2 col-6">
-                  <div class="description-block">
-                  <span class="text-success">SECURE</span>
-                  <h5 class="description-header">{{ ats_analysis.ats_summary.secure }}</h5>
-                  </div>
-                  
-                  </div>
-    
-                </div>
-                {% endif %}
+             
                 
                   </div>
           </div>
@@ -644,6 +645,50 @@
              <strong><i class="fa fa-code"></i> IPA BINARY CODE ANALYSIS</strong>
              </p>
               <div class="table-responsive">
+                {% if binary_analysis and 'summary' in binary_analysis and binary_analysis.summary|length > 0 %}
+            <div class="row">
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-danger">HIGH</span>
+              <h5 class="description-header">{{ binary_analysis.summary.high }}</h5>
+              </div>
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-warning"></i> WARNING</span>
+              <h5 class="description-header">{{ binary_analysis.summary.warning }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-info">INFO</span>
+              <h5 class="description-header">{{ binary_analysis.summary.info }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+                <div class="description-block border-right">
+                <span class="text-success">SECURE</span>
+                <h5 class="description-header">{{ binary_analysis.summary.secure }}</h5>
+                </div>
+                
+                </div>
+
+              <div class="col-sm-2 col-6">
+                <div class="description-block">
+                <span class="text-disabled">SUPPRESSED</span>
+                <h5 class="description-header">{{ binary_analysis.summary.suppressed }}</h5>
+                </div>
+                
+                </div>
+                
+              
+              </div>
+              {% endif %}
                <table id="table_code" class="table table-bordered table-hover table-striped">
                   <thead>
                       <tr>
@@ -713,50 +758,7 @@
                     {% endif %}
                  </tbody>
                     </table>
-            {% if binary_analysis and 'summary' in binary_analysis and binary_analysis.summary|length > 0 %}
-            <div class="row">
-              <div class="col-sm-2 col-6">
-              <div class="description-block border-right">
-              <span class="text-danger">HIGH</span>
-              <h5 class="description-header">{{ binary_analysis.summary.high }}</h5>
-              </div>
-              </div>
-              
-              <div class="col-sm-2 col-6">
-              <div class="description-block border-right">
-              <span class="text-warning"></i> WARNING</span>
-              <h5 class="description-header">{{ binary_analysis.summary.warning }}</h5>
-              </div>
-              
-              </div>
-              
-              <div class="col-sm-2 col-6">
-              <div class="description-block border-right">
-              <span class="text-info">INFO</span>
-              <h5 class="description-header">{{ binary_analysis.summary.info }}</h5>
-              </div>
-              
-              </div>
-              
-              <div class="col-sm-2 col-6">
-                <div class="description-block border-right">
-                <span class="text-success">SECURE</span>
-                <h5 class="description-header">{{ binary_analysis.summary.secure }}</h5>
-                </div>
-                
-                </div>
-
-              <div class="col-sm-2 col-6">
-                <div class="description-block">
-                <span class="text-disabled">SUPPRESSED</span>
-                <h5 class="description-header">{{ binary_analysis.summary.suppressed }}</h5>
-                </div>
-                
-                </div>
-                
-              
-              </div>
-              {% endif %}
+            
 
                   </div>
               

--- a/mobsf/templates/static_analysis/ios_binary_analysis.html
+++ b/mobsf/templates/static_analysis/ios_binary_analysis.html
@@ -561,8 +561,8 @@
                       </tr>
                   </thead>
                   <tbody>
-                    {% if ats_analysis|length > 0 %}
-                      {% for findings in ats_analysis %}
+                    {% if ats_analysis and 'ats_findings' in ats_analysis %}
+                      {% for findings in ats_analysis.ats_findings %}
                       <tr>
                         <td>{{ forloop.counter }}</td>
                         <td>
@@ -583,21 +583,45 @@
                         </td>
                       </tr>
                       {% endfor %}
-                    {% else %}
-                    <tr>
-                      <td></td>
-                      <td>
-                        No ATS exceptions found.
-                      <td>
-                        <span class="badge bg-success">secure</span>
-                      </td>
-                      <td>
-                        No insecure connections configured. App Transport Security (ATS) is enabled.
-                      </td>
-                    </tr>
                     {% endif %}
                   </tbody>
               </table>
+              {% if ats_analysis and 'ats_summary' in ats_analysis and ats_analysis.ats_summary|length > 0 %}
+              <div class="row">
+                <div class="col-sm-2 col-6">
+                <div class="description-block border-right">
+                <span class="text-danger">HIGH</span>
+                <h5 class="description-header">{{ ats_analysis.ats_summary.high }}</h5>
+                </div>
+                </div>
+                
+                <div class="col-sm-2 col-6">
+                <div class="description-block border-right">
+                <span class="text-warning"></i> WARNING</span>
+                <h5 class="description-header">{{ ats_analysis.ats_summary.warning }}</h5>
+                </div>
+                
+                </div>
+                
+                <div class="col-sm-2 col-6">
+                <div class="description-block border-right">
+                <span class="text-info">INFO</span>
+                <h5 class="description-header">{{ ats_analysis.ats_summary.info }}</h5>
+                </div>
+                
+                </div>
+                
+                <div class="col-sm-2 col-6">
+                  <div class="description-block">
+                  <span class="text-success">SECURE</span>
+                  <h5 class="description-header">{{ ats_analysis.ats_summary.secure }}</h5>
+                  </div>
+                  
+                  </div>
+    
+                </div>
+                {% endif %}
+                
                   </div>
           </div>
         </div><!-- /.card -->
@@ -632,7 +656,8 @@
                       </tr>
                   </thead>
                      <tbody>
-                    {% for issue, details in binary_analysis.items %}
+                    {% if binary_analysis and 'findings' in binary_analysis %}
+                    {% for issue, details in binary_analysis.findings.items %}
                     <tr>
                       <td>{{ forloop.counter }}</td>
                       <td>
@@ -685,8 +710,54 @@
                       </td>
                     </tr>
                     {% endfor %}
+                    {% endif %}
                  </tbody>
                     </table>
+            {% if binary_analysis and 'summary' in binary_analysis and binary_analysis.summary|length > 0 %}
+            <div class="row">
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-danger">HIGH</span>
+              <h5 class="description-header">{{ binary_analysis.summary.high }}</h5>
+              </div>
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-warning"></i> WARNING</span>
+              <h5 class="description-header">{{ binary_analysis.summary.warning }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-info">INFO</span>
+              <h5 class="description-header">{{ binary_analysis.summary.info }}</h5>
+              </div>
+              
+              </div>
+              
+              <div class="col-sm-2 col-6">
+                <div class="description-block border-right">
+                <span class="text-success">SECURE</span>
+                <h5 class="description-header">{{ binary_analysis.summary.secure }}</h5>
+                </div>
+                
+                </div>
+
+              <div class="col-sm-2 col-6">
+                <div class="description-block">
+                <span class="text-disabled">SUPPRESSED</span>
+                <h5 class="description-header">{{ binary_analysis.summary.suppressed }}</h5>
+                </div>
+                
+                </div>
+                
+              
+              </div>
+              {% endif %}
+
                   </div>
               
           </div>

--- a/mobsf/templates/static_analysis/ios_source_analysis.html
+++ b/mobsf/templates/static_analysis/ios_source_analysis.html
@@ -556,8 +556,8 @@
                       </tr>
                   </thead>
                   <tbody>
-                    {% if ats_analysis|length > 0 %}
-                      {% for findings in ats_analysis %}
+                    {% if ats_analysis and 'ats_findings' in ats_analysis %}
+                      {% for findings in ats_analysis.ats_findings %}
                       <tr>
                         <td>{{ forloop.counter }}</td>
                         <td>
@@ -578,21 +578,45 @@
                         </td>
                       </tr>
                       {% endfor %}
-                    {% else %}
-                    <tr>
-                      <td></td>
-                      <td>
-                        No ATS exceptions found.
-                      <td>
-                        <span class="badge bg-success">secure</span>
-                      </td>
-                      <td>
-                        No insecure connections configured. App Transport Security (ATS) is enabled.
-                      </td>
-                    </tr>
                     {% endif %}
                   </tbody>
               </table>
+              {% if ats_analysis and 'ats_summary' in ats_analysis and ats_analysis.ats_summary|length > 0 %}
+          <div class="row">
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-danger">HIGH</span>
+            <h5 class="description-header">{{ ats_analysis.ats_summary.high }}</h5>
+            </div>
+            </div>
+            
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-warning"></i> WARNING</span>
+            <h5 class="description-header">{{ ats_analysis.ats_summary.warning }}</h5>
+            </div>
+            
+            </div>
+            
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-info">INFO</span>
+            <h5 class="description-header">{{ ats_analysis.ats_summary.info }}</h5>
+            </div>
+            
+            </div>
+            
+            <div class="col-sm-2 col-6">
+              <div class="description-block">
+              <span class="text-success">SECURE</span>
+              <h5 class="description-header">{{ ats_analysis.ats_summary.secure }}</h5>
+              </div>
+              
+              </div>
+
+            </div>
+            {% endif %}
+            
                   </div>
           </div>
         </div><!-- /.card -->
@@ -628,7 +652,8 @@
                       </tr>
                   </thead>
                   <tbody>
-                    {% for rule, details in code_analysis.items %}
+                    {% if code_analysis and 'findings' in code_analysis %}
+                    {% for rule, details in code_analysis.findings.items %}
                   <tr>
                   <td>{{ forloop.counter }}</td>
                   <td>
@@ -688,9 +713,55 @@
 
                   </td>
                 </tr>    
-              {% endfor %} 
+              {% endfor %}
+              {% endif %}
            </tbody>
           </table>
+          {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
+          <div class="row">
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-danger">HIGH</span>
+            <h5 class="description-header">{{ code_analysis.summary.high }}</h5>
+            </div>
+            </div>
+            
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-warning"></i> WARNING</span>
+            <h5 class="description-header">{{ code_analysis.summary.warning }}</h5>
+            </div>
+            
+            </div>
+            
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-info">INFO</span>
+            <h5 class="description-header">{{ code_analysis.summary.info }}</h5>
+            </div>
+            
+            </div>
+            
+            <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-success">SECURE</span>
+              <h5 class="description-header">{{ code_analysis.summary.secure }}</h5>
+              </div>
+              
+              </div>
+
+            <div class="col-sm-2 col-6">
+              <div class="description-block">
+              <span class="text-disabled">SUPPRESSED</span>
+              <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
+              </div>
+              
+              </div>
+              
+            
+            </div>
+            {% endif %}
+            
             </div>
           </div>
         </div><!-- /.card -->

--- a/mobsf/templates/static_analysis/ios_source_analysis.html
+++ b/mobsf/templates/static_analysis/ios_source_analysis.html
@@ -545,6 +545,41 @@
              <strong><i class="fas fa-lock"></i> APP TRANSPORT SECURITY (ATS)</strong>
              </p>
               <div class="table-responsive">
+                {% if ats_analysis and 'ats_summary' in ats_analysis and ats_analysis.ats_summary|length > 0 %}
+          <div class="row">
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-danger">HIGH</span>
+            <h5 class="description-header">{{ ats_analysis.ats_summary.high }}</h5>
+            </div>
+            </div>
+            
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-warning"></i> WARNING</span>
+            <h5 class="description-header">{{ ats_analysis.ats_summary.warning }}</h5>
+            </div>
+            
+            </div>
+            
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-info">INFO</span>
+            <h5 class="description-header">{{ ats_analysis.ats_summary.info }}</h5>
+            </div>
+            
+            </div>
+            
+            <div class="col-sm-2 col-6">
+              <div class="description-block">
+              <span class="text-success">SECURE</span>
+              <h5 class="description-header">{{ ats_analysis.ats_summary.secure }}</h5>
+              </div>
+              
+              </div>
+
+            </div>
+            {% endif %}
                <table class="table table-bordered table-hover table-striped">
 
                   <thead>
@@ -581,41 +616,7 @@
                     {% endif %}
                   </tbody>
               </table>
-              {% if ats_analysis and 'ats_summary' in ats_analysis and ats_analysis.ats_summary|length > 0 %}
-          <div class="row">
-            <div class="col-sm-2 col-6">
-            <div class="description-block border-right">
-            <span class="text-danger">HIGH</span>
-            <h5 class="description-header">{{ ats_analysis.ats_summary.high }}</h5>
-            </div>
-            </div>
-            
-            <div class="col-sm-2 col-6">
-            <div class="description-block border-right">
-            <span class="text-warning"></i> WARNING</span>
-            <h5 class="description-header">{{ ats_analysis.ats_summary.warning }}</h5>
-            </div>
-            
-            </div>
-            
-            <div class="col-sm-2 col-6">
-            <div class="description-block border-right">
-            <span class="text-info">INFO</span>
-            <h5 class="description-header">{{ ats_analysis.ats_summary.info }}</h5>
-            </div>
-            
-            </div>
-            
-            <div class="col-sm-2 col-6">
-              <div class="description-block">
-              <span class="text-success">SECURE</span>
-              <h5 class="description-header">{{ ats_analysis.ats_summary.secure }}</h5>
-              </div>
               
-              </div>
-
-            </div>
-            {% endif %}
             
                   </div>
           </div>
@@ -639,6 +640,50 @@
              <strong><i class="fa fa-code"></i> CODE ANALYSIS</strong>
              </p>
               <div class="table-responsive">
+                {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
+          <div class="row">
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-danger">HIGH</span>
+            <h5 class="description-header">{{ code_analysis.summary.high }}</h5>
+            </div>
+            </div>
+            
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-warning"></i> WARNING</span>
+            <h5 class="description-header">{{ code_analysis.summary.warning }}</h5>
+            </div>
+            
+            </div>
+            
+            <div class="col-sm-2 col-6">
+            <div class="description-block border-right">
+            <span class="text-info">INFO</span>
+            <h5 class="description-header">{{ code_analysis.summary.info }}</h5>
+            </div>
+            
+            </div>
+            
+            <div class="col-sm-2 col-6">
+              <div class="description-block border-right">
+              <span class="text-success">SECURE</span>
+              <h5 class="description-header">{{ code_analysis.summary.secure }}</h5>
+              </div>
+              
+              </div>
+
+            <div class="col-sm-2 col-6">
+              <div class="description-block">
+              <span class="text-disabled">SUPPRESSED</span>
+              <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
+              </div>
+              
+              </div>
+              
+            
+            </div>
+            {% endif %}
                    <table id="table_code" class="table table-bordered table-hover table-striped">
                   <thead>
                       <tr>
@@ -717,50 +762,7 @@
               {% endif %}
            </tbody>
           </table>
-          {% if code_analysis and 'summary' in code_analysis and code_analysis.summary|length > 0 %}
-          <div class="row">
-            <div class="col-sm-2 col-6">
-            <div class="description-block border-right">
-            <span class="text-danger">HIGH</span>
-            <h5 class="description-header">{{ code_analysis.summary.high }}</h5>
-            </div>
-            </div>
-            
-            <div class="col-sm-2 col-6">
-            <div class="description-block border-right">
-            <span class="text-warning"></i> WARNING</span>
-            <h5 class="description-header">{{ code_analysis.summary.warning }}</h5>
-            </div>
-            
-            </div>
-            
-            <div class="col-sm-2 col-6">
-            <div class="description-block border-right">
-            <span class="text-info">INFO</span>
-            <h5 class="description-header">{{ code_analysis.summary.info }}</h5>
-            </div>
-            
-            </div>
-            
-            <div class="col-sm-2 col-6">
-              <div class="description-block border-right">
-              <span class="text-success">SECURE</span>
-              <h5 class="description-header">{{ code_analysis.summary.secure }}</h5>
-              </div>
-              
-              </div>
-
-            <div class="col-sm-2 col-6">
-              <div class="description-block">
-              <span class="text-disabled">SUPPRESSED</span>
-              <h5 class="description-header">{{ code_analysis.summary.suppressed }}</h5>
-              </div>
-              
-              </div>
-              
-            
-            </div>
-            {% endif %}
+          
             
             </div>
           </div>


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
This is a priority enterprise feature request. 

General information area about summary counts for all separate sections in static analysis. For example, after the analysis of the manifest file, showing how many high, how many low, how many information level findings are in a single table. Adding these tables to the PDF report (or any report format already supported within) for each section.

For Android
* Network Security, Certificate Analysis, Manifest Analysis, Code Analysis
For iOS
* App Transport Security, Code Analysis, Binary Code Analysis,
```

<img width="1078" alt="Screenshot 2023-04-10 at 2 22 18 PM" src="https://user-images.githubusercontent.com/4301109/231001541-1730222f-61ae-45f9-b4dc-2ec65c7d1951.png">
<img width="1104" alt="Screenshot 2023-04-10 at 2 23 26 PM" src="https://user-images.githubusercontent.com/4301109/231001738-30ae8163-735f-4518-b70d-bf1a4960d160.png">
<img width="1001" alt="Screenshot 2023-04-10 at 2 55 31 PM" src="https://user-images.githubusercontent.com/4301109/231006511-94bf7735-25dd-4550-ba7a-af0976069b11.png">

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=EFR02)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
