### PR TITLE
Windows Python tempfile permission error fix

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/code_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/code_analysis.py
@@ -37,9 +37,10 @@ def get_perm_rules(perm_rules, android_permissions):
                 dynamic_rules.append(p)
         rules = yaml.dump(dynamic_rules)
         if rules:
-            tmp = tempfile.NamedTemporaryFile(mode='w')
+            tmp = tempfile.NamedTemporaryFile(mode='w', delete=False)
             tmp.write(rules)
             tmp.flush()
+            tmp.close()
             return tmp
     except Exception:
         logger.error('Getting Permission Rules')
@@ -98,7 +99,10 @@ def code_analysis(app_dir, typ, manifest_file, android_permissions):
                 [src],
                 {}))
             logger.info('Android Permission Mapping Completed')
-            rule_file.close()
+            try:
+                os.remove(rule_file.name)
+            except:
+                pass
         # NIAP Scan
         niap_findings = niap_scan(
             niap_rules.as_posix(),

--- a/mobsf/StaticAnalyzer/views/android/code_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/code_analysis.py
@@ -1,6 +1,7 @@
 # -*- coding: utf_8 -*-
 """Module holding the functions for code analysis."""
 
+import os
 import logging
 import tempfile
 from pathlib import Path
@@ -37,9 +38,10 @@ def get_perm_rules(perm_rules, android_permissions):
                 dynamic_rules.append(p)
         rules = yaml.dump(dynamic_rules)
         if rules:
-            tmp = tempfile.NamedTemporaryFile(mode='w', delete=False)
+            tmp = tempfile.NamedTemporaryFile(
+                mode='w',
+                delete=False)
             tmp.write(rules)
-            tmp.flush()
             tmp.close()
             return tmp
     except Exception:
@@ -99,10 +101,7 @@ def code_analysis(app_dir, typ, manifest_file, android_permissions):
                 [src],
                 {}))
             logger.info('Android Permission Mapping Completed')
-            try:
-                os.remove(rule_file.name)
-            except:
-                pass
+            os.unlink(rule_file.name)
         # NIAP Scan
         niap_findings = niap_scan(
             niap_rules.as_posix(),


### PR DESCRIPTION
Fix the issue of unclosed files in Windows system causing unauthorized access to read yaml files.

 return yaml.safe_load(file_obj.read_text('utf-8', 'ignore'))
  File "C:\Python3\lib\pathlib.py", line 1266, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "C:\Python3\lib\pathlib.py", line 1252, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "C:\Python3\lib\pathlib.py", line 1120, in _opener
    return self._accessor.open(self, flags, mode)
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\test\\AppData\\Local\\Temp\\tmpclbvrcwq'

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
DESCRIBE THE DETAILS OF PULL REQUEST HERE
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
