### PR TITLE
Fixing bug executing setup.sh script in python venv

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -17,12 +17,17 @@ if [[ "$py_major" -ne 3 || "$py_minor" -lt 10 || "$py_minor" -gt 12 ]]; then
 fi
 echo "[INSTALL] Found Python ${python_version}"
 
-# Check and upgrade pip
-if python3 -m pip -V &>/dev/null; then
+# Pip Check and Upgrade
+python3 -m pip -V
+if [ $? -eq 0 ]; then
     echo '[INSTALL] Found pip'
-    upgrade_cmd="python3 -m pip install --no-cache-dir --upgrade pip"
-    [[ "$(uname)" != "Darwin" ]] && upgrade_cmd+=" --user"
-    eval $upgrade_cmd
+    # check if python is running in venv. The location for venv should be differ from /usr/lib/python3.xx
+    pip_location=`python3 -m pip -V`
+    if [[ $unamestr == 'Darwin' || "$pip_location" != "/usr/lib/python"* ]]; then
+        python3 -m pip install --no-cache-dir --upgrade pip
+    else
+        python3 -m pip install --no-cache-dir --upgrade pip --user
+    fi
 else
     echo '[ERROR] python3-pip not installed'
     exit 1


### PR DESCRIPTION
Fixing issue when running setup.sh in venv


steps to reproduce
-------------------------------
1) go to the MobSF folder
2) execute command "python -m venv venv"
3) execute command "source ./venv/bin/activate"
4) run setup.sh

console output:
.......
[notice] To update, run: pip install --upgrade pip ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv. [INSTALL] Installing Requirements
........


Solution:
---------------
after adding a check for pip location not in /usr/lib/python the script works without any errors

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
DESCRIBE THE DETAILS OF PULL REQUEST HERE
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
