### PR TITLE
Add files list in scorecard desc

### DIFF
--- a/mobsf/StaticAnalyzer/views/common/appsec.py
+++ b/mobsf/StaticAnalyzer/views/common/appsec.py
@@ -38,6 +38,17 @@ def common_fields(findings, data):
             sev = cd['metadata']['severity']
         desc = cd['metadata']['description']
         ref = cd['metadata'].get('ref', '')
+
+        files_dict = cd.get('files', {})
+        files_lines = [f"{file}, line(s) {lines}"
+                       for file, lines in files_dict.items()]
+        formated_files_str = '\n'.join(files_lines)
+
+        if files_dict:
+            fdesc = f'{desc}\n{ref}\n\nFiles:\n{formated_files_str}'
+        else:
+            fdesc = f'{desc}\n{ref}'
+
         findings[sev].append({
             'title': cd['metadata']['description'],
             'description': f'{desc}\n{ref}',

--- a/mobsf/StaticAnalyzer/views/common/appsec.py
+++ b/mobsf/StaticAnalyzer/views/common/appsec.py
@@ -40,7 +40,7 @@ def common_fields(findings, data):
         ref = cd['metadata'].get('ref', '')
 
         files_dict = cd.get('files', {})
-        files_lines = [f"{file}, line(s) {lines}"
+        files_lines = [f'{file}, line(s) {lines}'
                        for file, lines in files_dict.items()]
         all_files_str = '\n'.join(files_lines)
 

--- a/mobsf/StaticAnalyzer/views/common/appsec.py
+++ b/mobsf/StaticAnalyzer/views/common/appsec.py
@@ -42,10 +42,10 @@ def common_fields(findings, data):
         files_dict = cd.get('files', {})
         files_lines = [f"{file}, line(s) {lines}"
                        for file, lines in files_dict.items()]
-        formated_files_str = '\n'.join(files_lines)
+        all_files_str = '\n'.join(files_lines)
 
         if files_dict:
-            fdesc = f'{desc}\n{ref}\n\nFiles:\n{formated_files_str}'
+            fdesc = f'{desc}\n{ref}\n\nFiles:\n{all_files_str}'
         else:
             fdesc = f'{desc}\n{ref}'
 

--- a/mobsf/StaticAnalyzer/views/common/appsec.py
+++ b/mobsf/StaticAnalyzer/views/common/appsec.py
@@ -51,7 +51,7 @@ def common_fields(findings, data):
 
         findings[sev].append({
             'title': cd['metadata']['description'],
-            'description': f'{desc}\n{ref}',
+            'description': fdesc,
             'section': 'code',
         })
     # Permissions


### PR DESCRIPTION
### Describe the Pull Request

Hi guys! Thanks for your work on mobile security!

I'm using appsec section in mobsf report as well structured source of vulns in defectdojo mobsf scorecard [parser](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/tools/mobsf_scorecard/parser.py). After import it looks same as Mobsf Scorecard View:

<img width="778" alt="image" src="https://github.com/user-attachments/assets/dbea085f-8062-4cf4-8a28-69a6ef267ce1">

And for such vulns like this ones:

<img width="966" alt="image" src="https://github.com/user-attachments/assets/c15c363d-7bc1-473b-9efd-47e06e0cf412">

<img width="847" alt="image" src="https://github.com/user-attachments/assets/fe85aab0-1aa5-480f-93ae-17c8fdc10d22">

it is usefull to save list of files with vuln hits as it provided in this render for certs:

<img width="724" alt="image" src="https://github.com/user-attachments/assets/527dfeb0-60a4-4153-827e-d354eddf2162">

So please consider to add rendered list of files to descriptions str for all findings in code analysis section of appsec report.