### PR TITLE
Fix for missing 'packaging.metadata module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ python3-saml = "^1.16.0"
 bcrypt = "4.0.1" # Remove this in mitmproxy 12
 psycopg2-binary = "^2.9.10"
 lief = "^0.15.1"
-packaging = ">=21.3"
+packaging = ">=24.2"
 django-ratelimit = "^4.1.0"
 django-q2 = "^1.7.4"
 defusedxml = "^0.7.1"


### PR DESCRIPTION
Changed the packaging version to 24.2

========MobSF Clean Script for Unix=========
Running this script will delete the Scan database, all files uploaded and generated.

Deleting all uploads
Deleting all downloads
Deleting Static Analyzer migrations
Deleting Dynamic Analyzer migrations
Deleting MobSF migrations
Deleting Python byte code files
Deleting temp and log files
Deleting Scan database
Deleting Secret file
Deleting MobSF data directory: /home/coreb1t/.MobSF Done
[INSTALL] Migrating Database

No module named 'packaging.metadata'

No module named 'packaging.metadata'

No module named 'packaging.metadata'

No module named 'packaging.metadata'

No module named 'packaging.metadata'

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
DESCRIBE THE DETAILS OF PULL REQUEST HERE
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
Fix for missing 'packaging.metadata module. Updated to version 24.2
```
