### PR TITLE
Optimize rendering of big lists

### DIFF
--- a/mobsf/templates/base/list.html
+++ b/mobsf/templates/base/list.html
@@ -1,0 +1,7 @@
+<!-- "strings" on big binaries can easily result in millions of hits, avoid rendering them unless needed: -->
+<details {% if list|length < 100 %}open{% endif %}>
+  <summary>Show all {{ list | length }} {{ type }}</summary>
+  {% for val in list %}
+    {{ val }}<br/>
+  {% endfor %}
+</details>

--- a/mobsf/templates/base/list.html
+++ b/mobsf/templates/base/list.html
@@ -1,7 +1,9 @@
 <!-- "strings" on big binaries can easily result in millions of hits, avoid rendering them unless needed: -->
-<details {% if list|length < 100 %}open{% endif %}>
-  <summary>Show all {{ list | length }} {{ type }}</summary>
+{% if list|length != 0 %}
+<details {% if list|length < limit %}open{% endif %}>
+  <summary>{% if list|length < limit %}Showing{% else %}Show{% endif %} all <strong>{{ list | length }}</strong> {{ type }}</summary>
   {% for val in list %}
     {{ val }}<br/>
   {% endfor %}
 </details>
+{% endif %}

--- a/mobsf/templates/static_analysis/android_binary_analysis.html
+++ b/mobsf/templates/static_analysis/android_binary_analysis.html
@@ -2118,7 +2118,7 @@
               <strong><i class="fas fa-key"></i> POSSIBLE HARDCODED SECRETS</strong>
               </p>
                 <div class="list-group">
-                  {% include 'base/list.html' with list=secrets type="secrets" %}
+                  {% include 'base/list.html' with list=secrets type="secrets" limit=100 %}
                </div>
              </div>
            </div>
@@ -2141,26 +2141,24 @@
                <div class="list-group">
               {% if app_type not in 'so' %}
                   <p><strong>From APK Resource</strong></p>
-                  {% include 'base/list.html' with list=strings.strings_apk_res type="strings" %}
-                  <p><strong>From Code</strong></p>
-                  {% include 'base/list.html' with list=strings.strings_code type="strings" %}
+                  {% include 'base/list.html' with list=strings.strings_apk_res type="strings" limit=100 %}
+                  <p></p><p><strong>From Code</strong></p>
+                  {% include 'base/list.html' with list=strings.strings_code type="strings" limit=100 %}
               {% endif %}
+                    <p></p>
                     <p><strong>From Shared Objects</strong></p>
-                    {% include 'base/list.html' with list=strings.strings_so type="strings" %}
-                  <p>
                     {% for key, val in strings.items %}
                       {% if key == 'strings_so' %}
                         {% for ls in val %}
                           {% for k,v in ls.items %}
-                          <p></br><b><i>{{ k }}</i></b></p>
-                            {% for i in v %}
-                              {{ i }}<br/>
-                            {% endfor %}
+                          <p></br><strong><i>{{ k }}</i></strong></p>
+                          <div class="list-group">
+                            {% include 'base/list.html' with list=v type="strings" limit=5 %}
+                          </div>
                           {% endfor %}
                         {% endfor %}
                       {% endif %}
                     {% endfor %}                  
-                  </p>
               </div>
             </div>
           </div>
@@ -2182,7 +2180,7 @@
              <strong><i class="fa fa-th"></i> SYMBOLS</strong>
              </p>
                <div class="list-group">
-                {% include 'base/list.html' with list=file_analysis type="symbols" %}
+                {% include 'base/list.html' with list=file_analysis type="symbols" limit=50 %}
               </div>
             </div>
           </div>
@@ -2205,10 +2203,8 @@
              <strong><i class="fa fa-language"></i> ACTIVITIES</strong>
              </p>
                <div class="list-group">
