### PR TITLE
Control USE_HOME with Env Var

### DIFF
--- a/mobsf/MobSF/settings.py
+++ b/mobsf/MobSF/settings.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 #       MOBSF CONFIGURATION
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 BANNER, VERSION, MOBSF_VER = get_mobsf_version()
-USE_HOME = True
+USE_HOME = os.getenv("MOBSF_USE_HOME", "1") == "1"
 # True : All Uploads/Downloads will be stored in user's home directory
 # False : All Uploads/Downloads will be stored under MobSF root directory
 


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

I needed to be able to dynamically change if "USE_HOME" is active so I setup an Env Var to do that

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)
