### PR TITLE
Fix false positives caused in Android manifest analysis

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
+++ b/mobsf/StaticAnalyzer/views/android/manifest_analysis.py
@@ -86,9 +86,11 @@ def is_tls_redirect(url_from: str, url_to: str):
     """Check if redirect is a simple TLS (i.e. safe) upgrade."""
     if not url_from.startswith("http://") or not url_to.startswith("https://"):
         return False
-    
+
     if url_from[7:] == url_to[8:]:
         return True
+    else:
+        return False
 
 
 def _check_url(host, w_url):
@@ -107,13 +109,15 @@ def _check_url(host, w_url):
         status_code = r.status_code
         if status_code in (301, 302):
             redirect_url = r.headers.get('Location')
-            
+
             # recurse (redirect) only if redirect URL is a simple TLS upgrade
             if redirect_url and is_tls_redirect(w_url, redirect_url):
-                logger.info(f'{status_code} Redirect detected (TLS upgrade) || From: {w_url} || To: {redirect_url}')
+                logger.info(
+                    f'{status_code} Redirect detected (TLS upgrade) || From: {w_url} || To: {redirect_url}')
                 return _check_url(host, redirect_url)
             else:
-                logger.warning(f'{status_code} Redirect detected || From: {w_url} || To: {redirect_url}')
+                logger.warning(
+                    f'{status_code} Redirect detected || From: {w_url} || To: {redirect_url}')
                 status = False
         if (str(status_code).startswith('2') and iden in str(r.json())):
             status = True


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

Problem:
- Recurring false positives coming from the Android manifest analysis module.
- FPs occur when well-known URLs like `assetlinks.json` redirect from http->https. In these instances, high-severity findings would appear in the Manifest Analysis section suggesting that the URLs were configured incorrectly, when in fact the 301 redirect is a valid configuration.
- Ordinarily this would be resolved by setting `allow_redirects` to `True` in the `requests.get`, but this was removed in (f22c584aa7d43527970c9da61eb678953cfc0a8e) specifically to mitigate https://github.com/MobSF/Mobile-Security-Framework-MobSF/security/advisories/GHSA-m435-9v6r-v5f6.
- This PR aims to reduce a specific, common false positive while maintaining protections against SSRF.

Solution:
- Check redirects to see if they're simple TLS upgrades; if so, perform a manual redirect to the TLS version.


### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Mac, Windows, and Docker
- [x] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [x] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)


