### PR TITLE
Migrate VirusTotal integration to API v3

### DIFF
--- a/mobsf/MalwareAnalyzer/views/VirusTotal.py
+++ b/mobsf/MalwareAnalyzer/views/VirusTotal.py
@@ -1,4 +1,6 @@
 import logging
+import time
+from urllib.parse import urlparse
 
 import requests
 
@@ -13,6 +15,15 @@ from mobsf.MobSF.utils import (
 
 logger = logging.getLogger(__name__)
 
+# VirusTotal API v3 limits (MB)
+VT_SMALL_FILE_LIMIT_MB = 32
+VT_MAX_FILE_LIMIT_MB = 650
+# Poll newly uploaded analyses without blocking scans forever
+VT_POLL_INTERVAL_SEC = 15
+VT_POLL_MAX_ATTEMPTS = 12
+VT_REQUEST_TIMEOUT = 30
+VT_UPLOAD_TIMEOUT = 300
+
 
 class VirusTotal:
 
@@ -21,122 +32,265 @@ class VirusTotal:
     API_CONN_ERROR = 'VirusTotal Connection Error'
 
     def __init__(self, checksum):
-        self.base_url = settings.VIRUS_TOTAL_BASE_URL
+        self.base_url = settings.VIRUS_TOTAL_BASE_URL.rstrip('/')
         self.checksum = checksum
+
+    def _headers(self):
+        return {
+            'Accept': 'application/json',
+            'x-apikey': settings.VT_API_KEY,
+        }
+
+    def _proxies(self):
+        try:
+            return upstream_proxy('https')
+        except Exception as exp:
+            msg = 'Setting upstream proxy'
+            logger.exception(msg)
+            append_scan_status(self.checksum, msg, repr(exp))
+            return {}, True
+
+    def _is_safe_vt_url(self, url):
+        """Allow only VirusTotal hosts for upload/analysis URLs."""
+        try:
+            parsed = urlparse(url)
+            if parsed.scheme not in ('http', 'https'):
+                return False
+            host = (parsed.hostname or '').lower()
+            return (host == 'virustotal.com'
+                    or host.endswith('.virustotal.com'))
+        except Exception:
+            return False
+
+    def _request(self, method, url, timeout=VT_REQUEST_TIMEOUT, **kwargs):
+        """Perform an authenticated VirusTotal request."""
+        proxies, verify = self._proxies()
+        headers = kwargs.pop('headers', {})
+        req_headers = self._headers()
+        req_headers.update(headers)
+        try:
+            response = requests.request(
+                method,
+                url,
+                timeout=timeout,
+                headers=req_headers,
+                proxies=proxies,
+                verify=verify,
+                **kwargs)
+        except Exception as exp:
+            logger.error(self.API_CONN_ERROR)
+            append_scan_status(
+                self.checksum,
+                self.API_CONN_ERROR,
+                repr(exp))
+            return None
+        if response.status_code in (401, 403):
+            logger.error(self.API_KEY_ERROR)
+            append_scan_status(
+                self.checksum,
+                self.API_KEY_ERROR,
+                self.API_KEY_ERROR_SHORT)
+            return None
+        return response
+
+    def _normalize_report(self, raw):
+        """
+        Convert a VT v3 file object into the v2-shaped dict templates expect.
+
+        Templates use positives/total/scans/permalink/verbose_msg and treat
+        dicts with fewer than 9 keys as status messages.
+        """
+        data = raw.get('data') or {}
+        attrs = data.get('attributes') or {}
+        stats = attrs.get('last_analysis_stats') or {}
+        results = attrs.get('last_analysis_results') or {}
+
+        positives = int(stats.get('malicious', 0) or 0)
+        total = sum(
+            int(stats.get(key, 0) or 0)
+            for key in (
+                'malicious',
+                'suspicious',
+                'undetected',
+                'harmless',
+                'timeout',
+                'confirmed-timeout',
+                'failure',
+                'type-unsupported',
+            ))
+
+        scans = {}
+        for engine, result in results.items():
+            category = result.get('category') or ''
+            scans[engine] = {
+                'detected': category == 'malicious',
+                'result': result.get('result') or category,
+                'version': result.get('engine_version') or '',
+                'update': result.get('engine_update') or '',
+            }
+
+        file_id = data.get('id') or attrs.get('sha256') or self.checksum
+        return {
+            'response_code': 1,
+            'verbose_msg': 'Scan finished, information embedded',
+            'positives': positives,
+            'total': total,
+            'md5': attrs.get('md5') or '',
+            'sha1': attrs.get('sha1') or '',
+            'sha256': attrs.get('sha256') or file_id,
+            'scan_date': str(attrs.get('last_analysis_date') or ''),
+            'permalink': f'https://www.virustotal.com/gui/file/{file_id}',
+            'resource': file_id,
+            'scan_id': file_id,
+            'scans': scans,
+        }
+
+    def _queued_message(self, message=None):
+        """Status-only payload so templates show verbose_msg."""
+        return {
+            'verbose_msg': message or (
+                'VirusTotal analysis request successfully queued'),
+            'positives': 0,
+            'total': 0,
+        }
 
     def get_report(self):
         """
-        Get Report from VT.
+        Get Report from VT API v3.
 
-        :param file_hash: md5/sha1/sha256
-        :return: json response / None
+        :return: normalized report dict / None
         """
         try:
-            file_hash = self.checksum
-            url = self.base_url + 'report'
-            params = {
-                'apikey': settings.VT_API_KEY,
-                'resource': file_hash}
-            headers = {'Accept-Encoding': 'gzip, deflate'}
-            try:
-                proxies, verify = upstream_proxy('https')
-            except Exception as exp:
-                msg = 'Setting upstream proxy'
-                logger.exception(msg)
-                append_scan_status(file_hash, msg, repr(exp))
-            try:
-                response = requests.get(
-                    url,
-                    timeout=5,
-                    params=params,
-                    headers=headers,
-                    proxies=proxies,
-                    verify=verify)
-                if response.status_code == 403:
-                    logger.error(self.API_KEY_ERROR)
-                    append_scan_status(
-                        file_hash,
-                        self.API_KEY_ERROR,
-                        self.API_KEY_ERROR_SHORT)
-                    return None
-            except Exception as exp:
-                logger.error(self.API_CONN_ERROR)
-                append_scan_status(
-                    file_hash,
-                    self.API_CONN_ERROR,
-                    repr(exp))
+            url = f'{self.base_url}/{self.checksum}'
+            response = self._request('GET', url)
+            if response is None:
+                return None
+            if response.status_code == 404:
+                return None
+            if response.status_code != 200:
+                msg = (f'VirusTotal report request failed '
+                       f'({response.status_code})')
+                logger.warning(msg)
+                append_scan_status(self.checksum, msg)
                 return None
             try:
-                json_response = response.json()
-                return json_response
+                return self._normalize_report(response.json())
             except ValueError:
                 return None
         except Exception as exp:
             msg = 'Failed to get report from VirusTotal'
             logger.exception(msg)
-            append_scan_status(file_hash, msg, repr(exp))
+            append_scan_status(self.checksum, msg, repr(exp))
             return None
+
+    def _get_upload_url(self):
+        """Get a one-time URL for files larger than 32MB."""
+        url = f'{self.base_url}/upload_url'
+        response = self._request('GET', url)
+        if response is None or response.status_code != 200:
+            return None
+        try:
+            upload_url = response.json().get('data')
+        except ValueError:
+            return None
+        if not upload_url or not self._is_safe_vt_url(upload_url):
+            msg = 'VirusTotal returned an invalid upload URL'
+            logger.error(msg)
+            append_scan_status(self.checksum, msg)
+            return None
+        return upload_url
 
     def upload_file(self, file_path):
         """
-        Upload File to VT.
+        Upload File to VT API v3.
 
-        :param file_path: file path to upload
-        :return: json response / None
+        Uses /files for <=32MB and /files/upload_url for larger files
+        up to 650MB.
+        :return: analysis JSON / None
         """
         try:
-            url = self.base_url + 'scan'
-            if file_size(file_path) > 31:
-                logger.warning('VirusTotal Public API does '
-                               'not support files above 32 MB')
+            size_mb = file_size(file_path)
+            if size_mb > VT_MAX_FILE_LIMIT_MB:
+                msg = ('VirusTotal does not support files '
+                       f'above {VT_MAX_FILE_LIMIT_MB} MB')
+                logger.warning(msg)
+                append_scan_status(self.checksum, msg)
                 return None
-            files = {'file': open(file_path, 'rb')}
-            headers = {'apikey': settings.VT_API_KEY}
-            try:
-                proxies, verify = upstream_proxy('https')
-            except Exception as exp:
-                msg = 'Setting upstream proxy'
-                logger.exception(msg)
-                append_scan_status(self.checksum, msg, repr(exp))
-            try:
-                response = requests.post(
-                    url,
-                    timeout=5,
-                    files=files,
-                    data=headers,
-                    proxies=proxies,
-                    verify=verify)
-                if response.status_code == 403:
-                    logger.error(self.API_KEY_ERROR)
-                    append_scan_status(
-                        self.checksum,
-                        self.API_KEY_ERROR,
-                        self.API_KEY_ERROR_SHORT)
-                    return None
-            except Exception as exp:
-                logger.error(self.API_CONN_ERROR)
-                append_scan_status(
-                    self.checksum,
-                    self.API_CONN_ERROR,
-                    repr(exp))
-                return None
-            json_response = response.json()
-            return json_response
 
+            if size_mb > VT_SMALL_FILE_LIMIT_MB:
+                msg = ('VirusTotal: requesting large-file '
+                       f'upload URL ({size_mb} MB)')
+                logger.info(msg)
+                append_scan_status(self.checksum, msg)
+                upload_url = self._get_upload_url()
+                if not upload_url:
+                    return None
+            else:
+                upload_url = self.base_url
+
+            with open(file_path, 'rb') as file_handle:
+                response = self._request(
+                    'POST',
+                    upload_url,
+                    timeout=VT_UPLOAD_TIMEOUT,
+                    files={'file': file_handle})
+            if response is None:
+                return None
+            if response.status_code not in (200, 201):
+                msg = (f'VirusTotal upload failed '
+                       f'({response.status_code})')
+                logger.warning(msg)
+                append_scan_status(self.checksum, msg)
+                return None
+            try:
+                return response.json()
+            except ValueError:
+                return None
         except Exception as exp:
             msg = 'Failed to upload file to VirusTotal'
             logger.exception(msg)
             append_scan_status(self.checksum, msg, repr(exp))
             return None
 
+    def _poll_analysis(self, analysis_url):
+        """Poll an analysis object until completed or timeout."""
+        if not self._is_safe_vt_url(analysis_url):
+            msg = 'VirusTotal returned an invalid analysis URL'
+            logger.error(msg)
+            append_scan_status(self.checksum, msg)
+            return False
+
+        for attempt in range(VT_POLL_MAX_ATTEMPTS):
+            response = self._request('GET', analysis_url)
+            if response is None:
+                return False
+            if response.status_code != 200:
+                return False
+            try:
+                status = (
+                    response.json()
+                    .get('data', {})
+                    .get('attributes', {})
+                    .get('status'))
+            except ValueError:
+                return False
+            if status == 'completed':
+                return True
+            msg = (f'VirusTotal: analysis status "{status}" '
+                   f'({attempt + 1}/{VT_POLL_MAX_ATTEMPTS})')
+            logger.info(msg)
+            append_scan_status(self.checksum, msg)
+            time.sleep(VT_POLL_INTERVAL_SEC)
+        return False
+
     def get_result(self, file_path):
         """
         Get Results from VT.
 
-        Uploading a file and getting the approval msg from VT
-        or fetching existing report
+        Fetch an existing report, or upload the file (with large-file
+        support) and poll briefly for completion.
         :param file_path: file's path
-        :return: VirusTotal result json / None upon error
+        :return: VirusTotal result dict / None upon error
         """
         try:
             file_hash = self.checksum
@@ -144,37 +298,52 @@ class VirusTotal:
             logger.info(msg)
             append_scan_status(file_hash, msg)
             report = self.get_report()
-            # Check for existing report
             if report:
-                if report['response_code'] == 1:
-                    msg = f'VirusTotal: {report["verbose_msg"]}'
-                    logger.info(msg)
-                    append_scan_status(file_hash, msg)
-                    return report
-            if settings.VT_UPLOAD:
-                msg = 'VirusTotal: file upload'
+                msg = f'VirusTotal: {report["verbose_msg"]}'
                 logger.info(msg)
                 append_scan_status(file_hash, msg)
-                upload_response = self.upload_file(file_path)
-                if upload_response:
-                    msg = f'VirusTotal: {upload_response["verbose_msg"]}'
-                    logger.info(msg)
-                    append_scan_status(file_hash, msg)
-                return upload_response
-            else:
+                return report
+
+            if not settings.VT_UPLOAD:
                 msg = ('VirusTotal Scan not performed as file '
                        f'upload is disabled in {get_config_loc()}. '
                        'To enable file upload, set VT_UPLOAD to True.')
                 logger.info(msg)
                 append_scan_status(file_hash, msg)
-                message = ('Scan not performed, VirusTotal file '
-                           f'upload disabled in {get_config_loc()}')
-                report = {
-                    'verbose_msg': message,
-                    'positives': 0,
-                    'total': 0}
-                return report
+                return self._queued_message(
+                    'Scan not performed, VirusTotal file '
+                    f'upload disabled in {get_config_loc()}')
+
+            msg = 'VirusTotal: file upload'
+            logger.info(msg)
+            append_scan_status(file_hash, msg)
+            upload_response = self.upload_file(file_path)
+            if not upload_response:
+                return None
+
+            analysis_url = (
+                upload_response
+                .get('data', {})
+                .get('links', {})
+                .get('self'))
+            if analysis_url:
+                msg = 'VirusTotal: waiting for analysis'
+                logger.info(msg)
+                append_scan_status(file_hash, msg)
+                if self._poll_analysis(analysis_url):
+                    report = self.get_report()
+                    if report:
+                        msg = f'VirusTotal: {report["verbose_msg"]}'
+                        logger.info(msg)
+                        append_scan_status(file_hash, msg)
+                        return report
+
+            msg = 'VirusTotal analysis request successfully queued'
+            logger.info(msg)
+            append_scan_status(file_hash, msg)
+            return self._queued_message(msg)
         except Exception as exp:
             msg = 'VirusTotal: Error getting result'
             logger.exception(msg)
             append_scan_status(file_hash, msg, repr(exp))
+            return None

--- a/mobsf/MobSF/settings.py
+++ b/mobsf/MobSF/settings.py
@@ -130,7 +130,7 @@ API_ONLY = os.getenv('MOBSF_API_ONLY', '0')
 MALWARE_DB_URL = 'https://www.malwaredomainlist.com/mdlcsv.php'
 MALTRAIL_DB_URL = ('https://raw.githubusercontent.com/stamparm/aux/'
                    'master/maltrail-malware-domains.txt')
-VIRUS_TOTAL_BASE_URL = 'https://www.virustotal.com/vtapi/v2/file/'
+VIRUS_TOTAL_BASE_URL = 'https://www.virustotal.com/api/v3/files'
 EXODUS_URL = 'https://reports.exodus-privacy.eu.org'
 APPMONSTA_URL = 'https://api.appmonsta.com/v1/stores/android/details/'
 ITUNES_URL = 'https://itunes.apple.com/lookup'
@@ -510,7 +510,7 @@ else:
     # ========DISABLED BY DEFAULT COMPONENTS=========
     # Get AppMonsta API from https://appmonsta.com/dashboard/get_api_key/
     APPMONSTA_API = os.getenv('MOBSF_APPMONSTA_API', '')
-    # ----------VirusTotal--------------------------
+    # ----------VirusTotal (API v3)-----------------
     VT_ENABLED = bool(os.getenv('MOBSF_VT_ENABLED', ''))
     VT_API_KEY = os.getenv('MOBSF_VT_API_KEY', '')
     VT_UPLOAD = bool(os.getenv('MOBSF_VT_UPLOAD', ''))
@@ -518,9 +518,10 @@ else:
     # Make sure VT_API_KEY is set to your VirusTotal API key
     # register at: https://www.virustotal.com/#/join-us
     # You can get your API KEY from:
-    # https://www.virustotal.com/en/user/<username>/apikey/
-    # Files will be uploaded to VirusTotal
-    # if VT_UPLOAD is set to True.
+    # https://www.virustotal.com/gui/user/<username>/apikey/
+    # Files will be uploaded to VirusTotal if VT_UPLOAD is True.
+    # Files <=32MB use /files; larger files use /files/upload_url
+    # (up to 650MB).
     # ===============================================
     # =======IOS DYNAMIC ANALYSIS SETTINGS===========
     # Should be SSH IP:PORT, example: 192.168.1.100:22


### PR DESCRIPTION
## Summary
- Replace deprecated VirusTotal API v2 with v3 (`/api/v3/files`)
- Support large-file uploads via `/files/upload_url` (up to 650MB; ≤32MB still uses `/files`)
- Poll analysis briefly after upload, then normalize the v3 report for existing UI/PDF templates
- Validate upload/analysis URLs are VirusTotal hosts before use

Fixes #2560

## Test plan
- [ ] Set `MOBSF_VT_ENABLED=1`, `MOBSF_VT_API_KEY`, restart MobSF
- [ ] Scan a known APK with upload off → existing VT report shows `positives/total`
- [ ] Scan an unknown sample with `MOBSF_VT_UPLOAD=1` → upload + report or queued message
- [ ] (Optional) Scan a file >32MB → logs show large-file upload URL path
- [ ] Bad API key → permission error logged, no crash

Made with [Cursor](https://cursor.com)