### PR TITLE
[HOTFIX] Fix false positive in debug symbol stripping check using objdump

### DIFF
--- a/mobsf/StaticAnalyzer/views/common/binary/macho.py
+++ b/mobsf/StaticAnalyzer/views/common/binary/macho.py
@@ -23,7 +23,14 @@ def objdump_is_debug_symbol_stripped(macho_file):
     out = subprocess.check_output(
         [shutil.which('objdump'), '--syms', macho_file],
         stderr=subprocess.STDOUT)
-    return b' d  ' not in out
+    out = out.decode('utf-8', 'ignore')
+    # radr://5614542 symbol is added back for
+    # debug symbols stripped binaries
+    stripped_sym = 'radr://5614542'
+    for line in out.splitlines():
+        if ' d  ' in line and stripped_sym not in line:
+            return False
+    return True
 
 
 class MachOChecksec:


### PR DESCRIPTION
### Describe the Pull Request

This PR fixes a false positive in the **debug symbol stripping check** for Mach-O binaries, as reported in issue #2502.

**Root Cause**

Commit 78e9563 refactored the symbol-stripping detection to use `objdump --syms` instead of LIEF. However, it did not carry over the special-case handling for the `radr://5614542` symbol. Apple’s toolchain adds this symbol back even when debug symbols are fully stripped (see [issue #1917 (comment)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/issues/1917#issuecomment-1238078359)). As a result, MobSF was incorrectly reporting that binaries still contained debug symbols, leading to **false positives** on properly stripped Mach-O files.

**Fix**

- Updated `objdump_is_debug_symbol_stripped()` to explicitly skip lines that contain only the `radr://5614542` symbol.
- If a line contains the ` d ` (debug) symbol type **and** does **not** include `radr://5614542`, the binary is now correctly marked as **not stripped**.

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [ ] Tested Working on Linux, Mac, Windows, and Docker
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments (if any)

The fix is minimal and simply restores the `radr://5614542` handling that was present before the `objdump`-based refactor. It prevents false positives while preserving the performance benefits of using native tooling.
