### PR TITLE
fix!: apktool not extracting the pak informations properly

### DIFF
--- a/mobsf/StaticAnalyzer/views/android/converter.py
+++ b/mobsf/StaticAnalyzer/views/android/converter.py
@@ -173,12 +173,13 @@ def run_apktool(app_path, app_dir, tools_dir):
                 '-jar',
                 str(apktool_path),
                 'd',
-                '-p',
+                '--match-original',
+                '--frame-path',
                 gettempdir(),
-                '-f',
-                '-s',
+                '--force',
+                '--no-src',
                 str(app_path),
-                '-o',
+                '--output',
                 str(output_dir)]
         logger.info('Converting AXML to XML with apktool')
         with open(os.devnull, 'w') as fnull:


### PR DESCRIPTION
### Describe the Pull Request

```
Following the Pull request #2630 (I made...) The call for running apktool was modified and did not include the '--match-original' option causing the extracted files to omit some elements. Someone from my team remarked that the build version, version code, min SDK, etc were missing and after doing tests I have pin pointed that this missing argument was at fault and hence I have added it back.
```

### Checklist for PR

- [x] Run MobSF unit tests and lint `tox -e lint,test`
- [x] Tested Working on Linux, Windows, and Docker
- [ ] Tested Working on Mac
- [ ] Add unit test for any new Web API (Refer: `StaticAnalyzer/tests.py`) (not relevant)
- [ ] Make sure tests are passing on your PR [![MobSF tests](https://github.com/MobSF/Mobile-Security-Framework-MobSF/workflows/MobSF%20tests/badge.svg?branch=master)](https://github.com/MobSF/Mobile-Security-Framework-MobSF/actions)

### Additional Comments

I have taken advantage of this to put the more explicit version of the arguments for readability.
Also sorry for not having seen that before.