-                  <p>  
-                    {% for act in activities %}
-                      {{ act}} <br/>
-                    {% endfor %}               
+                  <p>
+                    {% include 'base/list.html' with list=activities type="activities" limit=50 %}            
                   </p>
               </div>
             </div>
@@ -2230,10 +2226,8 @@
              <strong><i class="fa fa-cogs"></i> SERVICES</strong>
              </p>
                <div class="list-group">
-                  <p>  
-                     {% for srv in services %}
-                        {{ srv}} <br/>
-                    {% endfor %}                  
+                  <p>
+                    {% include 'base/list.html' with list=services type="services" limit=50 %}
                   </p>
               </div>
             </div>
@@ -2255,10 +2249,8 @@
              <strong><i class="fa fa-assistive-listening-systems"></i> RECEIVERS</strong>
              </p>
                <div class="list-group">
-                  <p>  
-                      {% for rcv in receivers %}
-                    {{ rcv}} <br/>
-                  {% endfor %}               
+                  <p>
+                    {% include 'base/list.html' with list=receivers type="receivers" limit=50 %}
                   </p>
               </div>
             </div>
@@ -2281,10 +2273,8 @@
              <strong><i class="fa fa-database"></i> PROVIDERS</strong>
              </p>
                <div class="list-group">
-                  <p>  
-                  {% for prv in providers %}
-                    {{ prv }} <br/>
-                  {% endfor %}                            
+                  <p>
+                    {% include 'base/list.html' with list=providers type="providers" limit=50 %}
                   </p>
               </div>
             </div>
@@ -2306,7 +2296,7 @@
             <strong><i class="fab fa-buffer"></i> LIBRARIES</strong>
             </p>
               <div class="list-group">
-                {% include 'base/list.html' with list=libraries type="libraries" %}
+                {% include 'base/list.html' with list=libraries type="libraries" limit=100 %}
             </div>
           </div>
         </div>
@@ -2327,7 +2317,7 @@
             <strong><i class="far fa-copy"></i> FILES</strong>
             </p>
               <div class="list-group">
-                {% include 'base/list.html' with list=files type="files" %}
+                {% include 'base/list.html' with list=files type="files" limit=200 %}
             </div>
           </div>
         </div>

--- a/mobsf/templates/static_analysis/android_binary_analysis.html
+++ b/mobsf/templates/static_analysis/android_binary_analysis.html
@@ -2118,11 +2118,7 @@
               <strong><i class="fas fa-key"></i> POSSIBLE HARDCODED SECRETS</strong>
               </p>
                 <div class="list-group">
-                   <p>  
-                     {% for val in secrets %}
-                      {{ val }}<br/>
-                     {% endfor %}                  
-                   </p>
+                  {% include 'base/list.html' with list=secrets type="secrets" %}
                </div>
              </div>
            </div>
@@ -2145,28 +2141,13 @@
                <div class="list-group">
               {% if app_type not in 'so' %}
                   <p><strong>From APK Resource</strong></p>
-                  <p>  
-                    {% for key, val in strings.items %}
-                      {% if key == 'strings_apk_res' %}
-                        {% for v in val %}
-                          {{ v }}<br/>
-                        {% endfor %}
-                      {% endif %}
-                    {% endfor %}                  
-                  </p>
-                   <p><strong>From Code</strong></p>
-                  <p>  
-                    {% for key, val in strings.items %}
-                      {% if key == 'strings_code' %}
-                        {% for v in val %}
-                          {{ v }}<br/>
-                        {% endfor %}
-                      {% endif %}
-                    {% endfor %}                  
-                  </p>
+                  {% include 'base/list.html' with list=strings.strings_apk_res type="strings" %}
+                  <p><strong>From Code</strong></p>
+                  {% include 'base/list.html' with list=strings.strings_code type="strings" %}
               {% endif %}
                     <p><strong>From Shared Objects</strong></p>
-                  <p>  
+                    {% include 'base/list.html' with list=strings.strings_so type="strings" %}
+                  <p>
                     {% for key, val in strings.items %}
                       {% if key == 'strings_so' %}
                         {% for ls in val %}
