### PR TITLE
add apksigner.jar for reading signatures

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/jar_aar.py
+++ b/mobsf/StaticAnalyzer/views/android/jar_aar.py
@@ -100,8 +100,7 @@ def common_analysis(request, app_dic, rescan, api, analysis_type):
             )
             cert_dic = cert_info(
                 apk,
-                app_dic['app_path'],
-                app_dic['app_dir'],
+                app_dic,
                 man_data_dic)
         else:
             app_dic['manifest_file'] = None

--- a/mobsf/StaticAnalyzer/views/android/static_analyzer.py
+++ b/mobsf/StaticAnalyzer/views/android/static_analyzer.py
@@ -205,8 +205,7 @@ def static_analyzer(request, api=False):
                     elf_dict = library_analysis(app_dic['app_dir'], 'elf')
                     cert_dic = cert_info(
                         apk,
-                        app_dic['app_path'],
-                        app_dic['app_dir'],
+                        app_dic,
                         man_data_dic)
                     apkid_results = apkid_analysis(app_dic[
                         'app_dir'], app_dic['app_path'], app_dic['app_name'])

--- a/poetry.lock
+++ b/poetry.lock
@@ -1301,13 +1301,13 @@ pyasn1 = ">=0.4.6"
 
 [[package]]
 name = "libsast"
-version = "2.0.0"
+version = "2.0.1"
 description = "A generic SAST library built on top of semgrep and regex"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "libsast-2.0.0-py3-none-any.whl", hash = "sha256:424c94abadb9801dc5bb1c9afa8f189a8a4097e0b04b7a857e15da35de76c60b"},
-    {file = "libsast-2.0.0.tar.gz", hash = "sha256:476d43d5af63d99ea57c9ece2b5d8b7da113ece18c219a258fecc31b6fcc97bb"},
+    {file = "libsast-2.0.1-py3-none-any.whl", hash = "sha256:7111f9b1243f3c7e8ac202ad5de6b4f98c954dfd51340706d693970cc1f607d5"},
+    {file = "libsast-2.0.1.tar.gz", hash = "sha256:74459ff88efde95356026395934a671a7ca07357358998f51a4eea3abaa02c69"},
 ]
 
 [package.dependencies]
@@ -2959,13 +2959,13 @@ testing = ["coverage (>=5.0)", "pytest", "pytest-cover"]
 
 [[package]]
 name = "wcmatch"
-version = "8.4.1"
+version = "8.5"
 description = "Wildcard/glob file name matcher."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "wcmatch-8.4.1-py3-none-any.whl", hash = "sha256:3476cd107aba7b25ba1d59406938a47dc7eec6cfd0ad09ff77193f21a964dee7"},
-    {file = "wcmatch-8.4.1.tar.gz", hash = "sha256:b1f042a899ea4c458b7321da1b5e3331e3e0ec781583434de1301946ceadb943"},
+    {file = "wcmatch-8.5-py3-none-any.whl", hash = "sha256:14554e409b142edeefab901dc68ad570b30a72a8ab9a79106c5d5e9a6d241bd5"},
+    {file = "wcmatch-8.5.tar.gz", hash = "sha256:86c17572d0f75cbf3bcb1a18f3bf2f9e72b39a9c08c9b4a74e991e1882a8efb3"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1301,13 +1301,13 @@ pyasn1 = ">=0.4.6"
 
 [[package]]
 name = "libsast"
-version = "2.0.1"
+version = "2.0.2"
 description = "A generic SAST library built on top of semgrep and regex"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "libsast-2.0.1-py3-none-any.whl", hash = "sha256:7111f9b1243f3c7e8ac202ad5de6b4f98c954dfd51340706d693970cc1f607d5"},
-    {file = "libsast-2.0.1.tar.gz", hash = "sha256:74459ff88efde95356026395934a671a7ca07357358998f51a4eea3abaa02c69"},
+    {file = "libsast-2.0.2-py3-none-any.whl", hash = "sha256:f9c0a78cad457444af391be355419956abb7019f616437094153efb279ddf4c9"},
+    {file = "libsast-2.0.2.tar.gz", hash = "sha256:6465fb44ae0a27a48b398445117f5a785b41b923965a1a3c653e253e2ec29339"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

* Add `apksigner.jar`
* Use apksigner to extract signature versions (v1, v2, v3, v4)
* Fix: #2120

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=cert)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
