### PR TITLE
[SECURITY] Fix Arbitrary file writes on Windows

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/manifest_utils.py
+++ b/mobsf/StaticAnalyzer/views/android/manifest_utils.py
@@ -64,7 +64,7 @@ def get_manifest_apk(app_path, app_dir, tools_dir):
                 and is_file_exists(settings.APKTOOL_BINARY)):
             apktool_path = settings.APKTOOL_BINARY
         else:
-            apktool_path = os.path.join(tools_dir, 'apktool_2.9.2.jar')
+            apktool_path = os.path.join(tools_dir, 'apktool_2.9.3.jar')
         output_dir = os.path.join(app_dir, 'apktool_out')
         args = [find_java_binary(),
                 '-jar',


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
Arbitrary file writes on Windows with apktool fixed with this version
Discovered by [Cl0udG0d](https://github.com/Cl0udG0d?ref=connortumbleson.com) the previous path traversal fix was not hardened when running against Windows. It was learned that Windows will handle both path separators (/ and \) which v2.9.2 had previously isolated to the intended OS. Now cleansing of resource names will include both path separators no matter the OS.
```

### Checklist for PR

- [X] Run MobSF unit tests and lint `tox -e lint,test`
- [X] Tested Working on Linux, Mac, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [X] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