@@ -2201,11 +2182,7 @@
              <strong><i class="fa fa-th"></i> SYMBOLS</strong>
              </p>
                <div class="list-group">
-                  <p>  
-                     {% for val in file_analysis %}
-                       {{ val }}<br/>
-                     {% endfor %}
-                  </p>
+                {% include 'base/list.html' with list=file_analysis type="symbols" %}
               </div>
             </div>
           </div>
@@ -2329,11 +2306,7 @@
             <strong><i class="fab fa-buffer"></i> LIBRARIES</strong>
             </p>
               <div class="list-group">
-                <p>  
-                {% for lib in libraries %}
-                  {{ lib }} <br/>
-                {% endfor %}                                       
-                </p>
+                {% include 'base/list.html' with list=libraries type="libraries" %}
             </div>
           </div>
         </div>
@@ -2354,11 +2327,7 @@
             <strong><i class="far fa-copy"></i> FILES</strong>
             </p>
               <div class="list-group">
-                <p>  
-                {% for file in files %}
-                  {{ file}} <br/>
-                {% endfor %}                                      
-                </p>
+                {% include 'base/list.html' with list=files type="files" %}
             </div>
           </div>
         </div>

--- a/mobsf/templates/static_analysis/android_source_analysis.html
+++ b/mobsf/templates/static_analysis/android_source_analysis.html
@@ -1587,11 +1587,7 @@
                <strong><i class="fas fa-key"></i> POSSIBLE HARDCODED SECRETS</strong>
                </p>
                  <div class="list-group">
-                    <p>  
-                      {% for val in secrets %}
-                       {{ val }}<br/>
-                      {% endfor %}                  
-                    </p>
+                  {% include 'base/list.html' with list=secrets type="secrets" %}
                 </div>
               </div>
             </div>
@@ -1613,15 +1609,7 @@
                </p>
                  <div class="list-group">
                    <p><strong>From Code</strong></p>
-                  <p>  
-                    {% for key, val in strings.items %}
-                      {% if key == 'strings_code' %}
-                        {% for v in val %}
-                          {{ v }}<br/>
-                        {% endfor %}
-                      {% endif %}
-                    {% endfor %}                  
-                  </p>
+                   {% include 'base/list.html' with list=strings.strings_code type="strings" %}
                 </div>
               </div>
             </div>
@@ -1642,11 +1630,7 @@
              <strong><i class="fa fa-language"></i> ACTIVITIES</strong>
              </p>
                <div class="list-group">
-                  <p>  
-                    {% for act in activities %}
-                      {{ act}} <br/>
-                    {% endfor %}               
-                  </p>
+                  {% include 'base/list.html' with list=activities type="activities" %}
               </div>
             </div>
           </div>
@@ -1667,11 +1651,7 @@
              <strong><i class="fa fa-cogs"></i> SERVICES</strong>
              </p>
                <div class="list-group">
-                  <p>  
-                     {% for srv in services %}
-                        {{ srv}} <br/>
-                    {% endfor %}                  
-                  </p>
+                {% include 'base/list.html' with list=services type="services" %}
               </div>
             </div>
           </div>
@@ -1692,11 +1672,7 @@
              <strong><i class="fa fa-assistive-listening-systems"></i> RECEIVERS</strong>
              </p>
                <div class="list-group">
-                  <p>  
-                      {% for rcv in receivers %}
-                    {{ rcv}} <br/>
-                  {% endfor %}               
-                  </p>
+                 {% include 'base/list.html' with list=receivers type="receivers" %}
               </div>
             </div>
           </div>
@@ -1718,11 +1694,7 @@
              <strong><i class="fa fa-database"></i> PROVIDERS</strong>
              </p>
                <div class="list-group">
