### PR TITLE
Resolve the situation where the function name is bytes

### DIFF
--- a/mobsf/StaticAnalyzer/views/common/binary/elf.py
+++ b/mobsf/StaticAnalyzer/views/common/binary/elf.py
@@ -290,7 +290,14 @@ class ELFChecksec:
     def fortify(self):
         fortified_funcs = []
         for function in self.elf.symbols:
-            if function.name.endswith('_chk'):
+            if isinstance(function.name, bytes):
+                try:
+                    function_name = function.name.decode('utf-8')
+                except UnicodeDecodeError:
+                    function_name = function.name.decode('utf-8', 'replace')
+            else:
+                function_name = function.name
+            if function_name.endswith('_chk'):
                 fortified_funcs.append(function.name)
         return fortified_funcs
 


### PR DESCRIPTION
  fix error:
 if function.name.endswith('_chk'):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: endswith first arg must be bytes or a tuple of bytes, not str

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
DESCRIBE THE DETAILS OF PULL REQUEST HERE
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
