### PR TITLE
ci: bump Actions versions, pin Docker actions, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -56,7 +56,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -84,6 +84,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -17,13 +17,13 @@ jobs:
             uses: actions/checkout@v7
         -
             name: Set up QEMU
-            uses: docker/setup-qemu-action@v4
+            uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         -
             name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@v4
+            uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         -
             name: Login to DockerHub
-            uses: docker/login-action@v4
+            uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
             with:
                 username: ${{ secrets.DOCKER_USERNAME }}
                 password: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,13 +16,13 @@ jobs:
             uses: actions/checkout@v7
         -
             name: Set up QEMU
-            uses: docker/setup-qemu-action@v4
+            uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         -
             name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@v4
+            uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         -
             name: Login to DockerHub
-            uses: docker/login-action@v4
+            uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
             with:
                 username: ${{ secrets.DOCKER_USERNAME }}
                 password: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -16,10 +16,10 @@ jobs:
             uses: actions/checkout@v7
         -
             name: Set up QEMU
-            uses: docker/setup-qemu-action@v4
+            uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         -
             name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@v4
+            uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         -
             name: Build AMD64 image
             id: docker_build_amd

--- a/.github/workflows/mobsf-test.yml
+++ b/.github/workflows/mobsf-test.yml
@@ -22,9 +22,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -70,7 +70,7 @@ jobs:
         poetry run python manage.py migrate
         poetry run python manage.py create_roles
   
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '21'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
## Summary
- Bump non-Docker workflow Actions: `checkout`/`setup-python` to v7, `setup-java` to v5, CodeQL to v4
- SHA-pin Docker `setup-qemu`, `setup-buildx`, and `login` actions (with version comments), matching `build-push-action`
- Add weekly Dependabot updates for `github-actions`

## Test plan
- [ ] Confirm workflow YAML parses / Actions lint is clean
- [ ] Watch `MobSF tests` and `CodeQL` on this PR
- [ ] After merge, confirm Dependabot opens Actions update PRs on schedule

Made with [Cursor](https://cursor.com)