### PR TITLE
Dynamic Analysis from Docker Container using remote ADB debugging over TCP/IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ LABEL \
 # Environment vars
 ENV DEBIAN_FRONTEND="noninteractive" \
     ANALYZER_IDENTIFIER="" \
+    ADB_REMOTE_HOST="" \
     JDK_FILE="openjdk-16.0.1_linux-x64_bin.tar.gz" \
     JDK_FILE_ARM="openjdk-16.0.1_linux-aarch64_bin.tar.gz" \
     WKH_FILE="wkhtmltox_0.12.6-1.focal_amd64.deb" \

--- a/mobsf/DynamicAnalyzer/views/android/dynamic_analyzer.py
+++ b/mobsf/DynamicAnalyzer/views/android/dynamic_analyzer.py
@@ -69,7 +69,7 @@ def dynamic_analysis(request, api=False):
                    ' find android instance identifier.'
                    ' Please run an android instance and refresh'
                    ' this page. If this error persists,'
-                   ' set ANALYZER_IDENTIFIER in '
+                   ' set ANALYZER_IDENTIFIER or ADB_REMOTE_HOST in '
                    f'{get_config_loc()}')
             return print_n_send_error_response(request, msg, api)
         try:
@@ -137,7 +137,7 @@ def dynamic_analyzer(request, checksum, api=False):
                    ' find android instance identifier. '
                    'Please run an android instance and refresh'
                    ' this page. If this error persists,'
-                   ' set ANALYZER_IDENTIFIER in '
+                   ' set ANALYZER_IDENTIFIER or ADB_REMOTE_HOST in '
                    f'{get_config_loc()}')
             return print_n_send_error_response(request, msg, api)
 

--- a/mobsf/MobSF/settings.py
+++ b/mobsf/MobSF/settings.py
@@ -389,6 +389,7 @@ else:
 
     # =======ANDROID DYNAMIC ANALYSIS SETTINGS===========
     ANALYZER_IDENTIFIER = os.getenv('MOBSF_ANALYZER_IDENTIFIER', '')
+    ADB_REMOTE_HOST = os.getenv('ADB_REMOTE_HOST', '')
     FRIDA_TIMEOUT = int(os.getenv('MOBSF_FRIDA_TIMEOUT', '4'))
     ACTIVITY_TESTER_SLEEP = int(os.getenv('MOBSF_ACTIVITY_TESTER_SLEEP', '4'))
     # ==============================================

--- a/mobsf/MobSF/utils.py
+++ b/mobsf/MobSF/utils.py
@@ -327,6 +327,10 @@ def get_device():
         return os.getenv('ANALYZER_IDENTIFIER')
     if settings.ANALYZER_IDENTIFIER:
         return settings.ANALYZER_IDENTIFIER
+    if os.getenv('ADB_REMOTE_HOST'):
+        return os.getenv('ADB_REMOTE_HOST')
+    if settings.ADB_REMOTE_HOST:
+        return settings.ADB_REMOTE_HOST
     else:
         dev_id = ''
         out = subprocess.check_output([get_adb(), 'devices']).splitlines()
@@ -335,7 +339,8 @@ def get_device():
             return dev_id
     logger.error('Is the Android VM running?\n'
                  'MobSF cannot identify device id.\n'
-                 'Please set ''ANALYZER_IDENTIFIER in '
+                 'Please set ''ANALYZER_IDENTIFIER\n'
+                 ' or ADB_REMOTE_HOST in '
                  '%s', get_config_loc())
 
 


### PR DESCRIPTION
Dynamic Analysis is not supported from a docker container. This is because the environment in DynamicAnalyzer/views/android/environment.py is configured to only use serial device identifier (`adb -s <id>`). But it is also possible to allow ADB to debug over TCP/IP and thus communicate with an emulator instance and runs either on the host system or even also in a container. This is done by using (`adb -H <ip address>`).

For this, the following changes have been made:
* add a new environment variable `ADB_REMOTE_HOST` (analogous to `DEVICE_IDENTIFIER`)
* in environment.py check if this variable is set, and if this is the case:
* run adb commands over TCP/IP with a new command line: `adb -H ADB_REMOTE_HOST <commands>`

This new variable should be the IP Address of the host system. The host system should run an ADB daemon and an emulator instance.
Per default the ADB Daemon listens on localhost, therefore forwarding from the external network interface (eth0) to the loopback interface (lo0) should be configured.
This must be done for the following ports: 5037, 5554, 5555

If `ADB_REMOTE_HOST` environment variable is set (either in config.py or with `docker -r ADB_REMOTE_HOST`), by starting the dynamic analyzer, mobsf should automatically detect the running emulator instance and MobSFying and debugging should be possible.


Tested with Android Emulator and AVD Nexus_One_API_28 on Linux.