### PR TITLE
ci: publish to PyPI with OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,15 +2,17 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   contents: read
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # OIDC for PyPI Trusted Publishing
+      contents: read
 
     steps:
     - uses: actions/checkout@v7
@@ -18,14 +20,11 @@ jobs:
       uses: actions/setup-python@v7
       with:
         python-version: '3.x'
-    - name: Install dependencies
+    - name: Install Poetry
       run: |
         python -m pip install --upgrade pip
         pip install poetry==1.8.4
-    - name: Build and publish
-      env:
-        PYPI_TOKEN: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        poetry config pypi-token.pypi ${PYPI_TOKEN}
-        poetry build
-        poetry publish
+    - name: Build package
+      run: poetry build
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write  # OIDC for PyPI Trusted Publishing
+      id-token: write
       contents: read
 
     steps:


### PR DESCRIPTION
## Summary
- Migrate PyPI releases from a long-lived `PYPI_PASSWORD` API token to **OIDC Trusted Publishing**
- Build with Poetry, publish with SHA-pinned `pypa/gh-action-pypi-publish` (`id-token: write`)
- Trigger on `release: published` (covers draft → published)

## Required one-time PyPI setup
On https://pypi.org/manage/project/mobsf/settings/publishing/ (or pending publisher if first time), add a Trusted Publisher:

| Field | Value |
|-------|--------|
| Owner | `MobSF` |
| Repository | `Mobile-Security-Framework-MobSF` |
| Workflow name | `python-publish.yml` |
| Environment name | *(leave empty)* |

After the first successful OIDC publish:

1. Delete GitHub secrets `PYPI_PASSWORD` and `PYPI_USERNAME`
2. Revoke the old PyPI API token on pypi.org

## Test plan
- [ ] Confirm Trusted Publisher is configured on PyPI for this workflow
- [ ] Publish a test/pre-release (or next real release) and verify the workflow publishes without `PYPI_PASSWORD`
- [ ] Remove old PyPI token secrets after success

Made with [Cursor](https://cursor.com)