### PR TITLE
Add Android WebView mixed-content detection rule

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/rules/android_rules.yaml
+++ b/mobsf/StaticAnalyzer/views/android/rules/android_rules.yaml
@@ -295,6 +295,22 @@
     owasp-mobile: m3
     masvs: network-3
     ref: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#webview-server-certificate-verification
+- id: android_webview_mixed_content
+  message: >-
+    Insecure WebView Implementation. WebView is configured with
+    MIXED_CONTENT_ALWAYS_ALLOW, allowing a page loaded over HTTPS to load
+    content from insecure HTTP origins. This exposes the application to
+    man-in-the-middle content injection.
+  type: Regex
+  pattern: setMixedContentMode\(.{0,48}MIXED_CONTENT_ALWAYS_ALLOW
+  severity: high
+  input_case: exact
+  metadata:
+    cvss: 7.4
+    cwe: cwe-319
+    owasp-mobile: m3
+    masvs: network-1
+    ref: https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md
 - id: android_sql_raw_query
   message: >-
     App uses SQLite Database and execute raw SQL query. Untrusted user input in


### PR DESCRIPTION
This adds a static-analysis rule, `android_webview_mixed_content`, to the Android ruleset.

## What it detects

WebViews configured with `setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW)`. In this mode a page loaded over HTTPS is allowed to load resources (scripts, iframes, etc.) from insecure HTTP origins, which exposes the app to man-in-the-middle content injection. The existing WebView rules cover SSL-error bypass, file access and JS execution, but mixed content was not flagged.

```yaml
- id: android_webview_mixed_content
  type: Regex
  pattern: setMixedContentMode\(.{0,48}MIXED_CONTENT_ALWAYS_ALLOW
  severity: high
  metadata: {cwe: cwe-319, owasp-mobile: m3, masvs: network-1}
```

## Why it is precise (no false positives)

The pattern matches **only** the insecure `MIXED_CONTENT_ALWAYS_ALLOW` mode. It does **not** match the safe `MIXED_CONTENT_NEVER_ALLOW` or the intermediate `MIXED_CONTENT_COMPATIBILITY_MODE`.

Verified locally with libsast (the same engine MobSF uses), running the **full** `android_rules.yaml` against test snippets:

| Snippet | Expected | Result |
|---------|----------|--------|
| `setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW)` | fire | ✅ fired |
| `setMixedContentMode(WebSettings.MIXED_CONTENT_NEVER_ALLOW)` | no fire | ✅ silent |
| `setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE)` | no fire | ✅ silent |

The full ruleset parses cleanly and all rule IDs remain unique (52 rules).

## References
- https://developer.android.com/reference/android/webkit/WebSettings#setMixedContentMode(int)
- OWASP MASTG — Testing Network Communication