### PR TITLE
MOBSF_CORELLIUM_API_DOMAIN Update

### DIFF
--- a/mobsf/DynamicAnalyzer/views/ios/corellium_apis.py
+++ b/mobsf/DynamicAnalyzer/views/ios/corellium_apis.py
@@ -18,10 +18,13 @@ from mobsf.MobSF.utils import (
 SUCCESS_RESP = (200, 204)
 ERROR_RESP = (400, 403, 404, 409)
 OK = 'ok'
+CORELLIUM_DEFAULT = 'https://app.corellium.com'
 CORELLIUM_API_DOMAIN = getattr(
     settings,
     'CORELLIUM_API_DOMAIN',
-    'https://app.corellium.com')
+    CORELLIUM_DEFAULT)
+if not CORELLIUM_API_DOMAIN:
+    CORELLIUM_API_DOMAIN = CORELLIUM_DEFAULT
 CORELLIUM_API_KEY = getattr(
     settings,
     'CORELLIUM_API_KEY', '')

--- a/mobsf/MobSF/settings.py
+++ b/mobsf/MobSF/settings.py
@@ -435,7 +435,7 @@ else:
     # if VT_UPLOAD is set to True.
     # ===============================================
     # =======IOS DYNAMIC ANALYSIS SETTINGS===========
-    CORELLIUM_API_DOMAIN = os.getenv('MOBSF_CORELLIUM_API_DOMAIN', 'https://app.corellium.com')
+    CORELLIUM_API_DOMAIN = os.getenv('MOBSF_CORELLIUM_API_DOMAIN', '')
     CORELLIUM_API_KEY = os.getenv('MOBSF_CORELLIUM_API_KEY', '')
     CORELLIUM_PROJECT_ID = os.getenv('MOBSF_CORELLIUM_PROJECT_ID', '')
     # CORELLIUM_PROJECT_ID is optional, MobSF will use any available project id

--- a/mobsf/MobSF/settings.py
+++ b/mobsf/MobSF/settings.py
@@ -435,7 +435,7 @@ else:
     # if VT_UPLOAD is set to True.
     # ===============================================
     # =======IOS DYNAMIC ANALYSIS SETTINGS===========
-    CORELLIUM_API_DOMAIN = os.getenv('MOBSF_CORELLIUM_API_DOMAIN', '')
+    CORELLIUM_API_DOMAIN = os.getenv('MOBSF_CORELLIUM_API_DOMAIN', 'https://app.corellium.com')
     CORELLIUM_API_KEY = os.getenv('MOBSF_CORELLIUM_API_KEY', '')
     CORELLIUM_PROJECT_ID = os.getenv('MOBSF_CORELLIUM_PROJECT_ID', '')
     # CORELLIUM_PROJECT_ID is optional, MobSF will use any available project id


### PR DESCRIPTION
### Describe the Pull Request

Set the default of `MOBSF_CORELLIUM_API_DOMAIN` to `https://app.corellium.com` in `settings.py` as it was not being picked up properly in `dynamic_analyzer.py` for iOS

### Checklist for PR

- [X] Run MobSF unit tests and lint `tox -e lint,test`
- [X] Tested Working on Linux, Mac, Windows, and Docker
- [X] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [X] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

Several users commented on this issue in Slack