### PR TITLE
Save only unique intent priorities in findings

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/kb/android_manifest_desc.py
+++ b/mobsf/StaticAnalyzer/views/android/kb/android_manifest_desc.py
@@ -219,12 +219,12 @@ MANIFEST_DESC = {
         'name': 'Data SMS Receiver Set on Port: %s Found. [android:port]',
     },
     'high_intent_priority_found': {
-        'title': 'High Intent Priority (%s) {%s} hit(s)<br>[android:priority]',
+        'title': 'High Intent Priority (%s) - {%s} hit(s)<br>[android:priority]',
         'level': 'warning',
         'description': ('By setting an intent priority higher than another'
                         ' intent, the app effectively overrides '
                         'other requests.'),
-        'name': 'High Intent Priority (%s) {%s} hit(s) [android:priority]',
+        'name': 'High Intent Priority (%s) - {%s} hit(s) [android:priority]',
     },
     'high_action_priority_found': {
         'title': 'High Action Priority (%s)<br>[android:priority] ',

--- a/mobsf/StaticAnalyzer/views/android/kb/android_manifest_desc.py
+++ b/mobsf/StaticAnalyzer/views/android/kb/android_manifest_desc.py
@@ -219,12 +219,12 @@ MANIFEST_DESC = {
         'name': 'Data SMS Receiver Set on Port: %s Found. [android:port]',
     },
     'high_intent_priority_found': {
-        'title': 'High Intent Priority (%s) - {%s} hit(s)<br>[android:priority]',
+        'title': 'High Intent Priority (%s) - {%s} Hit(s)<br>[android:priority]',
         'level': 'warning',
         'description': ('By setting an intent priority higher than another'
                         ' intent, the app effectively overrides '
                         'other requests.'),
-        'name': 'High Intent Priority (%s) - {%s} hit(s) [android:priority]',
+        'name': 'High Intent Priority (%s) - {%s} Hit(s) [android:priority]',
     },
     'high_action_priority_found': {
         'title': 'High Action Priority (%s)<br>[android:priority] ',

--- a/mobsf/StaticAnalyzer/views/android/kb/android_manifest_desc.py
+++ b/mobsf/StaticAnalyzer/views/android/kb/android_manifest_desc.py
@@ -219,12 +219,12 @@ MANIFEST_DESC = {
         'name': 'Data SMS Receiver Set on Port: %s Found. [android:port]',
     },
     'high_intent_priority_found': {
-        'title': 'High Intent Priority (%s)<br>[android:priority]',
+        'title': 'High Intent Priority (%s) {%s} hit(s)<br>[android:priority]',
         'level': 'warning',
         'description': ('By setting an intent priority higher than another'
                         ' intent, the app effectively overrides '
                         'other requests.'),
-        'name': 'High Intent Priority (%s). [android:priority]',
+        'name': 'High Intent Priority (%s) {%s} hit(s) [android:priority]',
     },
     'high_action_priority_found': {
         'title': 'High Action Priority (%s)<br>[android:priority] ',

--- a/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
@@ -761,14 +761,18 @@ def manifest_analysis(app_dic, man_data_dic):
                 dataport = data.getAttribute(f'{ns}:port')
                 ret_list.append(('sms_receiver_port_found', (dataport,), ()))
         # INTENTS
+        processed_priorities = {}
         for intent in intents:
-            processed_priorities = []
             if intent.getAttribute(f'{ns}:priority').isdigit():
                 value = intent.getAttribute(f'{ns}:priority')
-                if int(value) > 100 and value not in processed_priorities:
-                    processed_priorities.append(value)
-                    ret_list.append(
-                        ('high_intent_priority_found', (value,), ()))
+                if int(value) > 100:
+                    if value not in processed_priorities:
+                        processed_priorities[value] = 1
+                    else:
+                        processed_priorities[value] += 1
+        for priority, count in processed_priorities.items():
+            ret_list.append(
+                ('high_intent_priority_found', (priority, count,), ()))
         # ACTIONS
         for action in actions:
             if action.getAttribute(f'{ns}:priority').isdigit():

--- a/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
@@ -762,9 +762,11 @@ def manifest_analysis(app_dic, man_data_dic):
                 ret_list.append(('sms_receiver_port_found', (dataport,), ()))
         # INTENTS
         for intent in intents:
+            processed_priorities = []
             if intent.getAttribute(f'{ns}:priority').isdigit():
                 value = intent.getAttribute(f'{ns}:priority')
-                if int(value) > 100:
+                if int(value) > 100 and value not in processed_priorities:
+                    processed_priorities.append(value)
                     ret_list.append(
                         ('high_intent_priority_found', (value,), ()))
         # ACTIONS


### PR DESCRIPTION
### Describe the Pull Request

Hi again! Another small fix, now manifest parser for android does not store and additional info about intents with high priorities (no intent names or filter schemas), but show all hits in reports:

<img width="1187" alt="image" src="https://github.com/user-attachments/assets/25d7621f-c1ab-429d-86d7-e44bc6a6a3eb">

<img width="368" alt="image" src="https://github.com/user-attachments/assets/c516a35b-dd5f-4c95-9cc0-edaf2129a13d">

So just added grouped high_intent_priority_found by priorities and add count of hits in title:

<img width="770" alt="image" src="https://github.com/user-attachments/assets/6f95afd7-c9a1-4eea-bf94-0ea33accf7f3">

