### PR TITLE
Correct CVSS calculation by accessing findings key properly

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/apk.py
+++ b/mobsf/StaticAnalyzer/views/android/apk.py
@@ -248,7 +248,7 @@ def apk_analysis_task(checksum, app_dic, rescan, queue=False):
 def generate_dynamic_context(request, app_dic, checksum, context, api):
     """Generate Dynamic Context."""
     context['appsec'] = get_android_dashboard(context, True)
-    context['average_cvss'] = get_avg_cvss(context['code_analysis'])
+    context['average_cvss'] = get_avg_cvss(context['code_analysis']['findings'])
     logcat_file = Path(app_dic['app_dir']) / 'logcat.txt'
     context['dynamic_analysis_done'] = logcat_file.exists()
     context['virus_total'] = None
@@ -365,7 +365,7 @@ def src_analysis_task(checksum, app_dic, rescan, pro_type, queue=False):
 def generate_dynamic_src_context(request, context, api):
     """Generate Dynamic Source Context."""
     context['appsec'] = get_android_dashboard(context, True)
-    context['average_cvss'] = get_avg_cvss(context['code_analysis'])
+    context['average_cvss'] = get_avg_cvss(context['code_analysis']['findings'])
     template = 'static_analysis/android_source_analysis.html'
     return context if api else render(request, template, context)
 


### PR DESCRIPTION
Fixed an issue where the average CVSS score calculation was incorrect due to improper access to the findings key within the JSON structure. The calculation logic was bypassing the findings key and therefore failing to extract valid CVSS scores.

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request

```
This PR fixes a bug where the average CVSS score calculation would always return 0  due to improper JSON traversal.
```

### Checklist for PR

- [ ] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

```
DESCRIBE HERE
```
