### PR TITLE
add MOBSF_ASYNC_ALL_IN_ONE

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -9,5 +9,14 @@ python3 manage.py createsuperuser --noinput --email ""
 set -e
 python3 manage.py create_roles
 
-exec gunicorn -b 0.0.0.0:8000 "mobsf.MobSF.wsgi:application" --workers=1 --threads=10 --timeout=3600 \
-    --worker-tmp-dir=/dev/shm --log-level=citical --log-file=- --access-logfile=- --error-logfile=- --capture-output
+if [[ -n "${MOBSF_ASYNC_ALL_IN_ONE}" ]] && [[ "${MOBSF_ASYNC_ALL_IN_ONE}" -eq "1" ]] ; then
+  # execute MobSF frontend and async worker queue in parallel
+  commands=(
+    'gunicorn -b 0.0.0.0:8000 "mobsf.MobSF.wsgi:application" --workers=1 --threads=10 --timeout=3600  --worker-tmp-dir=/dev/shm --log-level=citical --log-file=- --access-logfile=- --error-logfile=- --capture-output'
+    'python3 manage.py qcluster'
+  )
+  exec /usr/bin/printf "%s\0" "${commands[@]}" | /usr/bin/xargs -0 -I {} -P "${#commands[@]}" /usr/bin/sh -c "{}"
+else
+  exec gunicorn -b 0.0.0.0:8000 "mobsf.MobSF.wsgi:application" --workers=1 --threads=10 --timeout=3600 \
+      --worker-tmp-dir=/dev/shm --log-level=citical --log-file=- --access-logfile=- --error-logfile=- --capture-output
+fi


### PR DESCRIPTION
<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

I introduced the environment variable `MOBSF_ASYNC_ALL_IN_ONE` to `scripts/entrypoint.sh` which starts the MobSF web interface in parallel to the asynchronous scan queue. This drastically simplifies smaller setups which use async scanning to prevent out-of-memory kills due to a large number of parallel scans.

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

I also created https://github.com/MobSF/docs/pull/33 to reflect this change in the documentation.