### PR TITLE
Update pyproject.toml to fix issue #2286

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ gunicorn = {version = ">=20.0.4", markers = "sys_platform != 'win32'"}
 psutil = ">=5.8.0"
 shelljob = ">=0.6.2"
 asn1crypto = ">=1.4.0"
-oscrypto = ">=1.2.1"
+oscrypto = "{ git = "https://github.com/wbond/oscrypto.git", rev = "1547f53" }"
 distro = ">=1.5.0"
 ip2location = "8.10.0"
 lief = ">=0.12.3"


### PR DESCRIPTION
### Describe the Pull Request

Fixed a bug in oscrypto where the regex would fail to recognize the right version of SSL due to insufficient check on multiple digits.  However the owner of the repo does not plan to make a new release soon due to time constraints.  See -> https://github.com/wbond/oscrypto/issues/78 

This can be fixed by using a specific version from git pointing to the right commit.  Hence this change in the pyproject.toml file.

### Checklist for PR

Tested on the Kali System mentioned in Issue #2286.
If this is not good enough for this change, I need to invest more time.
However this is an upstream fix in the lib itself and only changes the dependency to a specific commit.

### Additional Comments (if any)

https://github.com/MobSF/Mobile-Security-Framework-MobSF/issues/2286