-                  <p>  
-                  {% for prv in providers %}
-                    {{ prv }} <br/>
-                  {% endfor %}                            
-                  </p>
+                 {% include 'base/list.html' with list=providers type="providers" %}
               </div>
             </div>
           </div>
@@ -1743,11 +1715,7 @@
             <strong><i class="fab fa-buffer"></i> LIBRARIES</strong>
             </p>
               <div class="list-group">
-                <p>  
-                {% for lib in libraries %}
-                  {{ lib }} <br/>
-                {% endfor %}                                       
-                </p>
+                {% include 'base/list.html' with list=libraries type="libraries" %}
             </div>
           </div>
         </div>
@@ -1768,11 +1736,7 @@
             <strong><i class="far fa-copy"></i> FILES</strong>
             </p>
               <div class="list-group">
-                <p>  
-                {% for file in files %}
-                  {{ file}} <br/>
-                {% endfor %}                                      
-                </p>
+                {% include 'base/list.html' with list=files type="files" %}
             </div>
           </div>
         </div>

--- a/mobsf/templates/static_analysis/android_source_analysis.html
+++ b/mobsf/templates/static_analysis/android_source_analysis.html
@@ -1587,7 +1587,7 @@
                <strong><i class="fas fa-key"></i> POSSIBLE HARDCODED SECRETS</strong>
                </p>
                  <div class="list-group">
-                  {% include 'base/list.html' with list=secrets type="secrets" %}
+                  {% include 'base/list.html' with list=secrets type="secrets" limit=100 %}
                 </div>
               </div>
             </div>
@@ -1609,7 +1609,7 @@
                </p>
                  <div class="list-group">
                    <p><strong>From Code</strong></p>
-                   {% include 'base/list.html' with list=strings.strings_code type="strings" %}
+                   {% include 'base/list.html' with list=strings.strings_code type="strings" limit=100 %}
                 </div>
               </div>
             </div>
@@ -1630,7 +1630,7 @@
              <strong><i class="fa fa-language"></i> ACTIVITIES</strong>
              </p>
                <div class="list-group">
-                  {% include 'base/list.html' with list=activities type="activities" %}
+                  {% include 'base/list.html' with list=activities type="activities" limit=50 %}
               </div>
             </div>
           </div>
@@ -1651,7 +1651,7 @@
              <strong><i class="fa fa-cogs"></i> SERVICES</strong>
              </p>
                <div class="list-group">
-                {% include 'base/list.html' with list=services type="services" %}
+                {% include 'base/list.html' with list=services type="services" limit=50 %}
               </div>
             </div>
           </div>
@@ -1672,7 +1672,7 @@
              <strong><i class="fa fa-assistive-listening-systems"></i> RECEIVERS</strong>
              </p>
                <div class="list-group">
-                 {% include 'base/list.html' with list=receivers type="receivers" %}
+                 {% include 'base/list.html' with list=receivers type="receivers" limit=50%}
               </div>
             </div>
           </div>
@@ -1694,7 +1694,7 @@
              <strong><i class="fa fa-database"></i> PROVIDERS</strong>
              </p>
                <div class="list-group">
-                 {% include 'base/list.html' with list=providers type="providers" %}
+                 {% include 'base/list.html' with list=providers type="providers" limit=50 %}
               </div>
             </div>
           </div>
@@ -1715,7 +1715,7 @@
             <strong><i class="fab fa-buffer"></i> LIBRARIES</strong>
             </p>
               <div class="list-group">
-                {% include 'base/list.html' with list=libraries type="libraries" %}
+                {% include 'base/list.html' with list=libraries type="libraries" limit=50 %}
             </div>
           </div>
         </div>
@@ -1736,7 +1736,7 @@
             <strong><i class="far fa-copy"></i> FILES</strong>
             </p>
               <div class="list-group">
-                {% include 'base/list.html' with list=files type="files" %}
+                {% include 'base/list.html' with list=files type="files" limit=200 %}
             </div>
           </div>
         </div>

