### PR TITLE
docs: add native installation guide and REST API examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,74 @@ MobSF is also bundled with [Android Tamer](https://tamerplatform.com), [BlackArc
 
 ## Documentation
 
-Quick setup with docker
+### Quick Setup with Docker
 
-```
+```bash
 docker pull opensecurity/mobile-security-framework-mobsf:latest
 docker run -it --rm -p 8000:8000 opensecurity/mobile-security-framework-mobsf:latest
 
 # Default username and password: mobsf/mobsf
 ```
+
+### Native Installation
+
+MobSF can be installed natively on Windows, macOS, and Linux for better performance and development.
+
+**Requirements:**
+- Python 3.12 or higher
+- Git
+- JDK 17+ (for Android analysis)
+
+**Windows:**
+```batch
+git clone https://github.com/MobSF/Mobile-Security-Framework-MobSF.git
+cd Mobile-Security-Framework-MobSF
+setup.bat
+run.bat
+```
+
+**macOS/Linux:**
+```bash
+git clone https://github.com/MobSF/Mobile-Security-Framework-MobSF.git
+cd Mobile-Security-Framework-MobSF
+chmod +x setup.sh run.sh
+./setup.sh
+./run.sh
+```
+
+After setup, access MobSF at `http://127.0.0.1:8000` with default credentials `mobsf/mobsf`.
+
+**Troubleshooting:**
+- If `setup.sh` fails on macOS, ensure Xcode Command Line Tools are installed: `xcode-select --install`
+- If port 8000 is in use, edit `mobsf/MobSF/settings.py` and change `BIND_ADDRESS` and `PORT`
+- For detailed installation instructions, see the [full documentation](https://mobsf.github.io/docs)
+
+### REST API Usage
+
+MobSF provides a REST API for automation and CI/CD integration.
+
+**Authentication:**
+All API requests require the API key. Find it in `mobsf/MobSF/settings.py` under `API_KEY`.
+
+**Example: Upload and scan an APK**
+```bash
+# Upload file
+curl -X POST http://127.0.0.1:8000/api/v1/upload \
+  -H "Authorization: YOUR_API_KEY" \
+  -F "file=@app.apk"
+
+# Start scan
+curl -X POST http://127.0.0.1:8000/api/v1/scan \
+  -H "Authorization: YOUR_API_KEY" \
+  -d "hash=<md5_hash>&scan_type=apk&re_scan=1"
+
+# Get report
+curl -X GET http://127.0.0.1:8000/api/v1/report_json \
+  -H "Authorization: YOUR_API_KEY" \
+  -d "hash=<md5_hash>"
+```
+
+For complete API documentation, see [API Reference](https://mobsf.github.io/docs/#/api).
 
 [![See MobSF Documentation](https://user-images.githubusercontent.com/4301109/70686099-3855f780-1c79-11ea-8141-899e39459da2.png)](https://mobsf.github.io/docs)
 


### PR DESCRIPTION
## What Problem This Solves

The README only provided Docker-based quick setup, leaving users who need native installation or API integration without guidance.

## Why This Change Was Made

Users face several challenges:
- No native installation instructions for Windows/macOS/Linux
- Missing requirements list (Python version, JDK, etc.)
- No troubleshooting for common setup issues
- REST API mentioned but no usage examples
- Users must navigate to external docs for basic setup information

## Changes

- Add native installation instructions for Windows (setup.bat/run.bat) and macOS/Linux (setup.sh/run.sh)
- Include clear requirements section (Python 3.12+, Git, JDK 17+)
- Add troubleshooting section for common issues (Xcode tools, port conflicts)
- Add REST API usage section with complete curl examples
- Provide authentication and scan workflow examples
- Improve documentation structure with clear subsections

## User Impact

Users can now:
- Install MobSF natively without Docker for better performance
- Understand system requirements before installation
- Resolve common setup issues independently
- Quickly integrate MobSF into CI/CD using REST API examples
- Find all essential information in the README without navigating to external docs

## Evidence

- Installation commands match existing setup.bat/setup.sh scripts
- API examples follow MobSF's actual API structure
- All links verified to point to existing documentation
- No code changes, documentation only