### PR TITLE
Bug 2491: feat: Update URL extraction to preserve case sensitivity

### DIFF
--- a/mobsf/DynamicAnalyzer/views/common/shared.py
+++ b/mobsf/DynamicAnalyzer/views/common/shared.py
@@ -27,17 +27,18 @@ logger = logging.getLogger(__name__)
 def extract_urls_domains_emails(checksum, data):
     """Extract URLs, Domains and Emails."""
     # URL Extraction
-    urls = re.findall(URL_REGEX, data.lower())
+    urls = re.findall(URL_REGEX, data)
     if urls:
         urls = list(set(urls))
     else:
         urls = []
     # Domain Extraction and Malware Check
     logger.info('Performing Malware check on extracted domains')
+    # For domain extraction, use lowercased URLs
     domains = MalwareDomainCheck().scan(
         checksum,
-        urls)
-    # Email Etraction Regex
+        [u.lower() for u in urls if isinstance(u, str)])
+    # Email Extraction Regex
     emails = set()
     for email in EMAIL_REGEX.findall(data.lower()):
         if email.startswith('//'):

--- a/mobsf/MobSF/utils.py
+++ b/mobsf/MobSF/utils.py
@@ -55,7 +55,7 @@ URL_REGEX = re.compile(
         r'file://|javascript:|data:|www\d{0,3}[.])'
         r'[\w().=/;,#:@?&~*+!$%\'{}-]+)'
     ),
-    re.UNICODE)
+    re.UNICODE | re.IGNORECASE)
 EMAIL_REGEX = re.compile(r'[\w+.-]{1,20}@[\w-]{1,20}\.[\w]{2,10}')
 USERNAME_REGEX = re.compile(r'^\w[\w\-\@\.]{1,35}$')
 GOOGLE_API_KEY_REGEX = re.compile(r'AIza[0-9A-Za-z-_]{35}$')

--- a/mobsf/StaticAnalyzer/views/common/shared_func.py
+++ b/mobsf/StaticAnalyzer/views/common/shared_func.py
@@ -358,7 +358,7 @@ def url_n_email_extract(dat, relative_path):
     url_n_file = []
     email_n_file = []
     # URL Extraction
-    urllist = URL_REGEX.findall(dat.lower())
+    urllist = URL_REGEX.findall(dat)
     for url in urllist:
         urls.add(url)
     if urls:


### PR DESCRIPTION
Bug 2491, which stated that the URLs were being converted to lowercase, which potentially caused issues for URLs with uppercase characters.

<!-- Thank you for your contribution to MobSF! -->

### Describe the Pull Request
All the URLs in Static Analysis were being forced to lowercase characters, which fails in real-world, because URLs are case sensitive, and only domains are case insensitive.
```
DESCRIBE THE DETAILS OF PULL REQUEST HERE
```

### Checklist for PR

- [*] Run MobSF unit tests and lint `tox -e lint,test`
- [] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)
I have tested this on couple of applications which have lowercase, uppercase, and mixture of both these. And now we are able to capture the case of the url too.
```
DESCRIBE HERE
```