--- a/mobsf/templates/static_analysis/ios_binary_analysis.html
+++ b/mobsf/templates/static_analysis/ios_binary_analysis.html
@@ -1572,11 +1572,7 @@
               <strong><i class="fas fa-key"></i> POSSIBLE HARDCODED SECRETS</strong>
               </p>
                 <div class="list-group">
-                   <p>  
-                      {% for val in secrets %}
-                        {{ val }}<br/>
-                      {% endfor %}
-                   </p>
+                  {% include 'base/list.html' with list=secrets type="secrets" %}
                </div>
              </div>
            </div>
@@ -1597,9 +1593,7 @@
              <strong><i class="fas fa-font"></i> STRINGS</strong>
              </p>
                <div class="list-group">
-                {% for string in strings %}
-                  {{string}} <br>
-                {% endfor %}
+                 {% include 'base/list.html' with list=strings type="strings" %}
               </div>
             </div>
           </div>
@@ -1621,11 +1615,7 @@
               <strong><i class="fa fa-th"></i> SYMBOLS</strong>
               </p>
                 <div class="list-group">
-                   <p>  
-                      {% for val in file_analysis %}
-                        {{ val }}<br/>
-                      {% endfor %}
-                   </p>
+                  {% include 'base/list.html' with list=file_analysis type="symbols" %}
                </div>
              </div>
            </div>
@@ -1648,12 +1638,7 @@
             <strong><i class="fab fa-buffer"></i> LIBRARIES</strong>
             </p>
               <div class="list-group">
-                <p>  
-                    {% for lib in libraries %}
-                      {{ lib }}
-                    <br/>
-                    {% endfor %}                             
-                </p>
+                {% include 'base/list.html' with list=libraries type="libraries" %}
             </div>
           </div>
         </div>
@@ -1674,11 +1659,7 @@
             <strong><i class="far fa-copy"></i> FILES</strong>
             </p>
               <div class="list-group">
-                <p>  
-                {% for file in files %}
-                  {{ file}} <br/>
-                {% endfor %}                               
-                </p>
+                {% include 'base/list.html' with list=files type="files" %}
             </div>
           </div>
         </div>

--- a/mobsf/templates/static_analysis/ios_binary_analysis.html
+++ b/mobsf/templates/static_analysis/ios_binary_analysis.html
@@ -1185,14 +1185,36 @@
                         {{ item.issue }}
                       </td>
                       <td>
-                        {% for file in item.files %}
+                    {% if item.files|length < 4 %}
+                       {% for file in item.files %}
+                        <small>
                           {% if file.type %}
                           <a href="{% url 'view_file_ios' %}?file={{file.file_path}}&amp;type={{file.type}}&amp;md5={{file.hash}}">{{ file.file_path }}</a>
                           {% else %}
                           {{ file.file_path }}
                           {% endif %}
-                          <br/>
+                        </small>
+                      </br>
+                      {% endfor %}
+                    {% else %}
+                      <a class="btn btn-primary btn-xs" data-toggle="collapse" href="#collapsefiles{{forloop.counter}}" role="button" aria-expanded="false" aria-controls="collapsefiles{{forloop.counter}}">
+                        Show Files
+                      </a>
+                      <div class="collapse" id="collapsefiles{{forloop.counter}}">
+                        {% for file in item.files %}
+                          <small>
+                            {% if file.type %}
+                            <a href="{% url 'view_file_ios' %}?file={{file.file_path}}&amp;type={{file.type}}&amp;md5={{file.hash}}">{{ file.file_path }}</a>
+                            {% else %}
+                            {{ file.file_path }}
+                            {% endif %}
+                          </small>
+                        </br>
                         {% endfor %}
+                      </div>
+                    {% endif %}
+
+
                       </td>
                   
                     </tr>
@@ -1572,7 +1594,7 @@
               <strong><i class="fas fa-key"></i> POSSIBLE HARDCODED SECRETS</strong>
               </p>
                 <div class="list-group">
