### PR TITLE
update apktool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ libsast>=1.5.1
 pdfkit>=0.6.1
 google-play-scraper>=0.1.2
 androguard==3.4.0a1
-apkid==2.1.4
+apkid==2.1.5
 quark-engine==23.5.1
 frida==15.2.2
 tldextract==3.4.4


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
Update apktool to 2.1.5

The following SDK got improvements, rules and fixes:

Packers:
AppSealing
BlackMod (modder)
5Play.ru (modder)
Aegis - AndroidRepublic (modder)
KangaPack
LIAPP
Protectors:
DexGuard v9.x (Aarch64)
DexProtector telemetry (Alice)
Verimatrix / InsideSecure
Protectt.ai
Google Play Integrity protection
Secucen AppIron
Ahope AppShield
AppCamo
EverSafe
VGuard
DxShield
Obfuscators:
LSPosed (seen in Momo, Shamiko and so on)
Android Republic VIP (modder)
```

### Checklist for PR

- [X] Run MobSF unit tests and lint `tox -e lint,test`
- [X] Tested Working on  Mac and Docker
- [X] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [X] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