-                  {% include 'base/list.html' with list=secrets type="secrets" %}
+                  {% include 'base/list.html' with list=secrets type="secrets" limit=100 %}
                </div>
              </div>
            </div>
@@ -1593,7 +1615,7 @@
              <strong><i class="fas fa-font"></i> STRINGS</strong>
              </p>
                <div class="list-group">
-                 {% include 'base/list.html' with list=strings type="strings" %}
+                 {% include 'base/list.html' with list=strings type="strings"  limit=100 %}
               </div>
             </div>
           </div>
@@ -1615,7 +1637,7 @@
               <strong><i class="fa fa-th"></i> SYMBOLS</strong>
               </p>
                 <div class="list-group">
-                  {% include 'base/list.html' with list=file_analysis type="symbols" %}
+                  {% include 'base/list.html' with list=file_analysis type="symbols"  limit=100 %}
                </div>
              </div>
            </div>
@@ -1638,7 +1660,7 @@
             <strong><i class="fab fa-buffer"></i> LIBRARIES</strong>
             </p>
               <div class="list-group">
-                {% include 'base/list.html' with list=libraries type="libraries" %}
+                {% include 'base/list.html' with list=libraries type="libraries"  limit=100 %}
             </div>
           </div>
         </div>
@@ -1659,7 +1681,7 @@
             <strong><i class="far fa-copy"></i> FILES</strong>
             </p>
               <div class="list-group">
-                {% include 'base/list.html' with list=files type="files" %}
+                {% include 'base/list.html' with list=files type="files" limit=200 %}
             </div>
           </div>
         </div>

--- a/mobsf/templates/static_analysis/ios_source_analysis.html
+++ b/mobsf/templates/static_analysis/ios_source_analysis.html
@@ -1190,7 +1190,7 @@
              <strong><i class="fas fa-font"></i> STRINGS</strong>
              </p>
                <div class="list-group">
-                 {% include 'base/list.html' with list=strings type="strings" %}
+                 {% include 'base/list.html' with list=strings type="strings"  limit=100 %}
               </div>
             </div>
           </div>
@@ -1211,7 +1211,7 @@
             <strong><i class="far fa-copy"></i> FILES</strong>
             </p>
               <div class="list-group">
-                {% include 'base/list.html' with list=files type="files" %}
+                {% include 'base/list.html' with list=files type="files"  limit=200 %}
             </div>
           </div>
         </div>

--- a/mobsf/templates/static_analysis/ios_source_analysis.html
+++ b/mobsf/templates/static_analysis/ios_source_analysis.html
@@ -1190,11 +1190,7 @@
              <strong><i class="fas fa-font"></i> STRINGS</strong>
              </p>
                <div class="list-group">
-                  <p>  
-                    {% for val in strings %}
-                     {{ val }}<br/>
-                    {% endfor %}                  
-                  </p>
+                 {% include 'base/list.html' with list=strings type="strings" %}
               </div>
             </div>
           </div>
@@ -1215,11 +1211,7 @@
             <strong><i class="far fa-copy"></i> FILES</strong>
             </p>
               <div class="list-group">
-                <p>  
-                {% for file in files %}
-                  {{ file}} <br/>
-                {% endfor %}                               
-                </p>
+                {% include 'base/list.html' with list=files type="files" %}
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

Most browsers doesn't like rendering thousands/millions of lines if not needed, so wrap (potentially) big lists in `<details>` and auto-open only if they are small (currently below 100 items)

This makes the "static report" page much more responsive for big apps:

![image](https://github.com/MobSF/Mobile-Security-Framework-MobSF/assets/147696419/bdda2e32-36ad-41ae-828d-b0315f10414e)

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, ~Mac, Windows, and Docker~ (this PR only adds cosmetic changes to HTML)
- [x] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`) (this PR only adds cosmetic changes to HTML, so no new tests)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)
