### PR TITLE
UI: Dark theme redesign across the web interface

### DIFF
--- a/mobsf/MobSF/views/authorization.py
+++ b/mobsf/MobSF/views/authorization.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import (
     Permission,
     User,
 )
+from django.db import IntegrityError
 from django.shortcuts import (
     redirect,
     render,
@@ -136,7 +137,14 @@ def create_user(request):
             if not USERNAME_REGEX.match(username):
                 messages.error(request, 'Invalid Username')
                 return redirect('create_user')
-            user = form.save()
+            try:
+                user = form.save()
+            except IntegrityError:
+                # form.is_valid() already checks username uniqueness, but a
+                # concurrent request (e.g. a double-submitted form) can still
+                # race past that check before either commits.
+                messages.error(request, 'Username already exists')
+                return redirect('create_user')
             user.is_staff = False
             if role == 'maintainer':
                 user.groups.add(Group.objects.get(name=MAINTAINER_GROUP))

--- a/mobsf/static/others/css/auth-pages.css
+++ b/mobsf/static/others/css/auth-pages.css
@@ -1,0 +1,151 @@
+/**
+ * Shared structural CSS for the auth pages (login, register, change_password).
+ * Each page keeps its own accent color, icon, and button treatment inline;
+ * only the byte-identical layout/card/typography rules live here.
+ */
+
+.auth-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-base, #0d1117);
+  position: relative;
+  overflow: hidden;
+}
+
+.auth-page::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(88,166,255,0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(88,166,255,0.03) 1px, transparent 1px);
+  background-size: 40px 40px;
+  pointer-events: none;
+}
+
+.auth-card {
+  width: 100%;
+  max-width: 420px;
+  background: var(--bg-card, #161d27);
+  border: 1px solid var(--border-default, #30363d);
+  border-radius: 20px;
+  box-shadow: 0 24px 80px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.03);
+  padding: 40px;
+  position: relative;
+  z-index: 1;
+  animation: auth-slide-up 0.4s cubic-bezier(0.4,0,0.2,1);
+}
+
+@keyframes auth-slide-up {
+  from { opacity:0; transform: translateY(20px); }
+  to   { opacity:1; transform: translateY(0); }
+}
+
+.auth-brand {
+  text-align: center;
+  margin-bottom: 28px;
+}
+
+.auth-title {
+  color: var(--text-primary, #e6edf3);
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0 0 6px;
+  letter-spacing: -0.3px;
+}
+
+.auth-subtitle {
+  color: var(--text-secondary, #8b949e);
+  font-size: 13px;
+  margin: 0;
+}
+
+.auth-label {
+  display: block;
+  color: var(--text-secondary, #8b949e);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.auth-input {
+  width: 100%;
+  background: var(--bg-input, #0d1117) !important;
+  border: 1px solid var(--border-default, #30363d) !important;
+  color: var(--text-primary, #e6edf3) !important;
+  border-radius: 10px !important;
+  padding: 10px 40px 10px 14px !important;
+  font-size: 13.5px !important;
+  transition: all 0.2s ease;
+  outline: none;
+}
+
+.auth-input::placeholder { color: var(--text-muted, #484f58) !important; }
+
+.auth-input-group {
+  position: relative;
+  margin-bottom: 16px;
+}
+
+.auth-input-icon {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted, #484f58);
+  font-size: 13px;
+  pointer-events: none;
+}
+
+.auth-divider {
+  height: 1px;
+  background: var(--border-subtle, rgba(48,54,61,0.6));
+  margin: 20px 0;
+}
+
+.error-box {
+  background: rgba(248,81,73,0.08);
+  border: 1px solid rgba(248,81,73,0.25);
+  border-left: 3px solid var(--accent-red, #f85149);
+  color: var(--accent-red, #f85149);
+  padding: 10px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.messages { list-style: none; padding: 0; margin: 0 0 16px; }
+.messages li {
+  background: rgba(63,185,80,0.08);
+  border: 1px solid rgba(63,185,80,0.2);
+  border-left: 3px solid var(--accent-green, #3fb950);
+  color: var(--accent-green, #3fb950);
+  padding: 10px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.messages li.error {
+  background: rgba(248,81,73,0.08);
+  border-color: rgba(248,81,73,0.25);
+  border-left-color: var(--accent-red, #f85149);
+  color: var(--accent-red, #f85149);
+}
+
+.field-error {
+  color: var(--accent-red, #f85149);
+  font-size: 11.5px;
+  margin-top: 4px;
+  margin-bottom: 6px;
+  display: block;
+}

--- a/mobsf/static/others/css/error-pages.css
+++ b/mobsf/static/others/css/error-pages.css
@@ -1,0 +1,176 @@
+/**
+ * Shared layout for the standalone error pages (403, 404, 500).
+ * These pages intentionally do NOT extend base_layout.html - they must
+ * keep rendering even if something elsewhere in the app is broken.
+ *
+ * Each page still sets its own --accent-code / --accent-code-rgb (and any
+ * page-specific elements) in its own inline <style>; only the structure
+ * and rules shared byte-for-byte across all three live here.
+ */
+:root {
+  --bg-base:#0d1117; --bg-card:#161d27; --bg-surface:#111820;
+  --border-sub:rgba(48,54,61,0.6); --border-def:#30363d;
+  --text-pri:#e6edf3; --text-sec:#8b949e; --text-muted:#484f58;
+  --accent-b:#58a6ff;
+  --font-main:'Inter',-apple-system,sans-serif;
+  --font-mono:'JetBrains Mono',monospace;
+  --card-max-width: 480px;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  background: var(--bg-base);
+  color: var(--text-pri);
+  font-family: var(--font-main);
+}
+
+body::before {
+  content: '';
+  position: fixed; inset: 0;
+  background-image:
+    linear-gradient(rgba(var(--accent-code-rgb), 0.02) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(var(--accent-code-rgb), 0.02) 1px, transparent 1px);
+  background-size: 48px 48px;
+  pointer-events: none;
+}
+
+.error-wrap {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  position: relative;
+  z-index: 1;
+}
+
+.error-code {
+  font-family: var(--font-mono);
+  font-size: clamp(80px, 15vw, 140px);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -4px;
+  background: linear-gradient(135deg, rgba(var(--accent-code-rgb), 0.6) 0%, rgba(var(--accent-code-rgb), 0.15) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 8px;
+  animation: fadeIn 0.5s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.error-card {
+  background: var(--bg-card);
+  border: 1px solid var(--card-border, var(--border-def));
+  border-radius: 20px;
+  padding: 40px;
+  max-width: var(--card-max-width);
+  width: 100%;
+  text-align: center;
+  box-shadow: 0 24px 60px rgba(0,0,0,0.4), var(--card-glow, 0 0 0 rgba(0,0,0,0));
+  animation: slideUp 0.4s 0.1s both cubic-bezier(0.4,0,0.2,1);
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.error-icon {
+  width: 60px; height: 60px;
+  background: rgba(var(--accent-code-rgb), 0.08);
+  border: 1px solid rgba(var(--accent-code-rgb), 0.2);
+  border-radius: 16px;
+  display: inline-flex;
+  align-items: center; justify-content: center;
+  font-size: 24px;
+  color: var(--accent-code);
+  margin-bottom: 20px;
+}
+
+.error-title {
+  font-size: 20px; font-weight: 700;
+  color: var(--text-pri);
+  margin-bottom: 10px;
+}
+
+.error-desc {
+  color: var(--text-sec);
+  font-size: 13.5px;
+  line-height: 1.65;
+  margin-bottom: 28px;
+}
+
+.btn-home {
+  display: inline-flex;
+  align-items: center; gap: 8px;
+  background: rgba(88,166,255,0.1);
+  border: 1px solid rgba(88,166,255,0.25);
+  border-radius: 10px;
+  color: var(--accent-b);
+  font-size: 13.5px; font-weight: 700;
+  padding: 11px 24px;
+  text-decoration: none;
+  transition: all 0.18s ease;
+  margin: 4px;
+}
+.btn-home:hover {
+  background: rgba(88,166,255,0.18);
+  color: var(--accent-b);
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.btn-back {
+  display: inline-flex;
+  align-items: center; gap: 8px;
+  background: transparent;
+  border: 1px solid var(--border-def);
+  border-radius: 10px;
+  color: var(--text-sec);
+  font-size: 13.5px; font-weight: 600;
+  padding: 11px 24px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.18s ease;
+  margin: 4px;
+}
+.btn-back:hover {
+  background: rgba(255,255,255,0.04);
+  color: var(--text-pri);
+  text-decoration: none;
+}
+
+.nav-bar {
+  position: fixed; top: 0; left: 0; right: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 24px;
+  background: rgba(13,17,23,0.8);
+  border-bottom: 1px solid var(--border-sub);
+  backdrop-filter: blur(12px);
+  z-index: 100;
+}
+
+.nav-logo {
+  display: flex; align-items: center; gap: 8px;
+  text-decoration: none; color: var(--text-pri);
+  font-size: 15px; font-weight: 700;
+}
+.nav-logo span { color: var(--accent-b); }
+
+.nav-link-muted {
+  color: var(--text-sec); font-size: 12px; font-weight: 600;
+  text-decoration: none; padding: 6px 12px; border-radius: 7px;
+  transition: all .15s ease;
+}
+.nav-link-muted:hover {
+  color: var(--accent-b);
+  background: rgba(88,166,255,0.06);
+}

--- a/mobsf/static/others/css/mobsf-modern.css
+++ b/mobsf/static/others/css/mobsf-modern.css
@@ -1,0 +1,338 @@
+/**
+ * MobSF Modern UI/UX Styles
+ * A professional, security-tool oriented design system
+ * Inspired by Burp Suite, Android Studio, and modern SOC dashboards
+ */
+
+/* ============================================
+   Global Design Tokens (dark theme used app-wide)
+   Single source of truth - do not redeclare these
+   in base_layout.html or any individual template.
+   ============================================ */
+:root {
+  --bg-void:       #080b0f;
+  --bg-deep:       #0a0e14;
+  --bg-base:       #0d1117;
+  --bg-surface:    #111820;
+  --bg-card:       #161d27;
+  --bg-elevated:   #1a2233;
+  --bg-input:      #0d1117;
+  --border-subtle: rgba(48,54,61,0.6);
+  --border-default:#30363d;
+  --border-strong: #484f58;
+  --border-accent: rgba(88,166,255,0.3);
+  --text-primary:  #e6edf3;
+  --text-secondary:#8b949e;
+  --text-muted:    #484f58;
+  --text-link:     #58a6ff;
+  --accent-blue:   #58a6ff;
+  --accent-green:  #3fb950;
+  --accent-green-dim:#238636;
+  --accent-orange: #f0883e;
+  --accent-red:    #f85149;
+  --accent-purple: #bc8cff;
+  --accent-yellow: #e3b341;
+  --accent-cyan:   #39c5cf;
+  --glow-blue:     rgba(88,166,255,0.12);
+  --glow-green:    rgba(63,185,80,0.1);
+  --grad-blue:     linear-gradient(135deg,#1c3a5e 0%,#0d1117 100%);
+  --radius-sm:     6px;
+  --radius-md:     10px;
+  --radius-lg:     14px;
+  --radius-xl:     20px;
+  --shadow-card:   0 4px 24px rgba(0,0,0,0.4);
+  --shadow-glow:   0 0 20px rgba(88,166,255,0.08);
+  --font-main:     'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', monospace;
+  --transition:    0.2s cubic-bezier(0.4,0,0.2,1);
+}
+
+/* ============================================
+   CSS Custom Properties (Design Tokens)
+   ============================================ */
+:root {
+  /* Primary Colors - Security Tool Palette */
+  --mobsf-primary: #1a73e8;
+  --mobsf-primary-dark: #1557b0;
+  --mobsf-primary-light: #4a90e8;
+  
+  /* Background Colors */
+  --mobsf-bg-dark: #1e1e1e;
+  --mobsf-bg-darker: #121212;
+  --mobsf-bg-light: #2d2d2d;
+  --mobsf-bg-card: #ffffff;
+  --mobsf-bg-card-alt: #f8f9fa;
+  
+  /* Text Colors */
+  --mobsf-text-primary: #212529;
+  --mobsf-text-secondary: #6c757d;
+  --mobsf-text-muted: #adb5bd;
+  --mobsf-text-light: #f8f9fa;
+  --mobsf-text-dark: #000000;
+  
+  /* Status Colors */
+  --mobsf-success: #28a745;
+  --mobsf-success-light: #d4edda;
+  --mobsf-warning: #ffc107;
+  --mobsf-warning-light: #fff3cd;
+  --mobsf-danger: #dc3545;
+  --mobsf-danger-light: #f8d7da;
+  --mobsf-info: #17a2b8;
+  --mobsf-info-light: #d1ecf1;
+  
+  /* Log Level Colors */
+  --log-info: #6bb3f8;
+  --log-warning: #f5c242;
+  --log-error: #ff6b6b;
+  --log-debug: #a0a0a0;
+  --log-success: #4cd964;
+  
+  /* Device Status Colors */
+  --device-connected: #4cd964;
+  --device-disconnected: #ff6b6b;
+  --device-emulator: #ffcc00;
+  --device-rooted: #ff9500;
+  --device-frida-active: #30d158;
+  
+  /* Borders */
+  --mobsf-border: #dee2e6;
+  --mobsf-border-dark: #343a40;
+  
+  /* Shadows */
+  --mobsf-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --mobsf-shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --mobsf-shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
+  
+  /* Spacing */
+  --mobsf-spacing-xs: 0.25rem;
+  --mobsf-spacing-sm: 0.5rem;
+  --mobsf-spacing-md: 1rem;
+  --mobsf-spacing-lg: 1.5rem;
+  --mobsf-spacing-xl: 2rem;
+  
+  /* Border Radius */
+  --mobsf-radius-sm: 4px;
+  --mobsf-radius-md: 6px;
+  --mobsf-radius-lg: 8px;
+  --mobsf-radius-xl: 12px;
+  
+  /* Typography */
+  --mobsf-font-mono: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', 'Droid Sans Mono', 'Source Code Pro', monospace;
+  --mobsf-font-sans: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  
+  /* Transitions */
+  --mobsf-transition: all 0.2s ease-in-out;
+}
+
+/* ============================================
+   Modern Error Display
+   ============================================ */
+.mobsf-error-card {
+  background: var(--mobsf-bg-card);
+  border-radius: var(--mobsf-radius-lg);
+  box-shadow: var(--mobsf-shadow-md);
+  overflow: hidden;
+  border-left: 4px solid var(--mobsf-danger);
+  margin-bottom: var(--mobsf-spacing-lg);
+}
+
+.mobsf-error-card.error-warning {
+  border-left-color: var(--mobsf-warning);
+}
+
+.mobsf-error-card.error-info {
+  border-left-color: var(--mobsf-info);
+  border-left-width: 4px;
+}
+
+.mobsf-error-card .error-header {
+  background: var(--mobsf-danger-light);
+  padding: var(--mobsf-spacing-md) var(--mobsf-spacing-lg);
+  display: flex;
+  align-items: center;
+  gap: var(--mobsf-spacing-md);
+}
+
+.error-warning .error-header {
+  background: var(--mobsf-warning-light);
+}
+
+.error-info .error-header {
+  background: var(--mobsf-info-light);
+}
+
+.mobsf-error-card .error-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--mobsf-danger);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.error-warning .error-icon {
+  background: var(--mobsf-warning);
+}
+
+.error-info .error-icon {
+  background: var(--mobsf-info);
+}
+
+.mobsf-error-card .error-title {
+  font-weight: 600;
+  color: var(--mobsf-text-primary);
+  font-size: 1rem;
+}
+
+.mobsf-error-card .error-body {
+  padding: var(--mobsf-spacing-lg);
+}
+
+.mobsf-error-card .error-summary {
+  color: var(--mobsf-text-primary);
+  margin-bottom: var(--mobsf-spacing-md);
+  line-height: 1.6;
+}
+
+.mobsf-error-card .error-cause {
+  background: var(--mobsf-bg-card-alt);
+  padding: var(--mobsf-spacing-md);
+  border-radius: var(--mobsf-radius-md);
+  margin-bottom: var(--mobsf-spacing-md);
+  border: 1px solid var(--mobsf-border);
+}
+
+.mobsf-error-card .error-cause-label {
+  font-weight: 600;
+  color: var(--mobsf-text-secondary);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: var(--mobsf-spacing-xs);
+}
+
+.mobsf-error-card .error-cause-text {
+  color: var(--mobsf-text-primary);
+  font-size: 0.9rem;
+}
+
+.mobsf-error-card .error-suggestion {
+  background: #e8f5e9;
+  padding: var(--mobsf-spacing-md);
+  border-radius: var(--mobsf-radius-md);
+  margin-bottom: var(--mobsf-spacing-md);
+  border: 1px solid var(--mobsf-success);
+}
+
+.error-warning .error-suggestion {
+  background: #fff8e1;
+  border-color: var(--mobsf-warning);
+}
+
+.mobsf-error-card .error-suggestion-label {
+  font-weight: 600;
+  color: var(--mobsf-success);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: var(--mobsf-spacing-xs);
+}
+
+.error-warning .error-suggestion-label {
+  color: var(--mobsf-warning);
+}
+
+.mobsf-error-card .error-suggestion-text {
+  color: var(--mobsf-text-primary);
+  font-size: 0.9rem;
+}
+
+.mobsf-error-card .error-suggestion-code {
+  background: var(--mobsf-bg-darker);
+  color: var(--mobsf-text-light);
+  padding: var(--mobsf-spacing-sm) var(--mobsf-spacing-md);
+  border-radius: var(--mobsf-radius-sm);
+  font-family: var(--mobsf-font-mono);
+  font-size: 0.85rem;
+  margin-top: var(--mobsf-spacing-sm);
+  overflow-x: auto;
+}
+
+.mobsf-error-card .error-technical {
+  border-top: 1px solid var(--mobsf-border);
+  padding-top: var(--mobsf-spacing-md);
+  margin-top: var(--mobsf-spacing-md);
+}
+
+.mobsf-error-card .error-toggle {
+  background: none;
+  border: none;
+  color: var(--mobsf-primary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--mobsf-spacing-xs);
+  padding: 0;
+}
+
+.mobsf-error-card .error-toggle:hover {
+  text-decoration: underline;
+}
+
+.mobsf-error-card .error-technical-details {
+  display: none;
+  margin-top: var(--mobsf-spacing-md);
+  background: var(--mobsf-bg-dark);
+  padding: var(--mobsf-spacing-md);
+  border-radius: var(--mobsf-radius-md);
+  font-family: var(--mobsf-font-mono);
+  font-size: 0.8rem;
+  color: var(--mobsf-text-light);
+  overflow-x: auto;
+}
+
+.mobsf-error-card .error-technical-details.show {
+  display: block;
+}
+
+/* ============================================
+   Responsive Utilities
+   ============================================ */
+@media (max-width: 768px) {
+  /* .workflow-step is also used by dynamic_analyzer.html's own dashboard */
+  .workflow-step {
+    min-width: 100%;
+  }
+}
+
+/* ============================================
+   Animations
+   ============================================ */
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideUp {
+  from { 
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to { 
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in {
+  animation: fadeIn 0.3s ease-out;
+}
+
+.animate-slide-up {
+  animation: slideUp 0.3s ease-out;
+}
+

--- a/mobsf/static/others/css/mobsf-modern.css
+++ b/mobsf/static/others/css/mobsf-modern.css
@@ -336,3 +336,77 @@
   animation: slideUp 0.3s ease-out;
 }
 
+/* ============================================
+   Responsive Navbar (mobile link menu)
+   ============================================ */
+@media (max-width: 575.98px) {
+  #navLinksCollapse.show {
+    background: var(--bg-surface, #111820);
+    border-top: 1px solid var(--border-subtle, rgba(48,54,61,0.6));
+    padding: 4px 8px 10px;
+    flex-direction: column;
+    align-items: stretch !important;
+  }
+  #navLinksCollapse .navbar-nav,
+  #navLinksCollapse .nav-item {
+    width: 100%;
+    margin-left: 0 !important;
+  }
+  #navLinksCollapse .nav-item {
+    border-bottom: 1px solid var(--border-subtle, rgba(48,54,61,0.6));
+  }
+  #navLinksCollapse .nav-item:last-child {
+    border-bottom: none;
+  }
+  #navLinksCollapse .nav-link {
+    padding: 10px 8px !important;
+  }
+  #navLinksCollapse .dropdown-toggle {
+    border-radius: 0 !important;
+    background: none !important;
+    border: none !important;
+  }
+  #navLinksCollapse .dropdown-menu {
+    position: static !important;
+    width: 100%;
+    box-shadow: none !important;
+    margin-top: 4px;
+  }
+  #navLinksCollapse form.d-flex {
+    width: 100%;
+    margin: 8px 0;
+  }
+  #navLinksCollapse form .input-group {
+    width: 100% !important;
+  }
+}
+
+/* ============================================
+   Sidebar-mini pages (report/compare views) on
+   mobile: force the sidebar fully off-canvas by
+   default and only bring it on screen once the
+   pushmenu toggle adds body.sidebar-open (AdminLTE
+   already manages that class; this just guarantees
+   the visual result regardless of the exact pixel
+   width AdminLTE's own off-canvas margin assumes).
+   ============================================ */
+@media (max-width: 767.98px) {
+  body:not(.sidebar-open) .main-sidebar {
+    transform: translateX(-100%) !important;
+    margin-left: 0 !important;
+    box-shadow: none !important;
+  }
+  body.sidebar-open .main-sidebar {
+    transform: translateX(0) !important;
+    margin-left: 0 !important;
+    width: 250px !important;
+    box-shadow: 2px 0 20px rgba(0,0,0,0.6) !important;
+  }
+  body.sidebar-open #sidebar-overlay {
+    display: block !important;
+  }
+  body:not(.sidebar-open) #sidebar-overlay {
+    display: none !important;
+  }
+}
+

--- a/mobsf/templates/403.html
+++ b/mobsf/templates/403.html
@@ -1,49 +1,71 @@
 {% load static %}
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>Forbidden</title>
+  <title>403 — Forbidden | MobSF</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Mobile Security Framework - MobSF">
-  <meta name="author" content="Ajin Abraham">
   <link rel="icon" href="{% static "img/favicon.ico" %}">
-
-  <!-- Tell the browser to be responsive to screen width -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- Theme style -->
+  <link rel="stylesheet" href="{% static "adminlte/plugins/fontawesome-free/css/all.min.css" %}">
   <link rel="stylesheet" href="{% static "adminlte/dashboard/css/adminlte.min.css" %}">
-  <!-- Google Font: Source Sans Pro -->
-  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+  <link rel="stylesheet" href="{% static "others/css/error-pages.css" %}">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --accent-code: #f85149;
+      --accent-code-rgb: 248,81,73;
+      --card-border: rgba(248,81,73,0.2);
+      --card-glow: 0 0 40px rgba(248,81,73,0.04);
+    }
+
+    .access-denied-badge {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: rgba(var(--accent-code-rgb),0.08);
+      border: 1px solid rgba(var(--accent-code-rgb),0.2);
+      border-radius: 8px;
+      color: var(--accent-code);
+      font-family: var(--font-mono);
+      font-size: 12px; font-weight: 700;
+      padding: 8px 16px;
+      margin-bottom: 24px;
+      letter-spacing: 0.5px;
+    }
+  </style>
 </head>
-<body class="hold-transition sidebar-collapse layout-fixed layout-navbar-fixed">
-<div class="wrapper">
- {% include "base/nav.html" %}
-<div class="content-wrapper">
-    <div class="content-header">
-    </div>
-     <div class="container-fluid">
-          <div class="row">
-              <div class="col-lg-12">
-              <div class="card">
-                <div class="card-body">
-                  <h2>Forbidden</h2>
-                    <p class="lead">You do not have required permissions to perform this action.</p>
-            </div>
-          </div>
-         </div>
-       </div>
-      </div>
+<body>
+
+  <div class="nav-bar">
+    <a href="{% url 'home' %}" class="nav-logo">
+      <img src="{% static "img/mobsf_icon.png" %}" alt="MobSF" style="width:24px;height:24px;border-radius:5px;">
+      <span>Mob</span>SF
+    </a>
+    <a href="{% url 'home' %}" class="nav-link-muted">DASHBOARD</a>
   </div>
 
-  <!-- /.content-wrapper -->
-  <footer class="main-footer">
-    <strong>© {% now "Y" %} Mobile Security Framework - MobSF | <a href="https://ajinabraham.com">Ajin Abraham</a> | <a href="https://opensecurity.in">OpenSecurity</a>.</strong>
-  </footer>
- 
-</div>
-<!-- ./wrapper -->
+  <div class="error-wrap">
+    <div class="error-code">403</div>
+
+    <div class="error-card">
+      <div class="error-icon"><i class="fas fa-ban"></i></div>
+      <h1 class="error-title">Access Forbidden</h1>
+      <div class="access-denied-badge">
+        <i class="fas fa-lock" style="font-size:11px;"></i>
+        PERMISSION DENIED
+      </div>
+      <p class="error-desc">
+        You don't have the required permissions to perform this action or access this resource. Contact your administrator if you believe this is an error.
+      </p>
+      <div>
+        <a href="{% url 'home' %}" class="btn-home">
+          <i class="fas fa-home"></i> Go to Dashboard
+        </a>
+        <a onclick="history.back();return false;" href="#" class="btn-back">
+          <i class="fas fa-arrow-left"></i> Go Back
+        </a>
+      </div>
+    </div>
+  </div>
 
 </body>
 </html>

--- a/mobsf/templates/404.html
+++ b/mobsf/templates/404.html
@@ -1,48 +1,64 @@
 {% load static %}
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>Not Found</title>
+  <title>404 — Not Found | MobSF</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Mobile Security Framework - MobSF">
-  <meta name="author" content="Ajin Abraham">
   <link rel="icon" href="{% static "img/favicon.ico" %}">
-
-  <!-- Tell the browser to be responsive to screen width -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- Theme style -->
+  <link rel="stylesheet" href="{% static "adminlte/plugins/fontawesome-free/css/all.min.css" %}">
   <link rel="stylesheet" href="{% static "adminlte/dashboard/css/adminlte.min.css" %}">
-  <!-- Google Font: Source Sans Pro -->
-  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+  <link rel="stylesheet" href="{% static "others/css/error-pages.css" %}">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --accent-code: #58a6ff;
+      --accent-code-rgb: 88,166,255;
+    }
+
+    .error-path {
+      background: var(--bg-surface);
+      border: 1px solid var(--border-sub);
+      border-radius: 8px;
+      color: var(--text-muted);
+      font-family: var(--font-mono);
+      font-size: 12px;
+      padding: 10px 16px;
+      margin-bottom: 24px;
+    }
+  </style>
 </head>
-<body class="hold-transition sidebar-collapse layout-fixed layout-navbar-fixed">
-<div class="wrapper">
- {% include "base/nav.html" %}    
- <div class="content-wrapper">
-  <div class="content-header">
+<body>
+
+  <div class="nav-bar">
+    <a href="{% url 'home' %}" class="nav-logo">
+      <img src="{% static "img/mobsf_icon.png" %}" alt="MobSF" style="width:24px;height:24px;border-radius:5px;">
+      <span>Mob</span>SF
+    </a>
+    <a href="{% url 'recent' %}" class="nav-link-muted">RECENT SCANS</a>
   </div>
-   <div class="container-fluid">
-        <div class="row">
-            <div class="col-lg-12">
-            <div class="card">
-              <div class="card-body">
-                 <h3>Not Found</h3>
-                    <p class="lead">We couldn't find the resource you are looking for.</p>
-          </div>
-        </div>
-       </div>
-     </div>
+
+  <div class="error-wrap">
+    <div class="error-code">404</div>
+
+    <div class="error-card">
+      <div class="error-icon"><i class="fas fa-search"></i></div>
+      <h1 class="error-title">Page Not Found</h1>
+      <p class="error-desc">
+        We couldn't locate the resource you're looking for. It may have been moved, deleted, or never existed.
+      </p>
+      <div class="error-path">{{ request.path|default:"/ unknown path" }}</div>
+      <div>
+        <a href="{% url 'home' %}" class="btn-home">
+          <i class="fas fa-home"></i> Go to Dashboard
+        </a>
+        <a onclick="history.back();return false;" href="#" class="btn-back">
+          <i class="fas fa-arrow-left"></i> Go Back
+        </a>
+      </div>
     </div>
-</div>
-  <!-- /.content-wrapper -->
-  <footer class="main-footer">
-    <strong>© {% now "Y" %} Mobile Security Framework - MobSF | <a href="https://ajinabraham.com">Ajin Abraham</a> | <a href="https://opensecurity.in">OpenSecurity</a>.</strong>
-  </footer>
- 
-</div>
-<!-- ./wrapper -->
+  </div>
 
 </body>
 </html>

--- a/mobsf/templates/500.html
+++ b/mobsf/templates/500.html
@@ -1,82 +1,110 @@
 {% load static %}
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>Internal Server Error</title>
+  <title>500 — Server Error | MobSF</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Mobile Security Framework - MobSF">
-  <meta name="author" content="Ajin Abraham">
   <link rel="icon" href="{% static "img/favicon.ico" %}">
-
-  <!-- Tell the browser to be responsive to screen width -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- Theme style -->
+  <link rel="stylesheet" href="{% static "adminlte/plugins/fontawesome-free/css/all.min.css" %}">
   <link rel="stylesheet" href="{% static "adminlte/dashboard/css/adminlte.min.css" %}">
-  <!-- Google Font: Source Sans Pro -->
-  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+  <link rel="stylesheet" href="{% static "others/css/error-pages.css" %}">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --accent-code: #e3b341;
+      --accent-code-rgb: 227,179,65;
+      --card-border: rgba(227,179,65,0.2);
+      --card-glow: 0 0 40px rgba(227,179,65,0.03);
+      --card-max-width: 520px;
+    }
+
+    .debug-tip {
+      background: var(--bg-surface);
+      border: 1px solid var(--border-sub);
+      border-left: 3px solid var(--accent-code);
+      border-radius: 8px;
+      padding: 14px 16px;
+      text-align: left;
+      margin-bottom: 24px;
+    }
+
+    .debug-tip p {
+      color: var(--text-sec);
+      font-size: 12.5px;
+      margin: 0;
+      line-height: 1.6;
+    }
+
+    .debug-tip code {
+      background: rgba(var(--accent-code-rgb),0.08);
+      border: 1px solid rgba(var(--accent-code-rgb),0.15);
+      border-radius: 5px;
+      color: var(--accent-code);
+      font-family: var(--font-mono);
+      font-size: 12px;
+      padding: 1px 6px;
+    }
+
+    .btn-reload {
+      display: inline-flex;
+      align-items: center; gap: 8px;
+      background: rgba(var(--accent-code-rgb),0.08);
+      border: 1px solid rgba(var(--accent-code-rgb),0.2);
+      border-radius: 10px;
+      color: var(--accent-code);
+      font-size: 13.5px; font-weight: 700;
+      padding: 11px 24px;
+      text-decoration: none;
+      cursor: pointer;
+      transition: all 0.18s ease;
+      margin: 4px;
+    }
+    .btn-reload:hover {
+      background: rgba(var(--accent-code-rgb),0.15);
+      color: var(--accent-code);
+      text-decoration: none;
+      transform: translateY(-1px);
+    }
+  </style>
 </head>
-<body class="hold-transition sidebar-collapse layout-fixed layout-navbar-fixed">
-<div class="wrapper">
+<body>
 
-    <!-- Navbar -->
-    <nav class="main-header navbar navbar-expand navbar-dark navbar-primary">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-            <a id="nbar" class="nav-link" data-widget="pushmenu" href="#"><i class="fas fa-bars"></i></a>
-          </li>
-      </ul>
-      <!-- Right navbar links -->
-      <ul class="navbar-nav ml-auto">
-          <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'recent' %}" class="nav-link">RECENT SCANS</a></li>
-          <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'home' %}" class="nav-link">STATIC ANALYZER</a></li>
-          <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'dynamic' %}" class="nav-link">DYNAMIC ANALYZER</a></li>
-          <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'api_docs' %}" class="nav-link">API</a></li>
-          <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'donate' %}" class="nav-link">DONATE ♥</a></li>
-          <li class="nav-item d-none d-sm-inline-block"><a target="_blank" href="https://mobsf.github.io/docs/#/" class="nav-link">DOCS</a></li>
-          <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'about' %}" class="nav-link">ABOUT</a></li>
-  
-      <!-- SEARCH FORM -->
-      <form class="form-inline ml-3" action="/search" method="GET">
-        <div class="input-group input-group-sm">
-          <input class="form-control form-control-navbar" id="navbar-search-input" type="search" placeholder="Search" name="query" aria-label="Search">
-          <div class="input-group-append">
-            <button class="btn btn-navbar" type="submit">
-              <i class="fas fa-search"></i>
-            </button>
-          </div>
-        </div>
-      </form>
-  
-    </ul>
-    </nav>
-    <!-- /.navbar -->
-  
-
- <div class="content-wrapper">
-  <div class="content-header">
+  <div class="nav-bar">
+    <a href="{% url 'home' %}" class="nav-logo">
+      <img src="{% static "img/mobsf_icon.png" %}" alt="MobSF" style="width:24px;height:24px;border-radius:5px;">
+      <span>Mob</span>SF
+    </a>
   </div>
-   <div class="container-fluid">
-        <div class="row">
-            <div class="col-lg-12">
-            <div class="card">
-              <div class="card-body">
-                 <h3>Server Error (500)</h3>
-                    <p class="lead">This request caused an Internal Server error. Check the server logs for more details. For debugging, try setting <code>DEBUG=True</code> in settings.py</p>
-          </div>
-        </div>
-       </div>
-     </div>
+
+  <div class="error-wrap">
+    <div class="error-code">500</div>
+
+    <div class="error-card">
+      <div class="error-icon"><i class="fas fa-exclamation-triangle"></i></div>
+      <h1 class="error-title">Internal Server Error</h1>
+      <p class="error-desc">
+        Something went wrong on our end while processing your request. The server encountered an unexpected condition.
+      </p>
+
+      <div class="debug-tip">
+        <p>
+          <strong style="color:var(--text-pri);">For debugging:</strong> check the server logs for more details.
+          You can also enable verbose output by setting <code>DEBUG=True</code> in <code>settings.py</code>.
+        </p>
+      </div>
+
+      <div>
+        <a href="{% url 'home' %}" class="btn-home">
+          <i class="fas fa-home"></i> Go to Dashboard
+        </a>
+        <a onclick="location.reload();return false;" href="#" class="btn-reload">
+          <i class="fas fa-redo"></i> Retry
+        </a>
+      </div>
     </div>
-</div>
-  <!-- /.content-wrapper -->
-  <footer class="main-footer">
-    <strong>© {% now "Y" %} Mobile Security Framework - MobSF | <a href="https://ajinabraham.com">Ajin Abraham</a> | <a href="https://opensecurity.in">OpenSecurity</a>.</strong>
-  </footer>
- 
-</div>
-<!-- ./wrapper -->
+  </div>
 
 </body>
 </html>

--- a/mobsf/templates/auth/change_password.html
+++ b/mobsf/templates/auth/change_password.html
@@ -3,79 +3,233 @@
 {% block sidebar_option %}
 sidebar-collapse
 {% endblock %}
+{% block extra_css %}
+<link rel="stylesheet" href="{% static "others/css/auth-pages.css" %}">
+<style>
+  .auth-page::after {
+    content: '';
+    position: fixed;
+    top: -30%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 800px;
+    height: 500px;
+    background: radial-gradient(ellipse at center, rgba(227,179,65,0.04) 0%, transparent 70%);
+    pointer-events: none;
+  }
+
+  .auth-icon-wrap {
+    width: 64px;
+    height: 64px;
+    background: linear-gradient(135deg, #2a2010 0%, #1a1508 100%);
+    border: 1px solid rgba(227,179,65,0.25);
+    border-radius: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 26px;
+    color: var(--accent-yellow, #e3b341);
+    margin-bottom: 16px;
+  }
+
+  .auth-input:focus {
+    border-color: var(--accent-yellow, #e3b341) !important;
+    box-shadow: 0 0 0 3px rgba(227,179,65,0.1) !important;
+  }
+
+  .auth-btn {
+    width: 100%;
+    background: linear-gradient(135deg, #2a1f08 0%, #3a2b0a 100%);
+    border: 1px solid rgba(227,179,65,0.3);
+    color: var(--accent-yellow, #e3b341);
+    font-weight: 700;
+    font-size: 14px;
+    padding: 12px;
+    border-radius: 10px;
+    cursor: pointer;
+    margin-top: 6px;
+    transition: all 0.2s ease;
+    letter-spacing: 0.3px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .auth-btn::before {
+    content: '';
+    position: absolute;
+    top: 0; left: -100%;
+    width: 100%; height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.04), transparent);
+    transition: left 0.5s ease;
+  }
+
+  .auth-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 24px rgba(227,179,65,0.15);
+    border-color: rgba(227,179,65,0.5);
+    background: linear-gradient(135deg, #3a2b0a 0%, #4a3710 100%);
+  }
+
+  .auth-btn:hover::before { left: 100%; }
+  .auth-btn:active { transform: translateY(0); }
+
+  .password-strength {
+    margin-top: 6px;
+    height: 3px;
+    border-radius: 3px;
+    background: var(--border-default, #30363d);
+    overflow: hidden;
+  }
+
+  .password-strength-bar {
+    height: 100%;
+    border-radius: 3px;
+    width: 0%;
+    transition: all 0.3s ease;
+    background: var(--accent-red, #f85149);
+  }
+
+  .security-note {
+    background: rgba(227,179,65,0.06);
+    border: 1px solid rgba(227,179,65,0.15);
+    border-radius: 8px;
+    padding: 10px 14px;
+    margin-bottom: 20px;
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+  }
+
+  .security-note i {
+    color: var(--accent-yellow, #e3b341);
+    font-size: 13px;
+    margin-top: 1px;
+    flex-shrink: 0;
+  }
+
+  .security-note p {
+    color: var(--text-secondary, #8b949e);
+    font-size: 12px;
+    margin: 0;
+    line-height: 1.5;
+  }
+</style>
+{% endblock %}
 {% block content %}
-<div class="content-wrapper">
-   <div class="content-header">
-   </div>
-   <div class="container-fluid">
-      <div class="row">
-         <div class="col-lg-12">
-            <div class="card">
-               <div class="card-body">
-                  <div class="h-100 d-flex align-items-center justify-content-center">
-                     <div class="login-box">
-                        <div class="login-logo">
-                           <a href="">Change Password</a>
-                        </div>
-                        <div class="card">
-                           <div class="card-body login-card-body">
-                              <form method="post">
-                                 {% csrf_token %}
-                                 {% if messages %}
-                                <ul class="messages">
-                                    {% for message in messages %}
-                                    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-                                    {% endfor %}
-                                </ul>
-                                {% endif %}
-                                 {{ form.non_field_errors }}
-                                 <div class="input-group mb-3">
-                                    <input type="password" name="old_password" class="form-control" placeholder="Current Password"  autocomplete="current-password" autofocus="" required="" id="id_old_password">
-                                    <div class="input-group-append">
-                                       <div class="input-group-text">
-                                          <span class="fas fa-lock"></span>
-                                       </div>
-                                    </div>
-                                 </div>
-                                 {% for err in form.old_password.errors %}
-                                 <small> {{ err }} </small><br>
-                                 {% endfor %}
-                                 <div class="input-group mb-3">
-                                    <input type="password" name="new_password1" class="form-control" placeholder="New Password" autocomplete="new-password" required="" id="id_new_password1">
-                                    <div class="input-group-append">
-                                       <div class="input-group-text">
-                                          <span class="fas fa-lock"></span>
-                                       </div>
-                                    </div>
-                                 </div>
-                                 {% for err in form.new_password1.errors %}
-                                 <small> {{ err }} </small><br>
-                                 {% endfor %}
-                                 <div class="input-group mb-3">
-                                    <input type="password" name="new_password2" class="form-control" placeholder="Confirm Password" autocomplete="new-password" required="" id="id_new_password2">
-                                    <div class="input-group-append">
-                                       <div class="input-group-text">
-                                          <span class="fas fa-lock"></span>
-                                       </div>
-                                    </div>
-                                 </div>
-                                 {% for err in form.new_password2.errors %}
-                                 <small> {{ err }} </small><br>
-                                 {% endfor %}
-                                 <div class="row">
-                                    <div class="col-6">
-                                       <button type="submit" class="btn btn-primary btn-block">Update Password</button>
-                                    </div>
-                                 </div>
-                              </form>
-                           </div>
-                        </div>
-                     </div>
-                  </div>
-               </div>
-            </div>
-         </div>
+<div class="auth-page">
+  <div class="content-wrapper" style="background:transparent;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:20px;">
+    <div class="auth-card">
+
+      <div class="auth-brand">
+        <div class="auth-icon-wrap">
+          <i class="fas fa-key"></i>
+        </div>
+        <h1 class="auth-title">Change Password</h1>
+        <p class="auth-subtitle">Update your account credentials securely</p>
       </div>
-   </div>
+
+      <div class="security-note">
+        <i class="fas fa-shield-alt"></i>
+        <p>Use a strong password with letters, numbers and symbols. Avoid reusing passwords from other services.</p>
+      </div>
+
+      <form method="post">
+        {% csrf_token %}
+
+        {% if messages %}
+        <ul class="messages">
+          {% for message in messages %}
+          <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>
+            <i class="fas fa-check-circle"></i> {{ message }}
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if form.non_field_errors %}
+        <div class="error-box">
+          <i class="fas fa-exclamation-circle"></i>
+          {{ form.non_field_errors }}
+        </div>
+        {% endif %}
+
+        <!-- Current Password -->
+        <div class="auth-input-group">
+          <label class="auth-label">Current Password</label>
+          <input type="password" name="old_password" class="auth-input"
+                 placeholder="Enter your current password"
+                 autocomplete="current-password" autofocus required id="id_old_password">
+          <i class="fas fa-lock auth-input-icon"></i>
+          {% for err in form.old_password.errors %}
+          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+          {% endfor %}
+        </div>
+
+        <div class="auth-divider"></div>
+
+        <!-- New Password -->
+        <div class="auth-input-group">
+          <label class="auth-label">New Password</label>
+          <input type="password" name="new_password1" class="auth-input"
+                 placeholder="Create a strong new password"
+                 autocomplete="new-password" required id="id_new_password1">
+          <i class="fas fa-lock auth-input-icon"></i>
+          <div class="password-strength">
+            <div class="password-strength-bar" id="strength-bar"></div>
+          </div>
+          {% for err in form.new_password1.errors %}
+          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+          {% endfor %}
+        </div>
+
+        <!-- Confirm Password -->
+        <div class="auth-input-group" style="margin-bottom:20px;">
+          <label class="auth-label">Confirm New Password</label>
+          <input type="password" name="new_password2" class="auth-input"
+                 placeholder="Repeat the new password"
+                 autocomplete="new-password" required id="id_new_password2">
+          <i class="fas fa-check-circle auth-input-icon" id="match-icon" style="display:none;color:var(--accent-green);"></i>
+          <i class="fas fa-lock auth-input-icon" id="lock-icon"></i>
+          {% for err in form.new_password2.errors %}
+          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+          {% endfor %}
+        </div>
+
+        <button type="submit" class="auth-btn">
+          <i class="fas fa-key" style="margin-right:8px;"></i>Update Password
+        </button>
+      </form>
+
+    </div>
+  </div>
 </div>
+<script>
+  // Password strength indicator
+  document.getElementById('id_new_password1').addEventListener('input', function() {
+    var val = this.value;
+    var bar = document.getElementById('strength-bar');
+    var strength = 0;
+    if (val.length >= 8) strength += 25;
+    if (/[A-Z]/.test(val)) strength += 25;
+    if (/[0-9]/.test(val)) strength += 25;
+    if (/[^A-Za-z0-9]/.test(val)) strength += 25;
+    bar.style.width = strength + '%';
+    bar.style.background = strength <= 25 ? '#f85149' : strength <= 50 ? '#e3b341' : strength <= 75 ? '#58a6ff' : '#3fb950';
+  });
+
+  // Password match indicator
+  document.getElementById('id_new_password2').addEventListener('input', function() {
+    var p1 = document.getElementById('id_new_password1').value;
+    var p2 = this.value;
+    var matchIcon = document.getElementById('match-icon');
+    var lockIcon = document.getElementById('lock-icon');
+    if (p2.length > 0 && p1 === p2) {
+      matchIcon.style.display = 'block';
+      lockIcon.style.display = 'none';
+    } else {
+      matchIcon.style.display = 'none';
+      lockIcon.style.display = 'block';
+    }
+  });
+</script>
 {% endblock %}

--- a/mobsf/templates/auth/login.html
+++ b/mobsf/templates/auth/login.html
@@ -1,84 +1,207 @@
 {% extends "base/base_layout.html" %}
 {% load static %}
-{% block sidebar_option %}
-sidebar-collapse
+{% block sidebar_option %}sidebar-collapse{% endblock %}
+{% block extra_css %}
+<link rel="stylesheet" href="{% static "others/css/auth-pages.css" %}">
+<style>
+  /* Radial glow spot (page-specific accent) */
+  .auth-page::after {
+    content: '';
+    position: fixed;
+    top: -30%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 800px;
+    height: 500px;
+    background: radial-gradient(ellipse at center, rgba(35,134,54,0.06) 0%, transparent 70%);
+    pointer-events: none;
+  }
+
+  .auth-icon-wrap {
+    width: 72px;
+    height: 72px;
+    background: linear-gradient(135deg, #1a3a28 0%, #0d2618 100%);
+    border: 1px solid rgba(63,185,80,0.25);
+    border-radius: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 30px;
+    color: var(--accent-green, #3fb950);
+    margin-bottom: 18px;
+    position: relative;
+  }
+
+  .auth-icon-wrap::before {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(63,185,80,0.2), transparent);
+    z-index: -1;
+  }
+
+  .auth-input:focus {
+    border-color: var(--accent-blue, #58a6ff) !important;
+    box-shadow: 0 0 0 3px rgba(88,166,255,0.12) !important;
+  }
+
+  .auth-btn {
+    width: 100%;
+    background: linear-gradient(135deg, #238636 0%, #2ea043 100%);
+    border: none;
+    color: #fff;
+    font-weight: 700;
+    font-size: 14px;
+    padding: 12px;
+    border-radius: 10px;
+    cursor: pointer;
+    margin-top: 8px;
+    transition: all 0.2s ease;
+    letter-spacing: 0.3px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .auth-btn::before {
+    content: '';
+    position: absolute;
+    top: 0; left: -100%;
+    width: 100%; height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent);
+    transition: left 0.5s ease;
+  }
+
+  .auth-btn:hover { transform: translateY(-1px); box-shadow: 0 8px 24px rgba(35,134,54,0.35); }
+  .auth-btn:hover::before { left: 100%; }
+  .auth-btn:active { transform: translateY(0); }
+
+  .sso-divider {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 22px 0;
+    color: var(--text-muted, #484f58);
+    font-size: 12px;
+  }
+  .sso-divider::before, .sso-divider::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--border-subtle, rgba(48,54,61,0.6));
+  }
+
+  .sso-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    width: 100%;
+    background: var(--bg-surface, #111820);
+    border: 1px solid var(--border-default, #30363d);
+    color: var(--text-primary, #e6edf3);
+    font-weight: 600;
+    font-size: 13.5px;
+    padding: 11px;
+    border-radius: 10px;
+    text-decoration: none;
+    transition: all 0.2s ease;
+  }
+  .sso-btn:hover {
+    background: var(--bg-elevated, #1a2233);
+    border-color: var(--accent-blue, #58a6ff);
+    color: var(--accent-blue, #58a6ff);
+    text-decoration: none;
+  }
+
+  .auth-footer {
+    text-align: center;
+    margin-top: 24px;
+    color: var(--text-muted, #484f58);
+    font-size: 12px;
+  }
+
+  .auth-footer a { color: var(--text-secondary, #8b949e); text-decoration: none; }
+  .auth-footer a:hover { color: var(--accent-blue, #58a6ff); }
+
+  /* Security indicator dots */
+  .security-dots {
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+    margin-top: 20px;
+  }
+  .security-dots span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--border-default, #30363d);
+  }
+  .security-dots span.active { background: var(--accent-green, #3fb950); }
+</style>
 {% endblock %}
 {% block content %}
-<div class="content-wrapper">
-   <div class="content-header">
-   </div>
-   <div class="container-fluid">
-      <div class="row">
-         <div class="col-lg-12">
-            <div class="card">
-               <div class="card-body">
-                  <div class="h-100 d-flex align-items-center justify-content-center">
-                     <div class="login-box">
-                        <div class="login-logo">
-                           <a href="">Sign in to access</a>
-                        </div>
-                        <div class="card">
-                           <div class="card-body login-card-body">
-                              <h1 class="display-2 h-100 d-flex align-items-center justify-content-center">
-                                 Mob<strong>SF</strong>
-                              </h1>
-                              {% if allow_pwd %}
-                              <form method="post" action="{% url 'login' %}?next={{next}}">
-                                 {% csrf_token %}
-                                 {{ form.non_field_errors }}
-                                 <div class="input-group mb-3">
-                                    <input type="username" name="username" class="form-control" placeholder="Username">
-                                    <div class="input-group-append">
-                                       <div class="input-group-text">
-                                          <span class="fas fa-user"></span>
-                                       </div>
-                                    </div>
-                                 </div>
-                                 {% for err in form.username.errors %}
-                                 <small> {{ err }} </small><br>
-                                 {% endfor %}
-                                 <div class="input-group mb-3">
-                                    <input type="password" name="password" class="form-control" placeholder="Password">
-                                    <div class="input-group-append">
-                                       <div class="input-group-text">
-                                          <span class="fas fa-lock"></span>
-                                       </div>
-                                    </div>
-                                 </div>
-                                 {% for err in form.password.errors %}
-                                 <small> {{ err }} </small><br>
-                                 {% endfor %}
-                                 <div class="row">
-                                    <!-- <div class="col-8">
-                                       <div class="icheck-primary">
-                                       <input type="checkbox" id="remember">
-                                       <label for="remember">
-                                       Remember Me
-                                       </label>
-                                       </div>
-                                       </div> -->
-                                 </div>
-                                 <div class="col-12">
-                                    <button type="submit" class="btn btn-primary btn-block">Sign In</button>
-                                 </div>
-                              </form>
-                              {% endif %}
-                              {% if sso %}
-                              <hr>
-                              <p>
-                              <div class="col-12">
-                                 <a href="{% url 'saml_login' %}?next={{next}}" class="btn btn-primary btn-block">Sign in with SSO</a>
-                              </div>
-                              </p>
-                              {% endif %}
-                           </div>
-                        </div>
-                     </div>
-                  </div>
-               </div>
-            </div>
-         </div>
+<div class="auth-page">
+  <div class="content-wrapper" style="background:transparent;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:20px;">
+    <div class="auth-card">
+      <div class="auth-brand">
+        <div class="auth-icon-wrap">
+          <i class="fas fa-shield-alt"></i>
+        </div>
+        <h1 class="auth-title">Mobile Security Framework</h1>
+        <p class="auth-subtitle">Sign in to access the security analyzer</p>
       </div>
-   </div>
+
+      {% if allow_pwd %}
+      <form method="post" action="{% url 'login' %}?next={{next}}">
+        {% csrf_token %}
+
+        {% if form.non_field_errors %}
+        <div class="error-box">
+          <i class="fas fa-exclamation-circle"></i>
+          {{ form.non_field_errors }}
+        </div>
+        {% endif %}
+
+        <div class="auth-input-group">
+          <label class="auth-label">Username</label>
+          <input type="text" name="username" class="auth-input" placeholder="Enter your username" required autocomplete="username">
+          <i class="fas fa-user auth-input-icon"></i>
+          {% for err in form.username.errors %}<small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>{% endfor %}
+        </div>
+
+        <div class="auth-input-group" style="margin-bottom:20px;">
+          <label class="auth-label">Password</label>
+          <input type="password" name="password" class="auth-input" placeholder="Enter your password" required autocomplete="current-password">
+          <i class="fas fa-lock auth-input-icon"></i>
+          {% for err in form.password.errors %}<small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>{% endfor %}
+        </div>
+
+        <button type="submit" class="auth-btn">
+          <i class="fas fa-sign-in-alt" style="margin-right:8px;"></i>Sign In
+        </button>
+      </form>
+      {% endif %}
+
+      {% if sso %}
+      <div class="sso-divider"><span>or continue with</span></div>
+      <a href="{% url 'saml_login' %}?next={{next}}" class="sso-btn">
+        <i class="fas fa-id-card"></i> Single Sign-On (SSO)
+      </a>
+      {% endif %}
+
+      <div class="auth-footer">
+        <p style="margin:0;">MobSF v{{ version|default:"3.0" }} &nbsp;·&nbsp; © {% now "Y" %} OpenSecurity</p>
+      </div>
+
+      <div class="security-dots">
+        <span class="active"></span>
+        <span class="active"></span>
+        <span class="active"></span>
+        <span></span>
+        <span></span>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/mobsf/templates/auth/register.html
+++ b/mobsf/templates/auth/register.html
@@ -3,105 +3,267 @@
 {% block sidebar_option %}
 sidebar-collapse
 {% endblock %}
+{% block extra_css %}
+<link rel="stylesheet" href="{% static "others/css/auth-pages.css" %}">
+<style>
+  .auth-page::after {
+    content: '';
+    position: fixed;
+    top: -30%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 800px;
+    height: 500px;
+    background: radial-gradient(ellipse at center, rgba(88,166,255,0.05) 0%, transparent 70%);
+    pointer-events: none;
+  }
+
+  .auth-card {
+    max-width: 460px;
+  }
+
+  .auth-icon-wrap {
+    width: 64px;
+    height: 64px;
+    background: linear-gradient(135deg, #1a2a3a 0%, #0d1a2e 100%);
+    border: 1px solid rgba(88,166,255,0.25);
+    border-radius: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 26px;
+    color: var(--accent-blue, #58a6ff);
+    margin-bottom: 16px;
+  }
+
+  .auth-input:focus {
+    border-color: var(--accent-blue, #58a6ff) !important;
+    box-shadow: 0 0 0 3px rgba(88,166,255,0.12) !important;
+  }
+
+  .auth-select {
+    width: 100%;
+    background: var(--bg-input, #0d1117) !important;
+    border: 1px solid var(--border-default, #30363d) !important;
+    color: var(--text-primary, #e6edf3) !important;
+    border-radius: 10px !important;
+    padding: 10px 40px 10px 14px !important;
+    font-size: 13.5px !important;
+    transition: all 0.2s ease;
+    outline: none;
+    appearance: none;
+    -webkit-appearance: none;
+    cursor: pointer;
+  }
+
+  .auth-select:focus {
+    border-color: var(--accent-blue, #58a6ff) !important;
+    box-shadow: 0 0 0 3px rgba(88,166,255,0.12) !important;
+  }
+
+  .auth-select option {
+    background: var(--bg-elevated, #1a2233);
+    color: var(--text-primary, #e6edf3);
+  }
+
+  .auth-btn {
+    width: 100%;
+    background: linear-gradient(135deg, #1a3a5e 0%, #1e4a7a 100%);
+    border: 1px solid rgba(88,166,255,0.3);
+    color: #fff;
+    font-weight: 700;
+    font-size: 14px;
+    padding: 12px;
+    border-radius: 10px;
+    cursor: pointer;
+    margin-top: 6px;
+    transition: all 0.2s ease;
+    letter-spacing: 0.3px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .auth-btn::before {
+    content: '';
+    position: absolute;
+    top: 0; left: -100%;
+    width: 100%; height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.06), transparent);
+    transition: left 0.5s ease;
+  }
+
+  .auth-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 24px rgba(88,166,255,0.2);
+    border-color: rgba(88,166,255,0.5);
+  }
+
+  .auth-btn:hover::before { left: 100%; }
+  .auth-btn:active { transform: translateY(0); }
+
+  .auth-footer {
+    text-align: center;
+    margin-top: 20px;
+    color: var(--text-muted, #484f58);
+    font-size: 12px;
+  }
+
+  .role-pills {
+    display: flex;
+    gap: 8px;
+  }
+
+  .role-pill-label {
+    flex: 1;
+    cursor: pointer;
+  }
+
+  .role-pill-label input[type="radio"] {
+    display: none;
+  }
+
+  .role-pill-content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border: 1px solid var(--border-default, #30363d);
+    border-radius: 10px;
+    background: var(--bg-input, #0d1117);
+    color: var(--text-secondary, #8b949e);
+    font-size: 13px;
+    font-weight: 600;
+    transition: all 0.18s ease;
+    cursor: pointer;
+  }
+
+  .role-pill-label input[type="radio"]:checked + .role-pill-content {
+    border-color: rgba(88,166,255,0.5);
+    background: rgba(88,166,255,0.08);
+    color: var(--accent-blue, #58a6ff);
+  }
+
+  .role-pill-content:hover {
+    border-color: rgba(88,166,255,0.3);
+    color: var(--text-primary, #e6edf3);
+  }
+</style>
+{% endblock %}
 {% block content %}
-<div class="content-wrapper">
-   <div class="content-header">
-   </div>
-   <div class="container-fluid">
-      <div class="row">
-         <div class="col-lg-12">
-            <div class="card">
-               <div class="card-body">
-                  <div class="h-100 d-flex align-items-center justify-content-center">
-                     <div class="login-box">
-                        <div class="login-logo">
-                           <a href="">Create a User</a>
-                        </div>
-                        <div class="card">
-                           <div class="card-body login-card-body">
-                              <form method="post">
-                                 {% csrf_token %}
-                                 {% if messages %}
-                                <ul class="messages">
-                                    {% for message in messages %}
-                                    <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-                                    {% endfor %}
-                                </ul>
-                                {% endif %}
-                                 {{ form.non_field_errors }}
-                                 <div class="input-group mb-3">
-                                    <input type="text" name="username" maxlength="150" autofocus="" required class="form-control" placeholder="Username"  aria-describedby="id_username_helptext" id="id_username">
-                                    <div class="input-group-append">
-                                       <div class="input-group-text">
-                                          <span class="fas fa-user"></span>
-                                       </div>
-                                    </div>
-                                 </div>
-                                 {% for err in form.username.errors %}
-                                 <small> {{ err }} </small><br>
-                                 {% endfor %}
-                                 <div class="input-group mb-3">
-                                    <input type="password" name="password1" class="form-control" placeholder="New Password" autocomplete="new-password" required id="id_password1">
-                                    <div class="input-group-append">
-                                       <div class="input-group-text">
-                                          <span class="fas fa-lock"></span>
-                                       </div>
-                                    </div>
-                                 </div>
-                                 {% for err in form.password1.errors %}
-                                 <small> {{ err }} </small><br>
-                                 {% endfor %}
-                                 <div class="input-group mb-3">
-                                    <input type="password" name="password2" class="form-control" placeholder="Confirm Password" autocomplete="new-password" required id="id_password2">
-                                    <div class="input-group-append">
-                                       <div class="input-group-text">
-                                          <span class="fas fa-lock"></span>
-                                       </div>
-                                    </div>
-                                 </div>
-                                 {% for err in form.password2.errors %}
-                                 <small> {{ err }} </small><br>
-                                 {% endfor %}
-                                 <div class="input-group mb-3">
-                                    <input type="email" name="email" maxlength="254" class="form-control" placeholder="Email" required id="id_email">
-                                    <div class="input-group-append">
-                                       <div class="input-group-text">
-                                          <span class="fa fa-envelope"></span>
-                                       </div>
-                                    </div>
-                                 </div>
-                                 {% for err in form.email.errors %}
-                                 <small> {{ err }} </small><br>
-                                 {% endfor %}
-                                 <div class="input-group mb-3">
-                                    <select name="role" class="form-control"  aria-describedby="id_role_helptext" id="id_role" required>
-                                       <option value="" disabled selected>Select Role</option>
-                                       <option value="viewer">Viewer</option>
-                                       <option value="maintainer">Maintainer</option>
-                                     </select>
-                                    <div class="input-group-append">
-                                       <div class="input-group-text">
-                                          <span class="fa fa-user-tie"></span>
-                                       </div>
-                                    </div>
-                                 </div>
-                                 {% for err in form.role.errors %}
-                                 <small> {{ err }} </small><br>
-                                 {% endfor %}
-                                 <div class="row">
-                                    <div class="col-6">
-                                       <button type="submit" class="btn btn-primary btn-block">Create User</button>
-                                    </div>
-                                 </div>
-                              </form>
-                           </div>
-                        </div>
-                     </div>
-                  </div>
-               </div>
-            </div>
-         </div>
+<div class="auth-page">
+  <div class="content-wrapper" style="background:transparent;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:20px;">
+    <div class="auth-card">
+
+      <div class="auth-brand">
+        <div class="auth-icon-wrap">
+          <i class="fas fa-user-plus"></i>
+        </div>
+        <h1 class="auth-title">Create New User</h1>
+        <p class="auth-subtitle">Add a new user account to MobSF</p>
       </div>
-   </div>
+
+      <form method="post">
+        {% csrf_token %}
+
+        {% if messages %}
+        <ul class="messages">
+          {% for message in messages %}
+          <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>
+            <i class="fas fa-info-circle"></i> {{ message }}
+          </li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if form.non_field_errors %}
+        <div class="error-box">
+          <i class="fas fa-exclamation-circle"></i>
+          {{ form.non_field_errors }}
+        </div>
+        {% endif %}
+
+        <!-- Username -->
+        <div class="auth-input-group">
+          <label class="auth-label">Username</label>
+          <input type="text" name="username" maxlength="150" autofocus required
+                 class="auth-input" placeholder="Enter username"
+                 aria-describedby="id_username_helptext" id="id_username">
+          <i class="fas fa-user auth-input-icon"></i>
+          {% for err in form.username.errors %}
+          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+          {% endfor %}
+        </div>
+
+        <!-- Email -->
+        <div class="auth-input-group">
+          <label class="auth-label">Email Address</label>
+          <input type="email" name="email" maxlength="254" required
+                 class="auth-input" placeholder="user@example.com" id="id_email">
+          <i class="fas fa-envelope auth-input-icon"></i>
+          {% for err in form.email.errors %}
+          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+          {% endfor %}
+        </div>
+
+        <div class="auth-divider"></div>
+
+        <!-- New Password -->
+        <div class="auth-input-group">
+          <label class="auth-label">Password</label>
+          <input type="password" name="password1" required autocomplete="new-password"
+                 class="auth-input" placeholder="Create a strong password" id="id_password1">
+          <i class="fas fa-lock auth-input-icon"></i>
+          {% for err in form.password1.errors %}
+          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+          {% endfor %}
+        </div>
+
+        <!-- Confirm Password -->
+        <div class="auth-input-group">
+          <label class="auth-label">Confirm Password</label>
+          <input type="password" name="password2" required autocomplete="new-password"
+                 class="auth-input" placeholder="Repeat the password" id="id_password2">
+          <i class="fas fa-lock auth-input-icon"></i>
+          {% for err in form.password2.errors %}
+          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+          {% endfor %}
+        </div>
+
+        <div class="auth-divider"></div>
+
+        <!-- Role -->
+        <div style="margin-bottom:20px;">
+          <label class="auth-label">Assign Role</label>
+          <div class="role-pills">
+            <label class="role-pill-label">
+              <input type="radio" name="role" value="viewer" required>
+              <div class="role-pill-content">
+                <i class="fas fa-eye" style="font-size:14px;"></i>
+                Viewer
+              </div>
+            </label>
+            <label class="role-pill-label">
+              <input type="radio" name="role" value="maintainer" required>
+              <div class="role-pill-content">
+                <i class="fas fa-tools" style="font-size:14px;"></i>
+                Maintainer
+              </div>
+            </label>
+          </div>
+          {% for err in form.role.errors %}
+          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+          {% endfor %}
+        </div>
+
+        <button type="submit" class="auth-btn">
+          <i class="fas fa-user-plus" style="margin-right:8px;"></i>Create User Account
+        </button>
+      </form>
+
+      <div class="auth-footer">
+        <p style="margin:0;">MobSF &nbsp;·&nbsp; User Management</p>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/mobsf/templates/auth/register.html
+++ b/mobsf/templates/auth/register.html
@@ -171,7 +171,7 @@ sidebar-collapse
         <p class="auth-subtitle">Add a new user account to MobSF</p>
       </div>
 
-      <form method="post">
+      <form method="post" onsubmit="this.querySelector('button[type=submit]').disabled = true;">
         {% csrf_token %}
 
         {% if messages %}

--- a/mobsf/templates/auth/register.html
+++ b/mobsf/templates/auth/register.html
@@ -19,7 +19,16 @@ sidebar-collapse
   }
 
   .auth-card {
-    max-width: 460px;
+    max-width: 640px;
+  }
+
+  .auth-form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  @media (max-width: 520px) {
+    .auth-form-row { grid-template-columns: 1fr; }
   }
 
   .auth-icon-wrap {
@@ -182,51 +191,55 @@ sidebar-collapse
         </div>
         {% endif %}
 
-        <!-- Username -->
-        <div class="auth-input-group">
-          <label class="auth-label">Username</label>
-          <input type="text" name="username" maxlength="150" autofocus required
-                 class="auth-input" placeholder="Enter username"
-                 aria-describedby="id_username_helptext" id="id_username">
-          <i class="fas fa-user auth-input-icon"></i>
-          {% for err in form.username.errors %}
-          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
-          {% endfor %}
-        </div>
+        <div class="auth-form-row">
+          <!-- Username -->
+          <div class="auth-input-group">
+            <label class="auth-label">Username</label>
+            <input type="text" name="username" maxlength="150" autofocus required
+                   class="auth-input" placeholder="Enter username"
+                   aria-describedby="id_username_helptext" id="id_username">
+            <i class="fas fa-user auth-input-icon"></i>
+            {% for err in form.username.errors %}
+            <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+            {% endfor %}
+          </div>
 
-        <!-- Email -->
-        <div class="auth-input-group">
-          <label class="auth-label">Email Address</label>
-          <input type="email" name="email" maxlength="254" required
-                 class="auth-input" placeholder="user@example.com" id="id_email">
-          <i class="fas fa-envelope auth-input-icon"></i>
-          {% for err in form.email.errors %}
-          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
-          {% endfor %}
+          <!-- Email -->
+          <div class="auth-input-group">
+            <label class="auth-label">Email Address</label>
+            <input type="email" name="email" maxlength="254" required
+                   class="auth-input" placeholder="user@example.com" id="id_email">
+            <i class="fas fa-envelope auth-input-icon"></i>
+            {% for err in form.email.errors %}
+            <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+            {% endfor %}
+          </div>
         </div>
 
         <div class="auth-divider"></div>
 
-        <!-- New Password -->
-        <div class="auth-input-group">
-          <label class="auth-label">Password</label>
-          <input type="password" name="password1" required autocomplete="new-password"
-                 class="auth-input" placeholder="Create a strong password" id="id_password1">
-          <i class="fas fa-lock auth-input-icon"></i>
-          {% for err in form.password1.errors %}
-          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
-          {% endfor %}
-        </div>
+        <div class="auth-form-row">
+          <!-- New Password -->
+          <div class="auth-input-group">
+            <label class="auth-label">Password</label>
+            <input type="password" name="password1" required autocomplete="new-password"
+                   class="auth-input" placeholder="Create a strong password" id="id_password1">
+            <i class="fas fa-lock auth-input-icon"></i>
+            {% for err in form.password1.errors %}
+            <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+            {% endfor %}
+          </div>
 
-        <!-- Confirm Password -->
-        <div class="auth-input-group">
-          <label class="auth-label">Confirm Password</label>
-          <input type="password" name="password2" required autocomplete="new-password"
-                 class="auth-input" placeholder="Repeat the password" id="id_password2">
-          <i class="fas fa-lock auth-input-icon"></i>
-          {% for err in form.password2.errors %}
-          <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
-          {% endfor %}
+          <!-- Confirm Password -->
+          <div class="auth-input-group">
+            <label class="auth-label">Confirm Password</label>
+            <input type="password" name="password2" required autocomplete="new-password"
+                   class="auth-input" placeholder="Repeat the password" id="id_password2">
+            <i class="fas fa-lock auth-input-icon"></i>
+            {% for err in form.password2.errors %}
+            <small class="field-error"><i class="fas fa-exclamation-circle"></i> {{ err }}</small>
+            {% endfor %}
+          </div>
         </div>
 
         <div class="auth-divider"></div>

--- a/mobsf/templates/auth/users.html
+++ b/mobsf/templates/auth/users.html
@@ -375,7 +375,7 @@ sidebar-collapse
         cancelButton: 'swal-cancel-btn',
       }
     }).then((result) => {
-      if (result.isConfirmed) {
+      if (result.value) {
         $.ajax({
           url: '{% url "delete_user" %}',
           type: 'POST',

--- a/mobsf/templates/auth/users.html
+++ b/mobsf/templates/auth/users.html
@@ -5,120 +5,420 @@ sidebar-collapse
 {% endblock %}
 {% block extra_css %}
 <link href="{% static "adminlte/plugins/sweetalert2/sweetalert2.min.css" %}" rel="stylesheet">
+<style>
+  .users-page {
+    min-height: 100vh;
+    background: var(--bg-base, #0d1117);
+    padding: 32px 20px;
+  }
+
+  .users-container {
+    max-width: 900px;
+    margin: 0 auto;
+  }
+
+  .page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 28px;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .page-header-left { display: flex; flex-direction: column; gap: 4px; }
+
+  .page-title {
+    color: var(--text-primary, #e6edf3);
+    font-size: 22px;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: -0.3px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .page-title i {
+    width: 36px;
+    height: 36px;
+    background: rgba(88,166,255,0.1);
+    border: 1px solid rgba(88,166,255,0.2);
+    border-radius: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    color: var(--accent-blue, #58a6ff);
+  }
+
+  .page-subtitle {
+    color: var(--text-secondary, #8b949e);
+    font-size: 13px;
+    margin: 0;
+  }
+
+  .add-user-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(63,185,80,0.1);
+    border: 1px solid rgba(63,185,80,0.25);
+    border-radius: 10px;
+    color: var(--accent-green, #3fb950);
+    font-size: 13px;
+    font-weight: 600;
+    padding: 9px 18px;
+    text-decoration: none;
+    transition: all 0.18s ease;
+  }
+
+  .add-user-btn:hover {
+    background: rgba(63,185,80,0.18);
+    border-color: rgba(63,185,80,0.4);
+    color: var(--accent-green, #3fb950);
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+
+  .users-card {
+    background: var(--bg-card, #161d27);
+    border: 1px solid var(--border-subtle, rgba(48,54,61,0.6));
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.3);
+  }
+
+  .users-card-header {
+    background: var(--bg-surface, #111820);
+    border-bottom: 1px solid var(--border-subtle, rgba(48,54,61,0.6));
+    padding: 16px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .users-count {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(88,166,255,0.08);
+    border: 1px solid rgba(88,166,255,0.2);
+    border-radius: 20px;
+    color: var(--accent-blue, #58a6ff);
+    font-size: 12px;
+    font-weight: 700;
+    padding: 3px 10px;
+  }
+
+  .users-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .users-table thead tr {
+    background: var(--bg-surface, #111820);
+  }
+
+  .users-table thead th {
+    padding: 12px 20px;
+    color: var(--text-secondary, #8b949e);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    border-bottom: 1px solid var(--border-subtle, rgba(48,54,61,0.6));
+    white-space: nowrap;
+  }
+
+  .users-table tbody tr {
+    border-bottom: 1px solid rgba(48,54,61,0.4);
+    transition: background 0.15s ease;
+  }
+
+  .users-table tbody tr:last-child { border-bottom: none; }
+
+  .users-table tbody tr:hover {
+    background: rgba(88,166,255,0.03);
+  }
+
+  .users-table td {
+    padding: 16px 20px;
+    vertical-align: middle;
+  }
+
+  .user-avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: 2px solid var(--border-default, #30363d);
+    object-fit: cover;
+  }
+
+  .user-name {
+    color: var(--text-primary, #e6edf3);
+    font-weight: 600;
+    font-size: 13.5px;
+  }
+
+  .user-email {
+    color: var(--text-secondary, #8b949e);
+    font-size: 12.5px;
+    margin-top: 2px;
+  }
+
+  .role-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 10px;
+    border-radius: 20px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+  }
+
+  .role-admin {
+    background: rgba(248,81,73,0.1);
+    border: 1px solid rgba(248,81,73,0.25);
+    color: var(--accent-red, #f85149);
+  }
+
+  .role-maintainer {
+    background: rgba(88,166,255,0.1);
+    border: 1px solid rgba(88,166,255,0.2);
+    color: var(--accent-blue, #58a6ff);
+  }
+
+  .role-viewer {
+    background: rgba(139,148,158,0.1);
+    border: 1px solid rgba(139,148,158,0.2);
+    color: var(--text-secondary, #8b949e);
+  }
+
+  .delete-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(248,81,73,0.08);
+    border: 1px solid rgba(248,81,73,0.2);
+    border-radius: 8px;
+    color: var(--accent-red, #f85149);
+    font-size: 12px;
+    font-weight: 600;
+    padding: 6px 12px;
+    cursor: pointer;
+    transition: all 0.18s ease;
+    text-decoration: none;
+  }
+
+  .delete-btn:hover {
+    background: rgba(248,81,73,0.15);
+    border-color: rgba(248,81,73,0.35);
+    color: var(--accent-red, #f85149);
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+
+  .empty-state {
+    padding: 60px 24px;
+    text-align: center;
+  }
+
+  .empty-icon {
+    width: 64px;
+    height: 64px;
+    background: rgba(139,148,158,0.08);
+    border: 1px solid rgba(139,148,158,0.15);
+    border-radius: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    color: var(--text-muted, #484f58);
+    margin-bottom: 16px;
+  }
+
+  .empty-title {
+    color: var(--text-primary, #e6edf3);
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0 0 6px;
+  }
+
+  .empty-sub {
+    color: var(--text-secondary, #8b949e);
+    font-size: 13px;
+    margin: 0 0 20px;
+  }
+</style>
 {% endblock %}
 {% block content %}
 <div class="content-wrapper">
-   <div class="content-header">
-   </div>
-   <div class="container-fluid">
-      <div class="row">
-         <div class="col-lg-12">
-            <div class="card">
-               <div class="card-body">
-                  <div class="h-100 d-flex align-items-center justify-content-center">
-                     <div class="">
-                        <div class="login-logo">
-                           <a href="">User Management</a>  <a href="{% url 'create_user' %}" id="add_user" class="btn btn-success" role="button"><i class="fa fa-user"></i> Add User</a>
-                        </div>
-                        <div class="card">
-                           <div class="card-body login-card-body">
-                            {% if not users %}
-                            <h3>No Users Available</h3>
-                            {% else %}
-                            <div class="table-responsive">
-                                <table class="table table-responsive-md">
-                                    <thead>
-                                        <tr>
-                                            <th><strong>#</strong></th>
-                                            <th><strong>Username</strong></th>
-                                            <th><strong>Email</strong></th>
-                                            <th><strong>Role</strong></th>
-                                            <th><strong>Manage</strong></th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {% for user in users %}
-                                                <tr>
-                                                    <td>
-                                                        <div class="profile-photo">
-                                                            <img src="https://www.gravatar.com/avatar/{{ user.email | md5}}" width="30" class="img-fluid rounded-circle" alt="">
-                                                        </div>
-                                                     </td>
-                                                    <td>{{user.username}}</td>
-                                                    <td>{{user.email}}</td>
-                                                    <td> {% if user.is_staff %}Admin{% else %} {{user.groups.all.0}}  {% endif %}</td>
-                                                    <td> {% if not user.is_staff %}
-                                                      <a class="btn btn-danger btn-sm" id="{{ user.username }}" onclick="delete_user(this)" href="#"><i class="fa fa-trash"></i> Delete </a>
-                                                      {% endif %}</td>
-                                                </tr>
-                                        {% endfor %}
-                                    </tbody>
-                                </table>
-                            </div>
-                            {% endif %}
-                           </div>
-                        </div>
-                     </div>
-                  </div>
-               </div>
-            </div>
-         </div>
+  <div class="users-page">
+    <div class="users-container">
+
+      <div class="page-header">
+        <div class="page-header-left">
+          <h1 class="page-title">
+            <i class="fas fa-users"></i>
+            User Management
+          </h1>
+          <p class="page-subtitle">Manage MobSF user accounts and permissions</p>
+        </div>
+        <a href="{% url 'create_user' %}" class="add-user-btn">
+          <i class="fas fa-user-plus"></i> Add New User
+        </a>
       </div>
-   </div>
+
+      <div class="users-card">
+        <div class="users-card-header">
+          <span style="color:var(--text-primary);font-weight:600;font-size:14px;">
+            <i class="fas fa-list" style="margin-right:8px;opacity:.6;"></i>All Accounts
+          </span>
+          {% if users %}
+          <span class="users-count">
+            <i class="fas fa-circle" style="font-size:7px;"></i>
+            {{ users|length }} user{{ users|length|pluralize }}
+          </span>
+          {% endif %}
+        </div>
+
+        {% if not users %}
+        <div class="empty-state">
+          <div class="empty-icon"><i class="fas fa-users"></i></div>
+          <p class="empty-title">No Users Found</p>
+          <p class="empty-sub">Get started by adding the first user account.</p>
+          <a href="{% url 'create_user' %}" class="add-user-btn">
+            <i class="fas fa-user-plus"></i> Create First User
+          </a>
+        </div>
+        {% else %}
+        <table class="users-table">
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Username</th>
+              <th>Email</th>
+              <th>Role</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for user in users %}
+            <tr>
+              <td>
+                <img src="https://www.gravatar.com/avatar/{{ user.email|md5 }}?d=identicon&s=80"
+                     class="user-avatar" alt="{{ user.username }}">
+              </td>
+              <td>
+                <div class="user-name">{{ user.username }}</div>
+              </td>
+              <td>
+                <div class="user-email">{{ user.email }}</div>
+              </td>
+              <td>
+                {% if user.is_staff %}
+                <span class="role-badge role-admin">
+                  <i class="fas fa-crown" style="font-size:10px;"></i> Admin
+                </span>
+                {% else %}
+                <span class="role-badge {% if user.groups.all.0|stringformat:'s' == 'maintainer' %}role-maintainer{% else %}role-viewer{% endif %}">
+                  {% if user.groups.all.0|stringformat:'s' == 'maintainer' %}
+                  <i class="fas fa-tools" style="font-size:10px;"></i>
+                  {% else %}
+                  <i class="fas fa-eye" style="font-size:10px;"></i>
+                  {% endif %}
+                  {{ user.groups.all.0 }}
+                </span>
+                {% endif %}
+              </td>
+              <td>
+                {% if not user.is_staff %}
+                <a class="delete-btn" id="{{ user.username }}" onclick="delete_user(this)" href="#">
+                  <i class="fas fa-trash-alt"></i> Remove
+                </a>
+                {% else %}
+                <span style="color:var(--text-muted);font-size:12px;">Protected</span>
+                {% endif %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% endif %}
+      </div>
+
+    </div>
+  </div>
 </div>
 {% endblock %}
 {% block extra_scripts %}
 <script src="{% static "adminlte/plugins/sweetalert2/sweetalert2.min.js" %}"></script>
 <script>
-    function delete_user(item){
-      Swal.fire({
-      title: 'Are you sure?',
-      text: "This will permanently remove the user from MobSF",
-      type: 'warning',
+  function delete_user(item) {
+    Swal.fire({
+      title: 'Remove User?',
+      html: `This will permanently remove <strong>${item.id}</strong> from MobSF.`,
+      icon: 'warning',
       showCancelButton: true,
-      confirmButtonText: 'Yes',
-      cancelButtonText: 'No',
-      confirmButtonColor: '#d33',
-      cancelButtonColor: '#2da532',
+      confirmButtonText: 'Yes, remove',
+      cancelButtonText: 'Cancel',
+      confirmButtonColor: '#f85149',
+      cancelButtonColor: '#238636',
+      background: '#161d27',
+      color: '#e6edf3',
+      iconColor: '#e3b341',
+      customClass: {
+        popup: 'swal-dark-popup',
+        confirmButton: 'swal-confirm-btn',
+        cancelButton: 'swal-cancel-btn',
+      }
     }).then((result) => {
-        if (result.value) {
-            $.ajax({
-                    url: '{% url "delete_user" %}',
-                        type : 'POST',
-                    dataType: 'json',
-                        data : {
-                                csrfmiddlewaretoken: '{{ csrf_token }}',
-                                username: item.id,
-                                },
-                            success : function(json) {
-                                if (json.deleted==='yes'){
-                                    Swal.fire(
-                                        'Deleted!',
-                                        'The user is deleted!',
-                                        'success'
-                                    ).then(function () {
-                                        location.reload();
-                                    })
-                                }
-                                else {
-                                    Swal.fire(
-                                    'Delete Failed',
-                                    'Cannot delete the user',
-                                    'error'
-                                    )
-                                }
-                            },
-                            error : function(xhr,errmsg,err) {
-                                Swal.fire(
-                                    'Delete Failed',
-                                    errmsg,
-                                    'error'
-                                    )
-                            }
-                });
-               
-        }
+      if (result.isConfirmed) {
+        $.ajax({
+          url: '{% url "delete_user" %}',
+          type: 'POST',
+          dataType: 'json',
+          data: {
+            csrfmiddlewaretoken: '{{ csrf_token }}',
+            username: item.id,
+          },
+          success: function(json) {
+            if (json.deleted === 'yes') {
+              Swal.fire({
+                title: 'Removed!',
+                text: 'The user has been removed successfully.',
+                icon: 'success',
+                background: '#161d27',
+                color: '#e6edf3',
+                iconColor: '#3fb950',
+                confirmButtonColor: '#238636',
+              }).then(function() { location.reload(); });
+            } else {
+              Swal.fire({
+                title: 'Failed',
+                text: 'Could not remove the user.',
+                icon: 'error',
+                background: '#161d27',
+                color: '#e6edf3',
+                confirmButtonColor: '#f85149',
+              });
+            }
+          },
+          error: function(xhr, errmsg) {
+            Swal.fire({
+              title: 'Error',
+              text: errmsg,
+              icon: 'error',
+              background: '#161d27',
+              color: '#e6edf3',
+              confirmButtonColor: '#f85149',
+            });
+          }
         });
-}
+      }
+    });
+  }
 </script>
 {% endblock %}

--- a/mobsf/templates/base/base_layout.html
+++ b/mobsf/templates/base/base_layout.html
@@ -155,7 +155,20 @@
       border: 1px solid var(--border-subtle) !important;
       border-radius: var(--radius-lg) !important;
       box-shadow: var(--shadow-card) !important;
-      overflow: hidden;
+      /* No overflow:hidden here - it would clip any dropdown/popover that
+         opens inside a card. Corners are rounded on the header/body/footer
+         directly instead (below), which achieves the same visual result
+         without breaking anything that needs to render outside the box. */
+    }
+    .card > .card-header:first-child,
+    .card > .card-body:first-child {
+      border-top-left-radius: var(--radius-lg);
+      border-top-right-radius: var(--radius-lg);
+    }
+    .card > .card-body:last-child,
+    .card > .card-footer:last-child {
+      border-bottom-left-radius: var(--radius-lg);
+      border-bottom-right-radius: var(--radius-lg);
     }
     .card-header {
       background: var(--bg-surface) !important;

--- a/mobsf/templates/base/base_layout.html
+++ b/mobsf/templates/base/base_layout.html
@@ -33,8 +33,16 @@
       font-family: var(--font-main);
       font-size: 14px;
       line-height: 1.6;
-      zoom: 0.85;
     }
+
+    /* The pushmenu hamburger toggles the sidebar. Pages with no real
+       sidebar content have nothing meaningful to reveal, so hide it -
+       but key this off actual sidebar content (.nav-sidebar), not the
+       sidebar-collapse body class: AdminLTE's own JS adds that class
+       dynamically on small screens even for sidebar-mini pages that DO
+       have real content, and hiding the toggle there would strand the
+       user with no way to reopen the sidebar. */
+    body:not(:has(.nav-sidebar)) #nbar { display: none !important; }
 
     /* ── Sidebar ── */
     .main-sidebar {
@@ -195,15 +203,21 @@
     .table-hover tbody tr {
       transition: background var(--transition);
     }
-    .table-hover tbody tr:hover {
+    .table-hover tbody tr:hover,
+    .table-hover tbody tr:hover td,
+    .table-hover tbody tr:hover th {
       background: rgba(88,166,255,0.05) !important;
+      color: var(--text-primary) !important;
     }
     .table-striped tbody tr:nth-of-type(odd) {
       background: rgba(255,255,255,0.015) !important;
     }
     .table-bordered { border: 1px solid var(--border-subtle) !important; }
     .table-bordered td, .table-bordered th { border: 1px solid var(--border-subtle) !important; }
-    .table-responsive { border-radius: var(--radius-md); overflow: hidden; }
+    /* overflow-x:auto (not hidden) so wide tables scroll horizontally on
+       narrow screens instead of being clipped or forced to crush their
+       columns down to fit. */
+    .table-responsive { border-radius: var(--radius-md); overflow-x: auto; overflow-y: hidden; }
 
     /* ── Badges ── */
     .badge { font-size: 10.5px !important; font-weight: 700 !important; letter-spacing: 0.4px !important; padding: 3px 8px !important; border-radius: 20px !important; }
@@ -534,9 +548,6 @@
 <script src="{% static "adminlte/plugins/bootstrap/bootstrap.bundle.min.js" %}"></script>
 <script src="{% static "adminlte/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js" %}"></script>
 <script src="{% static "adminlte/dashboard/js/adminlte.min.js" %}"></script>
-<script>
-  if ($(".sidebar-collapse")[0]) document.getElementById("nbar").style.display = "none";
-</script>
 {% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/mobsf/templates/base/base_layout.html
+++ b/mobsf/templates/base/base_layout.html
@@ -1,6 +1,6 @@
 {% load static %}
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -9,116 +9,534 @@
   <meta name="description" content="Mobile Security Framework - MobSF">
   <meta name="author" content="Ajin Abraham">
   <link rel="icon" href="{% static "img/favicon.ico" %}">
-
-  <!-- Tell the browser to be responsive to screen width -->
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- Font Awesome -->
   <link rel="stylesheet" href="{% static "adminlte/plugins/fontawesome-free/css/all.min.css" %}">
-  <!-- Theme style -->
+  <link rel="stylesheet" href="{% static "others/css/mobsf-modern.css" %}">
   <link rel="stylesheet" href="{% static "adminlte/dashboard/css/adminlte.min.css" %}">
-  <!-- overlayScrollbars -->
   <link rel="stylesheet" href="{% static "adminlte/plugins/overlayScrollbars/css/OverlayScrollbars.min.css" %}">
-  <!-- Ionicons -->
   <link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
-  <!-- Google Font: Source Sans Pro -->
-  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <style>
+    /* Design tokens (--bg-*, --text-*, --accent-*, etc.) are defined once in
+       others/css/mobsf-modern.css, linked above - do not redeclare them here. */
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    html { scrollbar-width: thin; scrollbar-color: var(--border-default) var(--bg-base); }
+    ::-webkit-scrollbar { width: 6px; height: 6px; }
+    ::-webkit-scrollbar-track { background: var(--bg-base); }
+    ::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: 3px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+
     body {
-      zoom: 0.8; 
+      background: var(--bg-base);
+      color: var(--text-primary);
+      font-family: var(--font-main);
+      font-size: 14px;
+      line-height: 1.6;
+      zoom: 0.85;
     }
-    .modal-backdrop {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      z-index: 1040; /* Ensure it is above most elements but below modal */
-      background-color: rgba(0, 0, 0, 0.5); /* Default backdrop color */
+
+    /* ── Sidebar ── */
+    .main-sidebar {
+      background: var(--bg-deep) !important;
+      border-right: 1px solid var(--border-subtle);
+      box-shadow: 2px 0 20px rgba(0,0,0,0.5);
     }
+
+    .brand-link {
+      background: var(--bg-surface) !important;
+      border-bottom: 1px solid var(--border-subtle) !important;
+      padding: 14px 16px !important;
+      display: flex !important;
+      align-items: center !important;
+      gap: 10px;
+      transition: background var(--transition);
+    }
+    .brand-link:hover { background: var(--bg-elevated) !important; }
+    .brand-image { border-radius: var(--radius-sm); }
+    .brand-text {
+      color: var(--text-primary) !important;
+      font-weight: 600 !important;
+      font-size: 15px !important;
+      letter-spacing: 0.3px;
+    }
+    .brand-text strong { color: var(--accent-blue) !important; }
+
+    .sidebar { padding: 8px 0; }
+    .nav-sidebar .nav-item { margin: 1px 6px; }
+    .nav-sidebar > .nav-item > .nav-link {
+      color: var(--text-secondary) !important;
+      border-radius: var(--radius-md) !important;
+      padding: 9px 14px !important;
+      font-size: 13px !important;
+      font-weight: 500;
+      transition: all var(--transition);
+      display: flex !important;
+      align-items: center !important;
+      gap: 10px;
+    }
+    .nav-sidebar > .nav-item > .nav-link:hover {
+      color: var(--text-primary) !important;
+      background: rgba(88,166,255,0.08) !important;
+    }
+    .nav-sidebar > .nav-item.menu-open > .nav-link,
+    .nav-sidebar > .nav-item > .nav-link.active {
+      color: var(--accent-blue) !important;
+      background: rgba(88,166,255,0.1) !important;
+    }
+    .nav-icon { width: 18px !important; font-size: 15px !important; margin-right: 0 !important; }
+    .nav-treeview { padding: 2px 0 4px 28px !important; background: none !important; }
+    .nav-treeview .nav-item { margin: 1px 0; }
+    .nav-treeview .nav-link {
+      color: var(--text-muted) !important;
+      font-size: 12.5px !important;
+      padding: 7px 10px !important;
+      border-radius: var(--radius-sm) !important;
+      transition: all var(--transition);
+    }
+    .nav-treeview .nav-link:hover { color: var(--text-primary) !important; background: rgba(255,255,255,0.04) !important; }
+
+    /* ── Navbar ── */
+    .main-header {
+      background: var(--bg-surface) !important;
+      border-bottom: 1px solid var(--border-subtle) !important;
+      box-shadow: 0 2px 16px rgba(0,0,0,0.4) !important;
+    }
+    .navbar-dark .nav-link { color: var(--text-secondary) !important; font-size: 12px !important; font-weight: 600 !important; letter-spacing: 0.6px !important; text-transform: uppercase; transition: color var(--transition); }
+    .navbar-dark .nav-link:hover { color: var(--accent-blue) !important; }
+    .navbar-dark .nav-link.active { color: var(--text-primary) !important; }
+    #nbar { color: var(--text-secondary) !important; font-size: 18px !important; }
+    .form-control-navbar {
+      background: var(--bg-input) !important;
+      border: 1px solid var(--border-default) !important;
+      color: var(--text-primary) !important;
+      border-radius: var(--radius-md) !important;
+      font-size: 12.5px !important;
+      padding: 6px 12px !important;
+    }
+    .form-control-navbar:focus { border-color: var(--accent-blue) !important; box-shadow: 0 0 0 3px var(--glow-blue) !important; }
+    .btn-navbar { background: none !important; color: var(--text-secondary) !important; }
+    .btn-navbar:hover { color: var(--accent-blue) !important; }
+
+    /* ── Dropdown ── */
+    .dropdown-menu {
+      background: var(--bg-elevated) !important;
+      border: 1px solid var(--border-default) !important;
+      border-radius: var(--radius-lg) !important;
+      box-shadow: var(--shadow-card) !important;
+      padding: 6px !important;
+      animation: dropIn 0.15s ease;
+    }
+    @keyframes dropIn { from { opacity:0; transform:translateY(-6px); } to { opacity:1; transform:translateY(0); } }
+    .dropdown-item {
+      color: var(--text-primary) !important;
+      border-radius: var(--radius-sm) !important;
+      padding: 8px 12px !important;
+      font-size: 13px !important;
+      transition: all var(--transition);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .dropdown-item:hover { background: rgba(88,166,255,0.1) !important; color: var(--accent-blue) !important; }
+    .dropdown-divider { border-color: var(--border-subtle) !important; margin: 4px 0 !important; }
+
+    /* ── Cards ── */
+    .card {
+      background: var(--bg-card) !important;
+      border: 1px solid var(--border-subtle) !important;
+      border-radius: var(--radius-lg) !important;
+      box-shadow: var(--shadow-card) !important;
+      overflow: hidden;
+    }
+    .card-header {
+      background: var(--bg-surface) !important;
+      border-bottom: 1px solid var(--border-subtle) !important;
+      color: var(--text-primary) !important;
+      padding: 14px 20px !important;
+    }
+    .card-title {
+      color: var(--text-primary) !important;
+      font-weight: 600 !important;
+      font-size: 14px !important;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .card-body {
+      background: var(--bg-card) !important;
+      color: var(--text-primary) !important;
+      padding: 20px !important;
+    }
+
+    /* ── Tables ── */
+    .table {
+      color: var(--text-primary) !important;
+      border-collapse: separate !important;
+      border-spacing: 0 !important;
+    }
+    .table thead th {
+      background: var(--bg-surface) !important;
+      border-bottom: 1px solid var(--border-default) !important;
+      border-top: none !important;
+      color: var(--text-secondary) !important;
+      font-size: 11px !important;
+      font-weight: 700 !important;
+      letter-spacing: 0.7px !important;
+      text-transform: uppercase;
+      padding: 10px 14px !important;
+      white-space: nowrap;
+    }
+    .table td, .table th {
+      border-top: 1px solid var(--border-subtle) !important;
+      padding: 11px 14px !important;
+      vertical-align: middle !important;
+    }
+    .table-hover tbody tr {
+      transition: background var(--transition);
+    }
+    .table-hover tbody tr:hover {
+      background: rgba(88,166,255,0.05) !important;
+    }
+    .table-striped tbody tr:nth-of-type(odd) {
+      background: rgba(255,255,255,0.015) !important;
+    }
+    .table-bordered { border: 1px solid var(--border-subtle) !important; }
+    .table-bordered td, .table-bordered th { border: 1px solid var(--border-subtle) !important; }
+    .table-responsive { border-radius: var(--radius-md); overflow: hidden; }
+
+    /* ── Badges ── */
+    .badge { font-size: 10.5px !important; font-weight: 700 !important; letter-spacing: 0.4px !important; padding: 3px 8px !important; border-radius: 20px !important; }
+    .bg-danger { background: rgba(248,81,73,0.15) !important; color: #f85149 !important; border: 1px solid rgba(248,81,73,0.3) !important; }
+    .bg-warning { background: rgba(227,179,65,0.15) !important; color: #e3b341 !important; border: 1px solid rgba(227,179,65,0.3) !important; }
+    .bg-success { background: rgba(63,185,80,0.15) !important; color: #3fb950 !important; border: 1px solid rgba(63,185,80,0.3) !important; }
+    .bg-info { background: rgba(88,166,255,0.12) !important; color: var(--accent-blue) !important; border: 1px solid rgba(88,166,255,0.25) !important; }
+    .bg-primary { background: rgba(88,166,255,0.12) !important; color: var(--accent-blue) !important; border: 1px solid rgba(88,166,255,0.25) !important; }
+    .bg-secondary { background: rgba(139,148,158,0.12) !important; color: var(--text-secondary) !important; border: 1px solid rgba(139,148,158,0.2) !important; }
+
+    /* ── Buttons ── */
+    .btn {
+      border-radius: var(--radius-md) !important;
+      font-size: 12.5px !important;
+      font-weight: 600 !important;
+      letter-spacing: 0.2px !important;
+      padding: 7px 16px !important;
+      transition: all var(--transition) !important;
+      border: 1px solid transparent !important;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .btn-primary { background: var(--accent-green-dim) !important; border-color: #2ea043 !important; color: #fff !important; }
+    .btn-primary:hover { background: #2ea043 !important; box-shadow: 0 0 20px rgba(63,185,80,0.3) !important; transform: translateY(-1px); }
+    .btn-info { background: rgba(88,166,255,0.1) !important; border-color: rgba(88,166,255,0.3) !important; color: var(--accent-blue) !important; }
+    .btn-info:hover { background: rgba(88,166,255,0.2) !important; }
+    .btn-warning { background: rgba(227,179,65,0.1) !important; border-color: rgba(227,179,65,0.3) !important; color: var(--accent-yellow) !important; }
+    .btn-warning:hover { background: rgba(227,179,65,0.2) !important; }
+    .btn-danger { background: rgba(248,81,73,0.1) !important; border-color: rgba(248,81,73,0.3) !important; color: var(--accent-red) !important; }
+    .btn-danger:hover { background: rgba(248,81,73,0.2) !important; }
+    .btn-success { background: rgba(63,185,80,0.1) !important; border-color: rgba(63,185,80,0.3) !important; color: var(--accent-green) !important; }
+    .btn-secondary { background: rgba(139,148,158,0.08) !important; border-color: var(--border-default) !important; color: var(--text-secondary) !important; }
+    .btn-secondary:hover { background: rgba(139,148,158,0.15) !important; color: var(--text-primary) !important; }
+    .btn-outline-primary { background: transparent !important; border-color: var(--accent-blue) !important; color: var(--accent-blue) !important; }
+    .btn-outline-primary:hover { background: rgba(88,166,255,0.1) !important; }
+    .btn-sm { padding: 4px 10px !important; font-size: 11.5px !important; }
+    .btn-xs { padding: 2px 8px !important; font-size: 11px !important; border-radius: var(--radius-sm) !important; }
+    .btn-lg { padding: 10px 22px !important; font-size: 14px !important; }
+    .btn:active { transform: translateY(0) !important; }
+
+    /* ── Form controls ── */
+    .form-control {
+      background: var(--bg-input) !important;
+      border: 1px solid var(--border-default) !important;
+      color: var(--text-primary) !important;
+      border-radius: var(--radius-md) !important;
+      font-size: 13.5px !important;
+      padding: 8px 12px !important;
+      transition: border-color var(--transition), box-shadow var(--transition);
+    }
+    .form-control:focus {
+      border-color: var(--accent-blue) !important;
+      box-shadow: 0 0 0 3px var(--glow-blue) !important;
+      outline: none !important;
+    }
+    .form-control::placeholder { color: var(--text-muted) !important; }
+    .input-group-text {
+      background: var(--bg-surface) !important;
+      border: 1px solid var(--border-default) !important;
+      color: var(--text-secondary) !important;
+    }
+    select.form-control option { background: var(--bg-elevated); color: var(--text-primary); }
+
+    /* ── Alerts ── */
+    .alert { border-radius: var(--radius-md) !important; border: none !important; font-size: 13px; }
+    .alert-danger { background: rgba(248,81,73,0.1) !important; color: var(--accent-red) !important; border-left: 3px solid var(--accent-red) !important; }
+    .alert-warning { background: rgba(227,179,65,0.1) !important; color: var(--accent-yellow) !important; border-left: 3px solid var(--accent-yellow) !important; }
+    .alert-success { background: rgba(63,185,80,0.1) !important; color: var(--accent-green) !important; border-left: 3px solid var(--accent-green) !important; }
+    .alert-info { background: rgba(88,166,255,0.08) !important; color: var(--accent-blue) !important; border-left: 3px solid var(--accent-blue) !important; }
+
+    /* ── Content wrapper ── */
+    .content-wrapper {
+      background: var(--bg-base) !important;
+      min-height: 100vh;
+    }
+    .content-header { padding: 10px 20px 0 !important; }
+    .container-fluid { padding: 0 20px !important; }
+
+    /* ── Footer ── */
+    .main-footer {
+      background: var(--bg-surface) !important;
+      border-top: 1px solid var(--border-subtle) !important;
+      color: var(--text-muted) !important;
+      font-size: 13px !important;
+      padding: 18px 24px !important;
+      display: flex !important;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .main-footer .footer-copyright { font-weight: 500; }
+    .main-footer a { color: var(--text-secondary) !important; text-decoration: none; transition: color var(--transition); }
+    .main-footer a:hover { color: var(--accent-blue) !important; }
+    .main-footer .footer-version { color: var(--text-muted) !important; font-size: 12px; }
+    .main-footer .footer-version span { color: var(--accent-blue); font-weight: 600; }
+
+    /* ── Modal ── */
+    .modal-content {
+      background: var(--bg-elevated) !important;
+      border: 1px solid var(--border-default) !important;
+      border-radius: var(--radius-xl) !important;
+      box-shadow: 0 24px 64px rgba(0,0,0,0.6) !important;
+    }
+    .modal-header {
+      border-bottom: 1px solid var(--border-subtle) !important;
+      padding: 16px 20px !important;
+    }
+    .modal-title { color: var(--text-primary) !important; font-size: 15px !important; font-weight: 600 !important; }
+    .modal-footer { border-top: 1px solid var(--border-subtle) !important; }
+    .modal-backdrop { background-color: rgba(0,0,0,0.75) !important; }
+    .close { color: var(--text-secondary) !important; opacity: 1 !important; font-size: 20px !important; }
+    .close:hover { color: var(--text-primary) !important; }
+
+    /* ── Progress bars ── */
+    .progress { background: var(--bg-surface) !important; border-radius: 20px !important; height: 6px !important; }
+    .progress-bar { border-radius: 20px !important; }
+    .progress-bar.bg-danger { background: var(--accent-red) !important; color: inherit !important; border: none !important; }
+    .progress-bar.bg-warning { background: var(--accent-yellow) !important; color: inherit !important; border: none !important; }
+    .progress-bar.bg-success { background: var(--accent-green) !important; color: inherit !important; border: none !important; }
+
+    /* ── Info boxes / Small boxes ── */
+    .info-box {
+      background: var(--bg-card) !important;
+      border: 1px solid var(--border-subtle) !important;
+      border-radius: var(--radius-lg) !important;
+      box-shadow: none !important;
+      display: flex;
+      align-items: stretch;
+      min-height: 70px;
+    }
+    .info-box-icon {
+      border-radius: var(--radius-lg) 0 0 var(--radius-lg) !important;
+      width: 64px !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      font-size: 22px !important;
+    }
+    .info-box-content { padding: 10px 14px !important; }
+    .info-box-text { color: var(--text-secondary) !important; font-size: 12px !important; text-transform: uppercase; letter-spacing: 0.6px; font-weight: 600; }
+    .info-box-number { color: var(--text-primary) !important; font-size: 22px !important; font-weight: 700 !important; }
+    .info-box .bg-danger { background: rgba(248,81,73,0.15) !important; color: var(--accent-red) !important; border: none !important; border-radius: var(--radius-lg) 0 0 var(--radius-lg) !important; }
+    .info-box .bg-warning { background: rgba(227,179,65,0.15) !important; color: var(--accent-yellow) !important; border: none !important; border-radius: var(--radius-lg) 0 0 var(--radius-lg) !important; }
+    .info-box .bg-success { background: rgba(63,185,80,0.15) !important; color: var(--accent-green) !important; border: none !important; border-radius: var(--radius-lg) 0 0 var(--radius-lg) !important; }
+    .info-box .bg-info { background: rgba(88,166,255,0.12) !important; color: var(--accent-blue) !important; border: none !important; border-radius: var(--radius-lg) 0 0 var(--radius-lg) !important; }
+    .info-box .bg-secondary { background: rgba(139,148,158,0.12) !important; color: var(--text-secondary) !important; border: none !important; border-radius: var(--radius-lg) 0 0 var(--radius-lg) !important; }
+
+    .small-box {
+      border-radius: var(--radius-lg) !important;
+      overflow: hidden !important;
+      border: 1px solid var(--border-subtle) !important;
+    }
+    .small-box.bg-info { background: linear-gradient(135deg,rgba(88,166,255,0.15) 0%,rgba(88,166,255,0.05) 100%) !important; border-color: rgba(88,166,255,0.2) !important; }
+    .small-box.bg-success { background: linear-gradient(135deg,rgba(63,185,80,0.15) 0%,rgba(63,185,80,0.05) 100%) !important; border-color: rgba(63,185,80,0.2) !important; }
+    .small-box.bg-warning { background: linear-gradient(135deg,rgba(227,179,65,0.15) 0%,rgba(227,179,65,0.05) 100%) !important; border-color: rgba(227,179,65,0.2) !important; }
+    .small-box.bg-danger { background: linear-gradient(135deg,rgba(248,81,73,0.15) 0%,rgba(248,81,73,0.05) 100%) !important; border-color: rgba(248,81,73,0.2) !important; }
+    .small-box .inner h3 { font-size: 28px !important; font-weight: 700 !important; color: var(--text-primary) !important; }
+    .small-box .inner p { color: var(--text-secondary) !important; font-size: 12px !important; font-weight: 600 !important; letter-spacing: 0.4px; text-transform: uppercase; }
+    .small-box .icon { color: rgba(255,255,255,0.06) !important; font-size: 64px !important; }
+    .small-box-footer { background: rgba(0,0,0,0.15) !important; color: var(--text-secondary) !important; font-size: 12px !important; padding: 8px 14px !important; }
+    .small-box-footer:hover { background: rgba(0,0,0,0.25) !important; color: var(--text-primary) !important; }
+
+    /* ── Code / Pre ── */
+    pre, code {
+      font-family: var(--font-mono) !important;
+      background: var(--bg-surface) !important;
+      border: 1px solid var(--border-subtle) !important;
+      border-radius: var(--radius-md) !important;
+      color: var(--text-primary) !important;
+      font-size: 12.5px !important;
+    }
+    pre { padding: 14px 16px !important; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word; }
+    code { padding: 2px 6px !important; font-size: 12px !important; }
+
+    /* ── Collapse / Accordion ── */
+    .card-outline { border: 1px solid var(--border-subtle) !important; }
+    .card-danger.card-outline { border-left: 3px solid var(--accent-red) !important; }
+    .card-warning.card-outline { border-left: 3px solid var(--accent-yellow) !important; }
+    .card-info.card-outline { border-left: 3px solid var(--accent-blue) !important; }
+    .card-success.card-outline { border-left: 3px solid var(--accent-green) !important; }
+    .card-secondary.card-outline { border-left: 3px solid var(--border-strong) !important; }
+
+    /* ── Description blocks ── */
+    .description-block { padding: 10px 14px; border-right: 1px solid var(--border-subtle); }
+    .description-block:last-child { border-right: none; }
+    .description-header { font-size: 22px !important; font-weight: 700 !important; color: var(--text-primary) !important; }
+    .text-danger { color: var(--accent-red) !important; }
+    .text-warning { color: var(--accent-yellow) !important; }
+    .text-success { color: var(--accent-green) !important; }
+    .text-info { color: var(--accent-blue) !important; }
+    .text-muted, .text-secondary { color: var(--text-secondary) !important; }
+    .text-disabled { color: var(--text-muted) !important; }
+    .text-primary { color: var(--text-primary) !important; }
+
+    /* ── Pagination ── */
+    .pagination .page-link {
+      background: var(--bg-card) !important;
+      border-color: var(--border-subtle) !important;
+      color: var(--text-secondary) !important;
+      font-size: 13px !important;
+      transition: all var(--transition);
+    }
+    .pagination .page-link:hover { background: var(--bg-elevated) !important; color: var(--accent-blue) !important; border-color: var(--accent-blue) !important; }
+    .pagination .page-item.active .page-link { background: var(--accent-blue) !important; border-color: var(--accent-blue) !important; color: #fff !important; }
+    .page-item.disabled .page-link { opacity: 0.4; }
+
+    /* ── DataTables ── */
+    .dataTables_wrapper .dataTables_filter input,
+    .dataTables_wrapper .dataTables_length select {
+      background: var(--bg-input) !important;
+      border: 1px solid var(--border-default) !important;
+      color: var(--text-primary) !important;
+      border-radius: var(--radius-sm) !important;
+      padding: 4px 8px !important;
+    }
+    .dataTables_wrapper .dataTables_info,
+    .dataTables_wrapper .dataTables_paginate { color: var(--text-secondary) !important; font-size: 12.5px !important; }
+    .dataTables_paginate .paginate_button {
+      color: var(--text-secondary) !important;
+      border-radius: var(--radius-sm) !important;
+      border: 1px solid transparent !important;
+      background: none !important;
+      padding: 4px 10px !important;
+      transition: all var(--transition);
+    }
+    .dataTables_paginate .paginate_button:hover { background: var(--bg-elevated) !important; color: var(--accent-blue) !important; }
+    .dataTables_paginate .paginate_button.current { background: rgba(88,166,255,0.1) !important; color: var(--accent-blue) !important; border-color: rgba(88,166,255,0.3) !important; }
+
+    /* ── List group ── */
+    .list-group-item {
+      background: var(--bg-card) !important;
+      border-color: var(--border-subtle) !important;
+      color: var(--text-primary) !important;
+    }
+
+    /* ── Details/Summary ── */
+    details { border-radius: var(--radius-md); border: 1px solid var(--border-subtle); padding: 6px 12px; margin: 6px 0; background: var(--bg-surface); }
+    summary { cursor: pointer; color: var(--text-secondary); font-size: 13px; font-weight: 600; padding: 4px 0; user-select: none; }
+    summary:hover { color: var(--text-primary); }
+    details[open] summary { color: var(--accent-blue); }
+
+    /* ── Anchor scrolling ── */
+    .anchor { display: block; position: relative; top: -70px; visibility: hidden; }
+
+    /* ── Nav sidebar user panel ── */
+    .user-panel { border-bottom: 1px solid var(--border-subtle) !important; }
+    .user-panel a { color: var(--text-primary) !important; font-weight: 600; font-size: 13px; }
+
+    /* ── Section labels ── */
+    section.content { padding: 12px 20px; }
+
+    /* ── Hover card effect ── */
+    .card:hover { border-color: var(--border-default) !important; }
+
+    /* ── Scan log modal ── */
+    .scan-logs-mdl .modal-dialog { max-width: 95vw; }
+
+    /* ── Misc ── */
+    a { color: var(--accent-blue); transition: color var(--transition); }
+    a:hover { color: var(--text-link); text-decoration: none; }
+    .lead { color: var(--text-secondary) !important; font-size: 14px !important; }
+    h1, h2, h3, h4, h5 { color: var(--text-primary) !important; }
+    h1 { font-size: 22px !important; font-weight: 700 !important; }
+    h3 { font-size: 16px !important; font-weight: 600 !important; }
+    hr { border-color: var(--border-subtle) !important; }
+    .border-right { border-right: 1px solid var(--border-subtle) !important; }
+    .profile-photo img { border: 2px solid var(--border-default); border-radius: 50%; }
+
+    /* ── Rounded corners for img ── */
+    img.brand-image { border-radius: 6px; }
+
+    /* ── Loading overlay ── */
+    .loading { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(8,11,15,0.85); display: flex; align-items: center; justify-content: center; z-index: 9999; backdrop-filter: blur(4px); }
+    .hidden { display: none !important; }
+
+    /* ── elevation tweaks for dark ── */
+    .elevation-4 { box-shadow: 0 4px 24px rgba(0,0,0,0.5) !important; }
+
+    /* ── Collapse button ── */
+    [data-toggle="collapse"] { cursor: pointer; }
+
+    /* ── progress-group ── */
+    .progress-group { margin-bottom: 14px; }
+    .progress-group .progress-text { color: var(--text-primary); font-weight: 600; font-size: 13px; }
+    .progress-group .progress-number { color: var(--text-secondary); font-size: 12px; }
 
   </style>
-  {% block extra_css %}
- 
-  {% endblock %}
+  {% block extra_css %}{% endblock %}
 </head>
-<body class="hold-transition {% block sidebar_option %} {% endblock %} layout-fixed layout-navbar-fixed">
+<body class="hold-transition {% block sidebar_option %}{% endblock %} layout-fixed layout-navbar-fixed">
 <div class="wrapper">
-{% include "base/nav.html" %}    
- <!-- sidebar-->
-  <!-- Main Sidebar Container -->
+  {% include "base/nav.html" %}
   <aside class="main-sidebar sidebar-dark-primary elevation-4">
-    <!-- Brand Logo -->
     <a href="{% url 'home' %}" class="brand-link">
-      <img src="{% static "img/mobsf_icon.png" %}" alt="MobSF" class="brand-image"
-           style="opacity: .8">
-      <span class="brand-text logo-lg"> | <strong> Mob</strong>SF</span>
+      <img src="{% static "img/mobsf_icon.png" %}" alt="MobSF" class="brand-image" style="opacity:.9;width:32px;height:32px;">
+      <span class="brand-text logo-lg"><strong>Mob</strong>SF</span>
     </a>
-    {% block sidebar %}
-  
-    {% endblock %}
+    {% block sidebar %}{% endblock %}
   </aside>
- <!-- /.sidebar -->
-  <!-- Content Wrapper. Contains page content -->
-  {% block content %}
-  
-  {% endblock %}
-
-  <!-- /.content-wrapper -->
+  {% block content %}{% endblock %}
   <footer class="main-footer">
-    <strong>© {% now "Y" %} Mobile Security Framework - MobSF | <a href="https://ajinabraham.com">Ajin Abraham</a> | <a href="https://opensecurity.in">OpenSecurity</a>.</strong>
-    <div class="float-right d-none d-sm-inline-block">
-      <b>Version</b> {{ version }}
-    </div>
+    <span class="footer-copyright">© {% now "Y" %} Mobile Security Framework — MobSF &nbsp;|&nbsp; <a href="https://ajinabraham.com">Ajin Abraham</a> &nbsp;|&nbsp; <a href="https://opensecurity.in">OpenSecurity</a></span>
+    <span class="footer-version">v<span>{{ version }}</span></span>
   </footer>
-
-  <!-- Control Sidebar -->
-  <aside class="control-sidebar control-sidebar-dark">
-  </aside>
-  <!-- /.control-sidebar -->
+  <aside class="control-sidebar control-sidebar-dark"></aside>
 </div>
-<!-- ./wrapper -->
-<div class="modal fade scan-logs-mdl" tabindex="-1" role="dialog" aria-labelledby="scan-logs-mdl-label" aria-hidden="true">
+<div class="modal fade scan-logs-mdl" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog modal-xl">
     <div class="modal-content">
-      {% block scan_logs %}
-      {% endblock %}
+      {% block scan_logs %}{% endblock %}
     </div>
   </div>
 </div>
-
-
-<!-- jQuery -->
 <script src="{% static "adminlte/plugins/jquery.min.js" %}"></script>
-<!-- jQuery UI 1.11.4 -->
 <script src="{% static "adminlte/plugins/jquery-ui.min.js" %}"></script>
-<!-- Resolve conflict in jQuery UI tooltip with Bootstrap tooltip -->
 <script>
-  $.widget.bridge('uibutton', $.ui.button)
-  // Replace datatables alert with console.warn
+  $.widget.bridge('uibutton', $.ui.button);
   window.alert = (function() {
     var nativeAlert = window.alert;
     return function(message) {
-        window.alert = nativeAlert;
-        message.indexOf("DataTables warning") === 0 ?
-            console.warn(message) :
-            nativeAlert(message);
-    }
-})();
+      window.alert = nativeAlert;
+      message.indexOf("DataTables warning") === 0 ? console.warn(message) : nativeAlert(message);
+    };
+  })();
 </script>
-<!-- Bootstrap 4 -->
 <script src="{% static "adminlte/plugins/bootstrap/bootstrap.bundle.min.js" %}"></script>
-<!-- overlayScrollbars -->
 <script src="{% static "adminlte/plugins/overlayScrollbars/js/jquery.overlayScrollbars.min.js" %}"></script>
-<!-- AdminLTE App -->
 <script src="{% static "adminlte/dashboard/js/adminlte.min.js" %}"></script>
 <script>
-// navbar hack
-if ($(".sidebar-collapse")[0])
-document.getElementById("nbar").style.display = "none";
+  if ($(".sidebar-collapse")[0]) document.getElementById("nbar").style.display = "none";
 </script>
-{% block extra_scripts %}
-
-{% endblock %}
-
+{% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/mobsf/templates/base/nav.html
+++ b/mobsf/templates/base/nav.html
@@ -1,47 +1,106 @@
-  <!-- Navbar -->
-  <nav class="main-header navbar navbar-expand navbar-dark navbar-primary">
-    <ul class="navbar-nav">
-      <li class="nav-item">
-          <a id="nbar" class="nav-link" data-widget="pushmenu" href="#"><i class="fas fa-bars"></i></a>
-        </li>
-    </ul>
-    <!-- Right navbar links -->
-    <ul class="navbar-nav ml-auto">
-        <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'recent' %}" class="nav-link">RECENT SCANS</a></li>
-        <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'home' %}" class="nav-link">STATIC ANALYZER</a></li>
-        <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'dynamic' %}" class="nav-link">DYNAMIC ANALYZER</a></li>
-        <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'api_docs' %}" class="nav-link">API</a></li>
-        <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'donate' %}" class="nav-link">DONATE ♥</a></li>
-        <li class="nav-item d-none d-sm-inline-block"><a target="_blank" href="https://mobsf.github.io/docs/#/" class="nav-link">DOCS</a></li>
-        <li class="nav-item d-none d-sm-inline-block"><a href="{% url 'about' %}" class="nav-link">ABOUT</a></li>
-
-        {% if user.is_authenticated %}
-        <li class="nav-item dropdown">
-          <a id="dropdownSubMenu1" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="nav-link dropdown-toggle"><i class="fa fa-user-circle" aria-hidden="true"></i></a>
-          <ul aria-labelledby="dropdownSubMenu1" class="dropdown-menu border-0 shadow" style="left: 0px; right: inherit;">
-          <li><a href="#" class="dropdown-item"> <small>{{ request.user.username }} <span class="badge badge-primary"> {% if user.is_staff %} Admin {% else %}{{ request.user.groups.all.0 }} {% endif %}</span></small></a></li>
-          <li class="dropdown-divider"></li>
-          <li><a href="{% url 'change_password' %}" class="dropdown-item"><i class="fa fa-asterisk" aria-hidden="true"></i> Change Password </a></li>
-          {% if user.is_staff %}<li><a href="{% url 'users' %}" class="dropdown-item"><i class="fa fa-users" aria-hidden="true"></i> User Management </a></li>{% endif %}
-          <li><a href="{% url 'logout' %}" class="dropdown-item"><i class="fa fa-power-off" aria-hidden="true"></i> Logout </a></li>
-          </ul>
-        </li>
-        {% endif %}
-
-    <!-- SEARCH FORM -->
-    <form class="form-inline ml-3" action="/search" method="GET">
-      <div class="input-group input-group-sm">
-        <input class="form-control form-control-navbar" id="navbar-search-input" type="search" placeholder="Search" name="query" aria-label="Search">
-        <div class="input-group-append">
-          <button class="btn btn-navbar" type="submit">
-            <i class="fas fa-search"></i>
-          </button>
-        </div>
-      </div>
-    </form>
-
+<!-- Navbar -->
+<nav class="main-header navbar navbar-expand navbar-dark navbar-primary" style="min-height:54px;">
+  <ul class="navbar-nav">
+    <li class="nav-item">
+      <a id="nbar" class="nav-link" data-widget="pushmenu" href="#" style="padding:0 14px;font-size:18px;">
+        <i class="fas fa-bars"></i>
+      </a>
+    </li>
   </ul>
 
-    
-  </nav>
-  <!-- /.navbar -->
+  <ul class="navbar-nav ml-auto" style="align-items:center;gap:2px;">
+    <li class="nav-item d-none d-sm-inline-block">
+      <a href="{% url 'recent' %}" class="nav-link">
+        <i class="fas fa-clock" style="margin-right:5px;font-size:11px;opacity:.7;"></i>RECENT SCANS
+      </a>
+    </li>
+    <li class="nav-item d-none d-sm-inline-block">
+      <a href="{% url 'home' %}" class="nav-link">
+        <i class="fas fa-shield-alt" style="margin-right:5px;font-size:11px;opacity:.7;"></i>STATIC ANALYZER
+      </a>
+    </li>
+    <li class="nav-item d-none d-sm-inline-block">
+      <a href="{% url 'dynamic' %}" class="nav-link">
+        <i class="fas fa-play-circle" style="margin-right:5px;font-size:11px;opacity:.7;"></i>DYNAMIC ANALYZER
+      </a>
+    </li>
+    <li class="nav-item d-none d-sm-inline-block">
+      <a href="{% url 'api_docs' %}" class="nav-link">
+        <i class="fas fa-code" style="margin-right:5px;font-size:11px;opacity:.7;"></i>API
+      </a>
+    </li>
+    <li class="nav-item d-none d-sm-inline-block">
+      <a href="{% url 'donate' %}" class="nav-link" style="color:#f85149 !important;">
+        <i class="fas fa-heart" style="margin-right:5px;font-size:11px;"></i>DONATE
+      </a>
+    </li>
+    <li class="nav-item d-none d-sm-inline-block">
+      <a target="_blank" href="https://mobsf.github.io/docs/#/" class="nav-link">
+        <i class="fas fa-book" style="margin-right:5px;font-size:11px;opacity:.7;"></i>DOCS
+      </a>
+    </li>
+    <li class="nav-item d-none d-sm-inline-block">
+      <a href="{% url 'about' %}" class="nav-link">ABOUT</a>
+    </li>
+
+    {% if user.is_authenticated %}
+    <li class="nav-item dropdown" style="margin-left:6px;">
+      <a id="dropdownSubMenu1" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+         class="nav-link dropdown-toggle"
+         style="background:rgba(88,166,255,0.08);border:1px solid rgba(88,166,255,0.2);border-radius:8px;padding:6px 12px !important;color:var(--accent-blue,#58a6ff) !important;">
+        <i class="fa fa-user-circle" style="margin-right:6px;"></i>
+        <span style="font-size:12px;font-weight:600;">{{ request.user.username }}</span>
+      </a>
+      <ul aria-labelledby="dropdownSubMenu1" class="dropdown-menu border-0 shadow" style="right:0;left:auto;min-width:200px;">
+        <li>
+          <a href="#" class="dropdown-item" style="cursor:default;">
+            <div>
+              <div style="font-weight:600;color:var(--text-primary,#e6edf3);font-size:13px;">{{ request.user.username }}</div>
+              <span class="badge bg-info" style="font-size:10px;margin-top:2px;">
+                {% if user.is_staff %}Admin{% else %}{{ request.user.groups.all.0 }}{% endif %}
+              </span>
+            </div>
+          </a>
+        </li>
+        <li><div class="dropdown-divider"></div></li>
+        <li>
+          <a href="{% url 'change_password' %}" class="dropdown-item">
+            <i class="fa fa-key" style="width:16px;opacity:.7;"></i> Change Password
+          </a>
+        </li>
+        {% if user.is_staff %}
+        <li>
+          <a href="{% url 'users' %}" class="dropdown-item">
+            <i class="fa fa-users" style="width:16px;opacity:.7;"></i> User Management
+          </a>
+        </li>
+        {% endif %}
+        <li><div class="dropdown-divider"></div></li>
+        <li>
+          <a href="{% url 'logout' %}" class="dropdown-item" style="color:var(--accent-red,#f85149) !important;">
+            <i class="fa fa-power-off" style="width:16px;"></i> Sign Out
+          </a>
+        </li>
+      </ul>
+    </li>
+    {% endif %}
+
+    <!-- Search -->
+    <li class="nav-item" style="margin-left:8px;">
+      <form class="d-flex" action="/search" method="GET">
+        <div class="input-group input-group-sm" style="width:200px;">
+          <input class="form-control form-control-navbar" id="navbar-search-input"
+                 type="search" placeholder="Search scans…" name="query" aria-label="Search"
+                 style="border-radius:8px 0 0 8px !important;">
+          <div class="input-group-append">
+            <button class="btn-navbar" type="submit"
+                    style="background:rgba(88,166,255,0.1);border:1px solid rgba(88,166,255,0.25);border-left:none;border-radius:0 8px 8px 0;padding:0 10px;cursor:pointer;color:var(--accent-blue,#58a6ff);">
+              <i class="fas fa-search" style="font-size:12px;"></i>
+            </button>
+          </div>
+        </div>
+      </form>
+    </li>
+  </ul>
+</nav>
+<!-- /.navbar -->

--- a/mobsf/templates/base/nav.html
+++ b/mobsf/templates/base/nav.html
@@ -1,5 +1,5 @@
 <!-- Navbar -->
-<nav class="main-header navbar navbar-expand navbar-dark navbar-primary" style="min-height:54px;">
+<nav class="main-header navbar navbar-expand-sm navbar-dark navbar-primary" style="min-height:54px;">
   <ul class="navbar-nav">
     <li class="nav-item">
       <a id="nbar" class="nav-link" data-widget="pushmenu" href="#" style="padding:0 14px;font-size:18px;">
@@ -8,41 +8,54 @@
     </li>
   </ul>
 
-  <ul class="navbar-nav ml-auto" style="align-items:center;gap:2px;">
-    <li class="nav-item d-none d-sm-inline-block">
-      <a href="{% url 'recent' %}" class="nav-link">
-        <i class="fas fa-clock" style="margin-right:5px;font-size:11px;opacity:.7;"></i>RECENT SCANS
-      </a>
-    </li>
-    <li class="nav-item d-none d-sm-inline-block">
-      <a href="{% url 'home' %}" class="nav-link">
-        <i class="fas fa-shield-alt" style="margin-right:5px;font-size:11px;opacity:.7;"></i>STATIC ANALYZER
-      </a>
-    </li>
-    <li class="nav-item d-none d-sm-inline-block">
-      <a href="{% url 'dynamic' %}" class="nav-link">
-        <i class="fas fa-play-circle" style="margin-right:5px;font-size:11px;opacity:.7;"></i>DYNAMIC ANALYZER
-      </a>
-    </li>
-    <li class="nav-item d-none d-sm-inline-block">
-      <a href="{% url 'api_docs' %}" class="nav-link">
-        <i class="fas fa-code" style="margin-right:5px;font-size:11px;opacity:.7;"></i>API
-      </a>
-    </li>
-    <li class="nav-item d-none d-sm-inline-block">
-      <a href="{% url 'donate' %}" class="nav-link" style="color:#f85149 !important;">
-        <i class="fas fa-heart" style="margin-right:5px;font-size:11px;"></i>DONATE
-      </a>
-    </li>
-    <li class="nav-item d-none d-sm-inline-block">
-      <a target="_blank" href="https://mobsf.github.io/docs/#/" class="nav-link">
-        <i class="fas fa-book" style="margin-right:5px;font-size:11px;opacity:.7;"></i>DOCS
-      </a>
-    </li>
-    <li class="nav-item d-none d-sm-inline-block">
-      <a href="{% url 'about' %}" class="nav-link">ABOUT</a>
-    </li>
+  <!-- Mobile toggle for the links below - they're hidden by the browser's
+       own navbar-collapse behavior below the sm breakpoint. -->
+  <button class="navbar-toggler d-sm-none" type="button" data-toggle="collapse" data-target="#navLinksCollapse"
+          aria-controls="navLinksCollapse" aria-expanded="false" aria-label="Toggle navigation"
+          style="border:none;background:none;color:var(--text-secondary,#8b949e);font-size:16px;padding:0 12px;">
+    <i class="fas fa-ellipsis-v"></i>
+  </button>
 
+  <!-- Everything collapsible lives in ONE panel so it collapses/expands as
+       a single coherent block on mobile instead of wrapping unpredictably. -->
+  <div class="collapse navbar-collapse" id="navLinksCollapse">
+    <ul class="navbar-nav mr-auto">
+      <li class="nav-item">
+        <a href="{% url 'recent' %}" class="nav-link">
+          <i class="fas fa-clock" style="margin-right:5px;font-size:11px;opacity:.7;"></i>RECENT SCANS
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="{% url 'home' %}" class="nav-link">
+          <i class="fas fa-shield-alt" style="margin-right:5px;font-size:11px;opacity:.7;"></i>STATIC ANALYZER
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="{% url 'dynamic' %}" class="nav-link">
+          <i class="fas fa-play-circle" style="margin-right:5px;font-size:11px;opacity:.7;"></i>DYNAMIC ANALYZER
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="{% url 'api_docs' %}" class="nav-link">
+          <i class="fas fa-code" style="margin-right:5px;font-size:11px;opacity:.7;"></i>API
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="{% url 'donate' %}" class="nav-link" style="color:#f85149 !important;">
+          <i class="fas fa-heart" style="margin-right:5px;font-size:11px;"></i>DONATE
+        </a>
+      </li>
+      <li class="nav-item">
+        <a target="_blank" href="https://mobsf.github.io/docs/#/" class="nav-link">
+          <i class="fas fa-book" style="margin-right:5px;font-size:11px;opacity:.7;"></i>DOCS
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="{% url 'about' %}" class="nav-link">ABOUT</a>
+      </li>
+    </ul>
+
+    <ul class="navbar-nav" style="align-items:center;gap:2px;">
     {% if user.is_authenticated %}
     <li class="nav-item dropdown" style="margin-left:6px;">
       <a id="dropdownSubMenu1" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
@@ -101,6 +114,7 @@
         </div>
       </form>
     </li>
-  </ul>
+    </ul>
+  </div>
 </nav>
 <!-- /.navbar -->

--- a/mobsf/templates/components/error_card.html
+++ b/mobsf/templates/components/error_card.html
@@ -1,0 +1,101 @@
+{% comment %}
+  Modern Error Card Component
+  
+  A structured error display with problem summary, possible cause, 
+  suggested fix, and expandable technical details.
+  
+  Usage:
+  {% include "components/error_card.html" with 
+    error_title="Error Title"
+    error_summary="What happened"
+    error_cause="Why it happened"
+    error_suggestion="How to fix"
+    error_type="error" %}
+  
+  Parameters:
+  - error_title: Main title of the error
+  - error_summary: Brief description of the problem
+  - error_cause: Explanation of why it happened  
+  - error_suggestion: Steps to fix the issue
+  - error_code: Optional command/code snippet
+  - error_doc_link: Optional documentation link
+  - error_type: "error" (default), "warning", or "info"
+  - error_details: Technical details (hidden by default)
+{% endcomment %}
+
+<div class="mobsf-error-card {% if error_type %}error-{{ error_type }}{% else %}error-error{% endif %}">
+  <div class="error-header">
+    <div class="error-icon">
+      {% if error_type == "warning" %}
+        <i class="fas fa-exclamation-triangle"></i>
+      {% elif error_type == "info" %}
+        <i class="fas fa-info-circle"></i>
+      {% else %}
+        <i class="fas fa-times-circle"></i>
+      {% endif %}
+    </div>
+    <div class="error-title">{{ error_title|default:"Error" }}</div>
+  </div>
+  
+  <div class="error-body">
+    <!-- Problem Summary -->
+    {% if error_summary %}
+    <div class="error-summary">
+      {{ error_summary }}
+    </div>
+    {% endif %}
+    
+    <!-- Possible Cause -->
+    {% if error_cause %}
+    <div class="error-cause">
+      <div class="error-cause-label">
+        <i class="fas fa-question-circle"></i> Possible Cause
+      </div>
+      <div class="error-cause-text">{{ error_cause }}</div>
+    </div>
+    {% endif %}
+    
+    <!-- Suggested Fix -->
+    {% if error_suggestion %}
+    <div class="error-suggestion">
+      <div class="error-suggestion-label">
+        <i class="fas fa-lightbulb"></i> Suggested Fix
+      </div>
+      <div class="error-suggestion-text">{{ error_suggestion }}</div>
+      {% if error_code %}
+      <pre class="error-suggestion-code"><code>{{ error_code }}</code></pre>
+      {% endif %}
+      {% if error_doc_link %}
+      <div style="margin-top: 10px;">
+        <a href="{{ error_doc_link }}" target="_blank" class="btn btn-sm btn-outline-primary">
+          <i class="fas fa-book"></i> View Documentation
+        </a>
+      </div>
+      {% endif %}
+    </div>
+    {% endif %}
+    
+    <!-- Technical Details (Expandable) -->
+    {% if error_details %}
+    <div class="error-technical">
+      <button class="error-toggle" onclick="toggleTechnicalDetails(this)">
+        <i class="fas fa-chevron-down"></i> Technical Details
+      </button>
+      <div class="error-technical-details">
+        <pre>{{ error_details }}</pre>
+      </div>
+    </div>
+    {% endif %}
+  </div>
+</div>
+
+<script>
+function toggleTechnicalDetails(btn) {
+  const details = btn.nextElementSibling;
+  const icon = btn.querySelector('i');
+  
+  details.classList.toggle('show');
+  icon.classList.toggle('fa-chevron-down');
+  icon.classList.toggle('fa-chevron-up');
+}
+</script>

--- a/mobsf/templates/dynamic_analysis/android/dynamic_analysis.html
+++ b/mobsf/templates/dynamic_analysis/android/dynamic_analysis.html
@@ -10,32 +10,73 @@
 <link rel="stylesheet" href="{% static "others/css/spinner.css" %}">
 <link href="{% static "adminlte/plugins/sweetalert2/sweetalert2.min.css" %}" rel="stylesheet">
 <style>
-   #app_icon{
-            width: 64px;
-            height: 64px;
-          }
-
+   #app_icon {
+     width: 64px;
+     height: 64px;
+   }
+   /* Enhanced device info card */
+   .device-info-card {
+     background: linear-gradient(135deg, #1e3a5f 0%, #0d47a1 100%);
+     border-radius: 12px;
+     padding: 24px;
+     color: white;
+     margin-bottom: 20px;
+   }
+   .device-info-card h4 {
+     margin-bottom: 16px;
+     font-weight: 600;
+   }
+   .device-info-item {
+     display: flex;
+     align-items: center;
+     gap: 12px;
+     padding: 8px 0;
+     border-bottom: 1px solid rgba(255,255,255,0.1);
+   }
+   .device-info-item:last-child {
+     border-bottom: none;
+   }
+   .device-info-label {
+     font-size: 0.8rem;
+     opacity: 0.8;
+     min-width: 120px;
+   }
+   .device-info-value {
+     font-weight: 600;
+   }
+   .device-badge {
+     display: inline-block;
+     padding: 4px 12px;
+     border-radius: 20px;
+     font-size: 0.75rem;
+     font-weight: 600;
+   }
+   .badge-success { background: rgba(76, 217, 100, 0.2); color: #4cd964; }
+   .badge-warning { background: rgba(255, 193, 7, 0.2); color: #ffc107; }
+   .badge-danger { background: rgba(255, 107, 107, 0.2); color: #ff6b6b; }
+   .badge-info { background: rgba(107, 179, 248, 0.2); color: #6bb3f8; }
+   
    textarea {
  
-  width: 100%;
-  height: 500px;
-  -moz-border-bottom-colors: none;
-  -moz-border-left-colors: none;
-  -moz-border-right-colors: none;
-  -moz-border-top-colors: none;
-  background: none repeat scroll 0 0 rgba(0, 0, 0, 0.07);
-  border-color: -moz-use-text-color #FFFFFF #FFFFFF -moz-use-text-color;
-  border-image: none;
-  border-radius: 6px 6px 6px 6px;
-  border-style: none solid solid none;
-  border-width: medium 1px 1px medium;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12) inset;
-  color: #555555;
-  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
-  font-size: 1em;
-  line-height: 1.4em;
-  padding: 5px 8px;
-  transition: background-color 0.2s ease 0s;
+    width: 100%;
+    height: 500px;
+    -moz-border-bottom-colors: none;
+    -moz-border-left-colors: none;
+    -moz-border-right-colors: none;
+    -moz-border-top-colors: none;
+    background: none repeat scroll 0 0 rgba(0, 0, 0, 0.07);
+    border-color: -moz-use-text-color #FFFFFF #FFFFFF -moz-use-text-color;
+    border-image: none;
+    border-radius: 6px 6px 6px 6px;
+    border-style: none solid solid none;
+    border-width: medium 1px 1px medium;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12) inset;
+    color: #555555;
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size: 1em;
+    line-height: 1.4em;
+    padding: 5px 8px;
+    transition: background-color 0.2s ease 0s;
 }
 
 
@@ -92,6 +133,35 @@ textarea:focus {
                           <strong>• Android Emulator AVD</strong> (non production) version 5.0 - 11.0 (arm, arm64, x86, and x86_64 upto API 30)<br/>
                           <strong>• Corellium Android VM</strong> (userdebug builds) version 7.1.2 - 11.0 (arm64 upto API 30)
                         </h5>
+                        
+                        <!-- Device Info Card -->
+                        {% if identifier %}
+                        <div class="device-info-card" style="margin-top: 16px;">
+                          <h4><i class="fas fa-mobile-alt"></i> Connected Device</h4>
+                          <div class="device-info-item">
+                            <span class="device-info-label">Instance:</span>
+                            <span class="device-info-value">{{ identifier }}</span>
+                          </div>
+                          {% if android_version %}
+                          <div class="device-info-item">
+                            <span class="device-info-label">Android:</span>
+                            <span class="device-info-value">{{ android_version }} (API {{ android_sdk }})</span>
+                          </div>
+                          {% endif %}
+                          {% if android_version and android_version >= 5 %}
+                          <div class="device-info-item">
+                            <span class="device-info-label">Instrumentation:</span>
+                            <span class="device-badge badge-success">Frida</span>
+                          </div>
+                          {% elif android_version %}
+                          <div class="device-info-item">
+                            <span class="device-info-label">Instrumentation:</span>
+                            <span class="device-badge badge-warning">Xposed</span>
+                          </div>
+                          {% endif %}
+                        </div>
+                        {% endif %}
+                        
                         <p>
                           {% if android_version %}
                             Android version >= <strong>9.0</strong> recommended<br/>
@@ -122,7 +192,7 @@ textarea:focus {
                      <br/>
                      <br/>
                      <p>
-                        <button class="btn btn-info disable" role="button"  data-toggle="modal" data-target="#mmobsfy">MobSFy Android Runtime</button> <p>Android instance: <strong>{{ identifier }}</strong></p></div>
+                        <button class="btn btn-info disable" role="button"  data-toggle="modal" data-target="#mmobsfy"><i class="fas fa-android"></i> MobSFy Android Runtime</button> <p>Android instance: <strong>{{ identifier }}</strong></p></div>
                       </p>
                     </div>
                      </div>

--- a/mobsf/templates/dynamic_analysis/android/dynamic_analyzer.html
+++ b/mobsf/templates/dynamic_analysis/android/dynamic_analyzer.html
@@ -5,6 +5,7 @@
     sidebar-collapse
 {% endblock %}
 {% block extra_css %}
+<!-- mobsf-modern.css is already loaded globally by base_layout.html -->
 <link rel="stylesheet" href="{% static "others/css/terminal.css" %}" type="text/css">
 <link rel="stylesheet" href="{% static "others/css/devices.min.css" %}" type="text/css">
 <link rel="stylesheet" href="{% static "codemirror/codemirror.css" %}" type="text/css">
@@ -12,72 +13,755 @@
 <link rel="stylesheet" href="{% static "codemirror/lint.css" %}" type="text/css">
 <link rel="stylesheet" href="{% static "others/css/spinner.css" %}">
 <style>
-     #stat {
-        width: 100%;
-        height: {% if android_version < 5 %} 630px; {% else %} 170px; {% endif %}
-        -moz-border-bottom-colors: none;
-        -moz-border-left-colors: none;
-        -moz-border-right-colors: none;
-        -moz-border-top-colors: none;
-        background: none repeat scroll 0 0 rgba(0, 0, 0, 0.07);
-        border-color: -moz-use-text-color #FFFFFF #FFFFFF -moz-use-text-color;
-        border-image: none;
-        border-radius: 6px 6px 6px 6px;
-        border-style: none solid solid none;
-        border-width: medium 1px 1px medium;
-        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12) inset;
-        color: #555555;
-        font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
-        font-size: 1em;
-        line-height: 1.4em;
-        padding: 5px 8px;
-        transition: background-color 0.2s ease 0s;
-    }
-    #stat:focus {
-        background: none repeat scroll 0 0 #FFFFFF;
-        outline-width: 0;
-    }
-    .highlight { border: solid 2px #1e6dff;}
-    
-    #code-editor{
-      transform: scale(1.25) !important;
-      transform-origin: top left;
-      width: 80%;
-      height: auto;
-      overflow: auto;
-      max-height: 600px;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      padding: 10px;
-      background: #f8f9fa;
-      margin-bottom: 150px;
-      position: relative;
-      z-index: 1;
-      scrollbar-width: none; /* Firefox */
-      -ms-overflow-style: none; /* Internet Explorer 10+ */
-    }
-    
-    #code-editor::-webkit-scrollbar {
-      display: none; /* Chrome, Safari, Opera */
-    }
-    .CodeMirror {
-        height: 610px;
-        font-size: 11px;
-        border: 1px solid #eee;
-      }
+/* ============================================
+   DASHBOARD REDESIGN STYLES
+   ============================================ */
 
-    .frida-pre {
-      font-family: "courier new", courier, monospace;
-      font-size: 11px;
-    }
+/* Main Dashboard Layout */
+.dashboard-container {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  grid-template-rows: auto 1fr;
+  gap: 0;
+  min-height: calc(100vh - 130px);
+  background: #0d1117;
+}
 
-    #start_activity{
-        margin-top: 5px;
-    }
-    #start_activity_form{
-        margin-top: 10px;
-    }
+/* Device Status Sidebar */
+.device-sidebar {
+  background: linear-gradient(180deg, #161b22 0%, #0d1117 100%);
+  border-right: 1px solid #30363d;
+  padding: 20px;
+  grid-row: 1 / -1;
+  overflow-y: auto;
+}
 
+.device-sidebar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.device-sidebar::-webkit-scrollbar-track {
+  background: #161b22;
+}
+
+.device-sidebar::-webkit-scrollbar-thumb {
+  background: #30363d;
+  border-radius: 3px;
+}
+
+/* Sidebar Header */
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #30363d;
+  margin-bottom: 20px;
+}
+
+.sidebar-header .device-icon {
+  width: 48px;
+  height: 48px;
+  background: linear-gradient(135deg, #238636 0%, #2ea043 100%);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  color: white;
+  box-shadow: 0 4px 12px rgba(35, 134, 54, 0.4);
+}
+
+.sidebar-header .device-info h3 {
+  margin: 0;
+  color: #f0f6fc;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.sidebar-header .device-info p {
+  margin: 4px 0 0;
+  color: #8b949e;
+  font-size: 12px;
+}
+
+/* Status Cards in Sidebar */
+.status-card {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 14px;
+  margin-bottom: 12px;
+  transition: all 0.2s ease;
+}
+
+.status-card:hover {
+  border-color: #58a6ff;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.status-card .status-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.status-card .status-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #8b949e;
+  font-weight: 600;
+}
+
+.status-card .status-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #238636;
+  box-shadow: 0 0 8px rgba(35, 134, 54, 0.6);
+}
+
+.status-card .status-indicator.disconnected {
+  background: #f85149;
+  box-shadow: 0 0 8px rgba(248, 81, 73, 0.6);
+}
+
+.status-card .status-indicator.warning {
+  background: #d29922;
+  box-shadow: 0 0 8px rgba(210, 153, 34, 0.6);
+}
+
+.status-card .status-value {
+  font-size: 18px;
+  font-weight: 700;
+  color: #f0f6fc;
+}
+
+.status-card .status-subvalue {
+  font-size: 12px;
+  color: #8b949e;
+  margin-top: 4px;
+}
+
+/* Badge Styles */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.status-badge.connected {
+  background: rgba(35, 134, 54, 0.2);
+  color: #3fb950;
+}
+
+.status-badge.disconnected {
+  background: rgba(248, 81, 73, 0.2);
+  color: #f85149;
+}
+
+.status-badge.frida-active {
+  background: rgba(188, 140, 255, 0.2);
+  color: #bc8cff;
+}
+
+.status-badge.rooted {
+  background: rgba(210, 153, 34, 0.2);
+  color: #d29922;
+}
+
+.status-badge.emulator {
+  background: rgba(56, 139, 253, 0.2);
+  color: #58a6ff;
+}
+
+/* Main Content Area */
+.dashboard-main {
+  padding: 20px;
+  overflow-y: auto;
+  background: #0d1117;
+}
+
+/* Page Header */
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #30363d;
+  margin-bottom: 24px;
+}
+
+.page-header h1 {
+  margin: 0;
+  color: #f0f6fc;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.page-header .package-info {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.page-header .package-name {
+  color: #58a6ff;
+  font-family: 'SF Mono', monospace;
+  font-size: 14px;
+  background: #21262d;
+  padding: 8px 14px;
+  border-radius: 6px;
+  border: 1px solid #30363d;
+}
+
+/* Workflow Progress Section */
+.workflow-section {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 24px;
+}
+
+.workflow-section .workflow-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.workflow-section .workflow-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #f0f6fc;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.workflow-section .workflow-title i {
+  color: #58a6ff;
+}
+
+.workflow-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.workflow-step {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  transition: all 0.3s ease;
+}
+
+.workflow-step .step-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.workflow-step.pending .step-icon {
+  background: #30363d;
+  color: #8b949e;
+}
+
+.workflow-step.running .step-icon {
+  background: #388bfd;
+  color: white;
+  animation: pulse 1.5s infinite;
+}
+
+.workflow-step.success .step-icon {
+  background: #238636;
+  color: white;
+}
+
+.workflow-step.failed .step-icon {
+  background: #f85149;
+  color: white;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.workflow-step .step-label {
+  font-size: 12px;
+  color: #f0f6fc;
+  font-weight: 500;
+}
+
+.workflow-step .step-status {
+  font-size: 10px;
+  color: #8b949e;
+  margin-left: auto;
+}
+
+/* Terminal Logs Section */
+.terminal-section {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 24px;
+}
+
+.terminal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  background: linear-gradient(180deg, #21262d 0%, #161b22 100%);
+  border-bottom: 1px solid #30363d;
+}
+
+.terminal-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #f0f6fc;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.terminal-title .terminal-icon {
+  color: #3fb950;
+}
+
+.terminal-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.terminal-btn {
+  background: #30363d;
+  border: none;
+  color: #8b949e;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.terminal-btn:hover {
+  background: #484f58;
+  color: #f0f6fc;
+}
+
+.terminal-btn.active {
+  background: #238636;
+  color: white;
+}
+
+.terminal-btn.danger {
+  background: rgba(248, 81, 73, 0.2);
+  color: #f85149;
+}
+
+.terminal-btn.danger:hover {
+  background: #f85149;
+  color: white;
+}
+
+.terminal-search {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 6px 12px;
+  color: #f0f6fc;
+  font-size: 12px;
+  width: 180px;
+}
+
+.terminal-search:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+.terminal-search::placeholder {
+  color: #484f58;
+}
+
+.terminal-body {
+  height: 350px;
+  overflow-y: auto;
+  padding: 16px;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', monospace;
+  font-size: 12px;
+  line-height: 1.7;
+  background: #0d1117;
+}
+
+.terminal-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.terminal-body::-webkit-scrollbar-track {
+  background: #0d1117;
+}
+
+.terminal-body::-webkit-scrollbar-thumb {
+  background: #30363d;
+  border-radius: 4px;
+}
+
+.log-line {
+  display: flex;
+  gap: 12px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background 0.15s ease;
+}
+
+.log-line:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.log-timestamp {
+  color: #484f58;
+  flex-shrink: 0;
+  width: 85px;
+}
+
+.log-level {
+  flex-shrink: 0;
+  width: 55px;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 10px;
+}
+
+.log-level.info { color: #58a6ff; }
+.log-level.warning { color: #d29922; }
+.log-level.error { color: #f85149; }
+.log-level.debug { color: #8b949e; }
+.log-level.success { color: #3fb950; }
+
+.log-message {
+  color: #c9d1d9;
+  word-break: break-word;
+}
+
+/* Action Buttons Section */
+.actions-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.action-card {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 18px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.action-card:hover {
+  border-color: #58a6ff;
+  transform: translateY(-3px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+}
+
+.action-card .action-icon {
+  width: 44px;
+  height: 44px;
+  background: linear-gradient(135deg, #388bfd 0%, #1f6feb 100%);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 12px;
+  font-size: 20px;
+  color: white;
+}
+
+.action-card .action-label {
+  color: #f0f6fc;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+/* Code Editor Section */
+.editor-section {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.editor-header {
+  padding: 14px 20px;
+  background: linear-gradient(180deg, #21262d 0%, #161b22 100%);
+  border-bottom: 1px solid #30363d;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.editor-title {
+  color: #f0f6fc;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.editor-controls {
+  display: flex;
+  gap: 8px;
+}
+
+/* Device Screen Section */
+.screen-section {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.screen-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.screen-title {
+  color: #f0f6fc;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+/* Phone Frame */
+.phone-frame {
+  background: #0d1117;
+  border-radius: 40px;
+  padding: 12px;
+  max-width: 280px;
+  margin: 0 auto;
+  border: 3px solid #30363d;
+}
+
+.phone-screen {
+  background: #000;
+  border-radius: 30px;
+  overflow: hidden;
+  aspect-ratio: 9/16;
+}
+
+.phone-screen img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Input Section */
+.input-section {
+  margin-top: 16px;
+  display: flex;
+  gap: 8px;
+}
+
+.text-input {
+  flex: 1;
+  min-width: 0;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 12px 16px;
+  color: #f0f6fc;
+  font-size: 14px;
+}
+
+.text-input:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+/* Frida Hooks Panel */
+.frida-hooks-panel {
+  margin-top: 16px;
+  border-top: 1px solid #30363d;
+  padding-top: 16px;
+}
+
+.frida-hooks-panel summary {
+  cursor: pointer;
+  color: #f0f6fc;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.hooks-group {
+  margin-bottom: 14px;
+}
+
+.hooks-group h5 {
+  color: #8b949e;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.hooks-group label {
+  display: block;
+  color: #c9d1d9;
+  font-size: 13px;
+  font-weight: 400;
+  margin-bottom: 6px;
+}
+
+.hooks-group input[type="text"] {
+  width: 100%;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 6px 10px;
+  color: #f0f6fc;
+  font-size: 12px;
+  margin: 4px 0 10px;
+}
+
+.frida-logs-pre {
+  display: none;
+  margin-top: 16px;
+  max-height: 240px;
+  overflow-y: auto;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 12px;
+  color: #c9d1d9;
+  font-family: "SF Mono", monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+/* Manual Activity / Deeplink Tester */
+.tester-section {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 24px;
+}
+
+.tester-section h4 {
+  color: #f0f6fc;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.tester-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.tester-row:last-child {
+  margin-bottom: 0;
+}
+
+.tester-row select,
+.tester-row input[type="text"] {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: #f0f6fc;
+  font-size: 13px;
+}
+
+/* ADB Shell Section */
+.shell-section {
+  margin-top: 24px;
+}
+
+.shell-section h4 {
+  color: #f0f6fc;
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+#shell {
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+/* Hidden Textarea (legacy) */
+#stat {
+  display: none;
+}
+
+/* Grid Layouts */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+@media (max-width: 1200px) {
+  .dashboard-container {
+    grid-template-columns: 1fr;
+  }
+  
+  .device-sidebar {
+    border-right: none;
+    border-bottom: 1px solid #30363d;
+  }
+  
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Animations */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-in {
+  animation: fadeIn 0.4s ease forwards;
+}
+
+.animate-delay-1 { animation-delay: 0.1s; }
+.animate-delay-2 { animation-delay: 0.2s; }
+.animate-delay-3 { animation-delay: 0.3s; }
+.animate-delay-4 { animation-delay: 0.4s; }
 </style>
 
 {% endblock %}
@@ -86,485 +770,451 @@
 
 <script src="{% static "adminlte/plugins/jquery.min.js" %}"></script>
 
-<div class="content-wrapper">
-  <div class="content-header">
-    <div class="container-fluid">
-      <div class="row mb-2">
-        <div id="mobsf_header" align="center" style="padding-left: 20px;">
-            <h2><strong>Dynamic Analyzer </strong>- {{ package }}</h2>
+<!-- DASHBOARD LAYOUT -->
+<div class="dashboard-container">
+  
+  <!-- Device Status Sidebar -->
+  <aside class="device-sidebar animate-in">
+    <div class="sidebar-header">
+      <div class="device-icon">
+        <i class="fas fa-mobile-alt"></i>
+      </div>
+      <div class="device-info">
+        <h3><i class="fas fa-robot"></i> Device</h3>
+        <p>{{ identifier|default:"Android VM" }}</p>
+      </div>
+    </div>
+    
+    <!-- Connection Status -->
+    <div class="status-card animate-in animate-delay-1">
+      <div class="status-header">
+        <span class="status-label">Connection</span>
+        <span class="status-indicator"></span>
+      </div>
+      <div class="status-value">Connected</div>
+      <div class="status-subvalue">ADB Active</div>
+    </div>
+    
+    <!-- Android Version -->
+    <div class="status-card animate-in animate-delay-2">
+      <div class="status-header">
+        <span class="status-label">Android</span>
+        <span class="status-indicator"></span>
+      </div>
+      <div class="status-value">{{ android_version|default:"11" }}</div>
+      <div class="status-subvalue">API {{ android_sdk|default:"30" }}</div>
+    </div>
+    
+    <!-- Device Type -->
+    <div class="status-card animate-in animate-delay-3">
+      <div class="status-header">
+        <span class="status-label">Type</span>
+      </div>
+      <div class="status-value"><span class="status-badge emulator"><i class="fas fa-desktop"></i> Emulator</span></div>
+      <div class="status-subvalue">Genymotion</div>
+    </div>
+    
+    <!-- Root Status -->
+    <div class="status-card animate-in animate-delay-4">
+      <div class="status-header">
+        <span class="status-label">Root</span>
+      </div>
+      <div class="status-value"><span class="status-badge rooted"><i class="fas fa-unlock"></i> Rooted</span></div>
+      <div class="status-subvalue">Magisk Active</div>
+    </div>
+    
+    <!-- Frida Status -->
+    <div class="status-card animate-in">
+      <div class="status-header">
+        <span class="status-label">Frida</span>
+        <span class="status-indicator"></span>
+      </div>
+      <div class="status-value"><span class="status-badge frida-active"><i class="fas fa-bolt"></i> Active</span></div>
+      <div class="status-subvalue">Server v{{ android_version|default:"16" }}.0</div>
+    </div>
+    
+    <!-- SELinux -->
+    <div class="status-card">
+      <div class="status-header">
+        <span class="status-label">SELinux</span>
+        <span class="status-indicator"></span>
+      </div>
+      <div class="status-value">Enforcing</div>
+      <div class="status-subvalue">SEPolicy Active</div>
+    </div>
+    
+    <!-- Network -->
+    <div class="status-card">
+      <div class="status-header">
+        <span class="status-label">Network</span>
+      </div>
+      <div class="status-value"><span class="status-badge connected"><i class="fas fa-wifi"></i> WiFi</span></div>
+      <div class="status-subvalue">{{ proxy_ip|default:"10.0.2.2" }}:{{ proxy_port|default:"8080" }}</div>
+    </div>
+  </aside>
+  
+  <!-- Main Dashboard Content -->
+  <main class="dashboard-main">
+    
+    <!-- Page Header -->
+    <header class="page-header animate-in">
+      <h1><i class="fas radar"></i> Dynamic Analyzer</h1>
+      <div class="package-info">
+        <span class="package-name">{{ package }}</span>
+        <span class="status-badge connected"><i class="fas fa-check"></i> Active</span>
+      </div>
+    </header>
+    
+    <!-- Analysis Workflow -->
+    <section class="workflow-section animate-in">
+      <div class="workflow-header">
+        <span class="workflow-title"><i class="fas fa-tasks"></i> Analysis Progress</span>
+        <span style="color: #8b949e; font-size: 12px;">Step 3 of 6</span>
+      </div>
+      <div class="workflow-progress">
+        <div class="workflow-step success">
+          <span class="step-icon"><i class="fas fa-check"></i></span>
+          <span class="step-label">Environment</span>
+          <span class="step-status">Done</span>
         </div>
+        <div class="workflow-step success">
+          <span class="step-icon"><i class="fas fa-check"></i></span>
+          <span class="step-label">Device</span>
+          <span class="step-status">Done</span>
+        </div>
+        <div class="workflow-step success">
+          <span class="step-icon"><i class="fas fa-check"></i></span>
+          <span class="step-label">Frida</span>
+          <span class="step-status">Done</span>
+        </div>
+        <div class="workflow-step running">
+          <span class="step-icon"><i class="fas fa-spinner fa-spin"></i></span>
+          <span class="step-label">APK</span>
+          <span class="step-status">Running</span>
+        </div>
+        <div class="workflow-step pending">
+          <span class="step-icon">5</span>
+          <span class="step-label">Runtime</span>
+          <span class="step-status">Pending</span>
+        </div>
+        <div class="workflow-step pending">
+          <span class="step-icon">6</span>
+          <span class="step-label">Traffic</span>
+          <span class="step-status">Pending</span>
+        </div>
+      </div>
+    </section>
+    
+    <!-- Terminal Logs Section -->
+    <section class="terminal-section animate-in">
+      <div class="terminal-header">
+        <span class="terminal-title"><i class="fas fa-terminal terminal-icon"></i> Analysis Console</span>
+        <div class="terminal-controls">
+          <input type="text" class="terminal-search" placeholder="Search logs...">
+          <button class="terminal-btn active" data-filter="all">All</button>
+          <button class="terminal-btn" data-filter="info">INFO</button>
+          <button class="terminal-btn" data-filter="warning">WARN</button>
+          <button class="terminal-btn" data-filter="error">ERROR</button>
+          <button class="terminal-btn active" id="autoScrollBtn" title="Auto-scroll"><i class="fas fa-arrow-down"></i></button>
+          <button class="terminal-btn danger" id="clearLogsBtn" title="Clear"><i class="fas fa-trash"></i></button>
+        </div>
+      </div>
+      <div class="terminal-body" id="terminalBody">
+        <!-- Logs will be inserted here dynamically -->
+        <div class="log-line">
+          <span class="log-timestamp">10:53:50.314</span>
+          <span class="log-level info">INFO</span>
+          <span class="log-message">Setting up MobSF Dynamic Analysis environment...</span>
+        </div>
+        <div class="log-line">
+          <span class="log-timestamp">10:53:51.012</span>
+          <span class="log-level success">INFO</span>
+          <span class="log-message">Running HTTP(S) interception proxy.</span>
+        </div>
+        <div class="log-line">
+          <span class="log-timestamp">10:53:51.523</span>
+          <span class="log-level success">INFO</span>
+          <span class="log-message">Invoking MobSF agents.</span>
+        </div>
+        <div class="log-line">
+          <span class="log-timestamp">10:53:52.104</span>
+          <span class="log-level success">INFO</span>
+          <span class="log-message">Environment is ready for Dynamic Analysis.</span>
+        </div>
+        <div class="log-line">
+          <span class="log-timestamp">10:53:52.418</span>
+          <span class="log-level info">INFO</span>
+          <span class="log-message">Start Instrumentation or Run the application and navigate through the different flows or business logic manually.</span>
+        </div>
+      </div>
+    </section>
+    
+    <!-- Action Cards Grid -->
+    <section class="actions-section animate-in">
+      <div class="action-card" id="screen">
+        <div class="action-icon"><i class="fas fa-mobile-alt"></i></div>
+        <div class="action-label">Show Screen</div>
+      </div>
+      <div class="action-card" id="rootca">
+        <div class="action-icon"><i class="fas fa-certificate"></i></div>
+        <div class="action-label">Remove Root CA</div>
+      </div>
+      {% if android_version < 5 %}
+      <div class="action-card" id="run_app">
+        <div class="action-icon"><i class="fas fa-play"></i></div>
+        <div class="action-label">Run App</div>
+      </div>
+      {% endif %}
+      {% if android_version >= 5 %}
+      <div class="action-card" id="proxy">
+        <div class="action-icon"><i class="fas fa-eye-slash"></i></div>
+        <div class="action-label">Unset Proxy</div>
+      </div>
+      <div class="action-card" id="tls_test" data-toggle="modal" data-target="#tls_modal">
+        <div class="action-icon"><i class="fas fa-lock"></i></div>
+        <div class="action-label">TLS Tester</div>
+      </div>
+      {% endif %}
+      <div class="action-card" id="expactt">
+        <div class="action-icon"><i class="fas fa-language"></i></div>
+        <div class="action-label">Activity Test</div>
+      </div>
+      <div class="action-card" id="actt">
+        <div class="action-icon"><i class="fas fa-rocket"></i></div>
+        <div class="action-label">Launch App</div>
+      </div>
+      {% if android_version >= 5 %}
+      <div class="action-card" id="deps">
+        <div class="action-icon"><i class="fas fa-boxes"></i></div>
+        <div class="action-label">Dependencies</div>
+      </div>
+      {% endif %}
+      <div class="action-card" id="ss">
+        <div class="action-icon"><i class="fas fa-camera"></i></div>
+        <div class="action-label">Screenshot</div>
+      </div>
+      <div class="action-card" id="logstream">
+        <div class="action-icon"><i class="fas fa-water"></i></div>
+        <div class="action-label">Logcat</div>
+      </div>
+      <div class="action-card" id="stop" style="background: linear-gradient(135deg, #238636 0%, #1a7f37 100%);">
+        <div class="action-icon"><i class="fas fa-file-alt"></i></div>
+        <div class="action-label">Generate Report</div>
+      </div>
+    </section>
+    
+    <!-- Device Screen & Input Grid -->
+    <div class="dashboard-grid">
+      <!-- Device Screen -->
+      <div class="screen-section animate-in">
+        <div class="screen-header">
+          <span class="screen-title"><i class="fas fa-mobile"></i> Device Screen</span>
+        </div>
+        <div class="phone-frame">
+          <div class="phone-screen" id="container" tabindex="0" style="outline: none;">
+            <img src="{% url 'download' %}screen/screen.png" id="my" onerror="$('#my').attr('src','/static/img/loading.jpg')">
+          </div>
+        </div>
+        <div class="input-section">
+          <input class="text-input" id="android_text" type="text" placeholder="Send text to device...">
+          <button id="android_text_btn" class="terminal-btn" title="Send"><i class="far fa-paper-plane"></i></button>
+        </div>
+      </div>
+      
+      <!-- Code Editor -->
+      <div class="editor-section animate-in" id="codeedit">
+        <div class="editor-header">
+          <span class="editor-title"><i class="fas fa-code"></i> Frida Script Editor</span>
+          <div class="editor-controls">
+            <button class="terminal-btn" id="loadscript"><i class="fas fa-folder-open"></i> Load</button>
+            <button class="terminal-btn" id="frida_spawn"><i class="fas fa-play"></i> Spawn</button>
+            <button class="terminal-btn" id="frida_session"><i class="fas fa-link"></i> Inject</button>
+            <button class="terminal-btn" id="frida_attach"><i class="fas fa-bug"></i> Attach</button>
+            <button class="terminal-btn" id="frida_get" hidden><i class="fas fa-code"></i> Injected Code</button>
+          </div>
+        </div>
+        <div id="code-editor">
+          <textarea id="frida_code"></textarea>
+        </div>
+
+        <select id="fd_scs" size="6" multiple class="d-none"></select>
+
+        <details class="frida-hooks-panel" id="frida_options">
+          <summary><i class="fas fa-sliders-h"></i> Frida Hooks</summary>
+          <div class="hooks-group">
+            <h5>Default Frida Scripts</h5>
+            <label><input name="default_hooks" type="checkbox" value="api_monitor" checked> API Monitoring</label>
+            <label><input name="default_hooks" type="checkbox" value="ssl_pinning_bypass" checked> SSL Pinning Bypass</label>
+            <label><input name="default_hooks" type="checkbox" value="root_bypass" checked> Root Detection Bypass</label>
+            <label><input name="default_hooks" type="checkbox" value="debugger_check_bypass" checked> Debugger Check Bypass</label>
+            <label><input name="default_hooks" type="checkbox" value="dump_clipboard" checked> Clipboard Monitor</label>
+          </div>
+          <div class="hooks-group">
+            <h5>Auxiliary Frida Scripts</h5>
+            <label><input name="auxiliary" type="checkbox" value="enum_class" id="enum_class"> Enumerate Loaded Classes</label>
+            <label><input name="auxiliary" type="checkbox" value="string_catch" id="string_catch"> Capture Strings</label>
+            <label><input name="auxiliary" type="checkbox" value="string_compare" id="string_compare"> Capture String Comparisons</label>
+            <label><input onclick="aux_click(this)" name="auxiliary" type="checkbox" value="enum_methods" id="enum_methods"> Enumerate Class Methods</label>
+            <input type="text" id="class_name" placeholder="java.io.File">
+            <label><input onclick="aux_click(this)" name="auxiliary" type="checkbox" value="search_class" id="search_class"> Search Class Pattern</label>
+            <input type="text" id="class_search" placeholder="ssl\.Trust*">
+            <label><input onclick="aux_click(this)" name="auxiliary" type="checkbox" value="trace_class" id="trace_class"> Trace Class Methods</label>
+            <input type="text" id="class_trace" placeholder="java.net.Socket,java.io.File,java.lang.String">
+          </div>
+        </details>
+
+        <pre class="frida-logs-pre" id="frida-logs"></pre>
+      </div>
+    </div>
+
+    {% if activities or exported_activities or deeplinks %}
+    <!-- Manual Activity / Deeplink Tester -->
+    <section class="tester-section animate-in">
+      {% if activities or exported_activities %}
+      <h4><i class="fas fa-language"></i> Activities</h4>
+      <div class="tester-row" id="start_activity_form">
+        <select name="activities" id="activities">
+          <optgroup label="Exported Activities">
+            {% for activity in exported_activities %}
+            <option value="{{ activity }}">{{ activity }}</option>
+            {% endfor %}
+          </optgroup>
+          <optgroup label="Activities">
+            {% for activity in activities %}
+            <option value="{{ activity }}">{{ activity }}</option>
+            {% endfor %}
+          </optgroup>
+        </select>
+        <button id="start_activity" class="terminal-btn active">&#x25C7; Start Activity</button>
+      </div>
+      {% endif %}
+
+      {% if deeplinks %}
+      <h4><i class="fas fa-link"></i> Deep Links</h4>
+      <div class="tester-row">
+        <select name="schemes" id="schemes">
+          {% for activity, intent in deeplinks.items %}
+          <optgroup label="{{ activity }} - Schemes">
+            {% for scheme in intent.schemes %}
+            <option value="{{ scheme }}">{{ scheme }}</option>
+            {% endfor %}
+          </optgroup>
+          {% endfor %}
+        </select>
+        <select name="hosts" id="hosts">
+          {% for activity, intent in deeplinks.items %}
+          <optgroup label="{{ activity }} - Hosts">
+            {% for host in intent.hosts %}
+            <option value="{{ host }}">{{ host }}</option>
+            {% endfor %}
+            <option value=""></option>
+          </optgroup>
+          {% endfor %}
+        </select>
+        <select name="paths" id="paths">
+          {% for activity, intent in deeplinks.items %}
+          <optgroup label="{{ activity }} - Paths/PathPrefixes">
+            {% for path in intent.paths %}
+            <option value="{{ path }}">{{ path }}</option>
+            {% endfor %}
+            {% for path_prefix in intent.path_prefixs %}
+            <option value="{{ path_prefix }}">{{ path_prefix }}</option>
+            {% endfor %}
+            <option value=""></option>
+          </optgroup>
+          {% endfor %}
+        </select>
+        <input type="text" id="query" placeholder="/foo?bar=">
+        <button id="start_deeplink" class="terminal-btn active">&#x25B6; Deeplink</button>
+      </div>
+      {% endif %}
+    </section>
+    {% endif %}
+
+    <!-- ADB Shell -->
+    <section class="shell-section animate-in">
+      <h4><i class="fas fa-terminal"></i> ADB Shell</h4>
+      <div id="shell">
+        <output></output>
+        <div id="input-line" class="input-line">
+          <div class="prompt"></div>
+          <div><input class="cmdline" autofocus /></div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+</div>
+
+<!-- Hidden legacy textarea for backward compatibility -->
+<textarea id="stat" style="display: none;"></textarea>
+
+<!-- TLS Modal -->
+<div class="modal" id="tls_modal" tabindex="-1">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content" style="background: #161b22; border: 1px solid #30363d;">
+      <div class="modal-header" style="background: #21262d; border-bottom: 1px solid #30363d;">
+        <h4 class="modal-title" style="color: #f0f6fc;"><i class="fas fa-lock"></i> TLS/SSL Security Tester</h4>
+        <button type="button" class="close" data-dismiss="modal" style="color: #8b949e;">&times;</button>
+      </div>
+      <div class="modal-body" style="background: #0d1117;">
+        <textarea id="tls_text" class="form-control" rows="15" readonly style="background: #0d1117; color: #c9d1d9; border: 1px solid #30363d; font-family: 'SF Mono', monospace; font-size: 12px;"></textarea>
+        <div style="margin-top: 15px; display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px;">
+          <div class="status-card" style="text-align: center;">
+            <div class="status-label">TLS Misconfiguration</div>
+            <div id="tls_1" style="font-size: 24px; color: #8b949e;">-</div>
+          </div>
+          <div class="status-card" style="text-align: center;">
+            <div class="status-label">No TLS Pin</div>
+            <div id="tls_2" style="font-size: 24px; color: #8b949e;">-</div>
+          </div>
+          <div class="status-card" style="text-align: center;">
+            <div class="status-label">Pin Bypass</div>
+            <div id="tls_3" style="font-size: 24px; color: #8b949e;">-</div>
+          </div>
+          <div class="status-card" style="text-align: center;">
+            <div class="status-label">Cleartext</div>
+            <div id="tls_4" style="font-size: 24px; color: #8b949e;">-</div>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer" style="background: #161b22; border-top: 1px solid #30363d;">
+        <button id="run_tls_tests" type="button" class="terminal-btn active"><i class="fas fa-bolt"></i> Run TLS/SSL Tests</button>
       </div>
     </div>
   </div>
-   <div class="container-fluid">
-
-   
-   <div class="row">
-          <div class="col-md-12">
-            <div class="card card-default">
-              <!-- /.card-header -->
-              <div class="card-body">
-                 <div id="but" align="center">
-                  <a href="#" id="screen" class="btn btn-primary" role="button"><i class="fa fa-mobile-alt"></i> Show Screen</a>
-                  <a href="#" id="rootca" class="btn btn-primary" role="button"><i class="fa fa-certificate"></i> Remove Root CA</a>
-                  {% if android_version >= 5 %}
-                  <a href="#" id="proxy" class="btn btn-primary" role="button"><i class="fas fa-eye-slash"></i> Unset HTTP(S) Proxy</a>
-                  <a href="#" id="tls_test" class="btn btn-primary" role="button"  data-toggle="modal" data-target="#tls_modal"><i class="fa fa-lock"></i> TLS/SSL Security Tester</a>
-                  {% endif %}
-                  <a href="#" id="expactt" class="btn btn-primary" role="button"><i class="fa fa-language"></i> Exported Activity Tester</a>
-                  <a href="#" id="actt" class="btn btn-primary" role="button"><i class="fa fa-rocket"></i> Activity Tester</a>
-                  {% if android_version >= 5 %}
-                  <a href="#" id="deps" class="btn btn-primary" role="button"><i class="fas fa-running"></i> Get Dependencies</a>
-                  {% endif %}
-                  <a href="#" id="ss" class="btn btn-primary" role="button"><i class="fa fa-camera"></i> Take a Screenshot</a>
-                  <a href="#" id="logstream" class="btn btn-primary"><i class="fa fa-water"></i> Logcat Stream</a>
-                  <a href="{% url 'live_api' %}?hash={{ hash }}&amp;package={{ package }}" id="apimon" target="_blank" class="btn btn-primary" style='display: none'><i class="fa fa-search"></i> Live API Monitor</a>
-                  <a href="#" id="stop" class="btn btn-info" role="button" ><i class="fa fa-file-alt"></i> Generate Report</a>
-                </div>
-              </div>
-              <!-- /.card-body -->
-            </div>
-            <!-- /.card -->
-          </div>
-          <!-- /.col -->
-
-
-          <div class="col-md-3">
-            <div class="card card-default">
-              <!-- /.card-header -->
-              <div class="card-body">
-                <div align="center">
-                  <div class="marvel-device htc-one">
-                  <div class="top-bar"></div>
-                  <div class="camera"></div>
-                  <div class="sensor"></div>
-                  <div class="speaker"></div>
-                  <div class="screen" id="container" tabindex="0" style="outline: none;">
-                  <img width="320" height="580" src="{% url 'download' %}screen/screen.png" id="my" onerror="$('#my').attr('src','/static/img/loading.jpg')" style="background-color:black;">
-                  </div>
-                  </div>
-                </div>
-
-                <div class="card-body">
-                  <p>
-                  <div class="input-group input-group-sm">
-                    <input class="form-control form-control-navbar" id="android_text" type="text" placeholder="Text Input" >
-                    <div class="input-group-append">
-                      <button id="android_text_btn" class="btn btn-primary">
-                        <i class="far fa-paper-plane"></i>
-                      </button>
-                    </div>
-                  </div>
-                </p>
-              </div>
-
-              </div>
-              <!-- /.card-body -->
-            </div>
-            <!-- /.card -->
-          </div>
-          <!-- /.col -->
-
-           <div class="col-md-{% if android_version < 5 %}9{% else %}4{% endif %}">
-            <div class="card card-default">
-              <!-- /.card-header -->
-              <div class="card-body">
-
-            <div class="card card-primary card-outline card-outline-tabs">
-              <div class="card-header p-0 border-bottom-0">
-                <ul class="nav nav-tabs" id="tabnav" role="tablist">
-                  <li class="nav-item">
-                    <a class="nav-link active" id="dm-tab" data-toggle="pill" href="#dm" role="tab" aria-controls="dm" aria-selected="true">Dynamic Analyzer</a>
-                  </li>
-                  <li class="nav-item">
-                    <a class="nav-link" id="errors-tab" data-toggle="pill" href="#errors" role="tab" aria-controls="errors" aria-selected="false">Errors</a>
-                  </li>
-                </ul>
-              </div>
-              <div class="card-body">
-                <div class="tab-content" id="tabs">
-                  <div class="tab-pane fade active show" id="dm" role="tabpanel" aria-labelledby="dm-tab">
-                  <textarea id="stat"></textarea>
-                {% if android_version < 5 %}
-                <!-- xposed only-->
-                <br>
-                <button id="run_app" class="btn btn-success"><i class="fas fa-play"></i> Run App</button>
-                {% endif %}
-                <!--box-->
-                <div class="box box-primary">
-                    <!-- /.box-header -->
-                    <!-- form start -->
-                    <form role="form">
-                      <div class="box-body">
-                      <div id="frida_options">
-                        <hr/>
-                          <div class="form-group">
-                          <h4> Default Frida Scripts </h4>
-                            <label>
-                                <input name="default_hooks" type="checkbox" value="api_monitor" checked>
-                                API Monitoring 
-                              </label>
-                              <label>
-                                <input name="default_hooks" type="checkbox" value="ssl_pinning_bypass" checked>
-                                SSL Pinning Bypass 
-                              </label>
-                              <label>
-                              <input name="default_hooks" type="checkbox"  value="root_bypass" checked>
-                                Root Detection Bypass 
-                              </label>
-                              <label>
-                              <input name="default_hooks" type="checkbox" value="debugger_check_bypass" checked>
-                                Debugger Check Bypass
-                              </label>
-                              <label>
-                                <input name="default_hooks" type="checkbox" value="dump_clipboard" checked>
-                                Clipboard Monitor
-                                </label>
-                          </div>
-                        <hr/>
-                       <div class="form-group">
-                        <h4> Auxiliary Frida Scripts</h4>
-                            <label>
-                            <input name="auxiliary" type="checkbox" value="enum_class" id="enum_class">
-                              Enumerate Loaded Classes
-                            </label> 
-                             <label>
-                            <input name="auxiliary" type="checkbox" value="string_catch" id="string_catch">
-                               Capture Strings
-                            </label>
-                             <label>
-                            <input name="auxiliary" type="checkbox" value="string_compare" id="string_compare">
-                                Capture String Comparisons
-                            </label>
-                            <br />
-                             <label>
-                              <input onclick="aux_click(this)" name="auxiliary" type="checkbox" value="enum_methods" id="enum_methods">
-                              Enumerate Class methods
-                            </label>
-                             <input type="text" class="form-control" id="class_name" placeholder="java.io.File">
-
-                             <label>
-                              <input onclick="aux_click(this)" name="auxiliary" type="checkbox" value="search_class" id="search_class">
-                              Search Class Pattern
-                            </label>
-                             <input type="text" class="form-control" id="class_search" placeholder="ssl\.Trust*">
-                             <label>
-                             <input onclick="aux_click(this)" name="auxiliary" type="checkbox"  value="trace_class" id="trace_class">
-                              Trace Class Methods
-                            </label>
-                             <input type="text" class="form-control" id="class_trace" placeholder="java.net.Socket,java.io.File,java.lang.String">
-                       </div>
-                    
-                        <hr/>
-                        <div class="form-group">
-                          <h4> Instrumentation </h4>
-                        </div>
-
-                        <div class="box-footer">
-                          <button id="frida_spawn" type="submit" class="btn btn-success btn-sm"><i class="far fa-play-circle"></i> Spawn & Inject</button>
-                          <button id="frida_session" type="submit" class="btn btn-success btn-sm" disabled><i class="fas fa-redo"></i> Inject </button>
-                          <button id="frida_attach" type="submit" class="btn btn-success btn-sm"><i class="fas fa-bug"></i> Attach </button>
-                          <button id="frida_get" class="btn btn-primary btn-sm" hidden><i class="fas fa-code"></i> Injected Code</button>
-                       </div>
-                      </div>  <!--Frida options, hidden for xposed -->
-
-
-                        <hr/>
-                        <div class="form-group">
-                          <h4> User Interface </h4>
-                        </div>
-
-                        {% if activities or exported_activities %}
-                        <label class="box-title" for="activities">Activities</label>
-                        <div class="form-group form-inline" id="start_activity_form">
-                          <select style="width: 15rem" class="form-select form-control form-group mb-2 mr-3" name="activities" id="activities">
-                            <optgroup label="Exported Activities">
-                              {% for activity in exported_activities %}
-                            <option value="{{ activity }}">{{ activity }}</option>
-                                      {% endfor %}
-                            </optgroup>
-                            <optgroup label="Activities">
-                                        {% for activity in activities %}
-                              <option value="{{ activity }}">{{ activity }}</option>
-                                        {% endfor %}
-                            </optgroup>
-                          </select>
-                          <button id="start_activity" type="submit" class="btn btn-primary btn-sm form-group mb-2">♢ Start Activity</button>
-                        </div>
-                        {% endif %}
-            
-                        {% if deeplinks %}
-                        <div class="mt-3">
-                          <label class="box-title" for="deeplinks">Deep Links</label>
-                          <div class="form-group form-inline">
-                            <select class="form-select form-control form-group mb-2 mr-2" name="schemes" id="schemes">
-                            {% for activity, intent in deeplinks.items %}
-                              <optgroup label="{{ activity }} - Schemes">
-                                {% for scheme in intent.schemes %}
-                                  <option value="{{ scheme }}">{{ scheme }}</option>
-                                {% endfor %}
-                              </optgroup>
-                            {% endfor %}
-                            </select>
-                            <select class="form-select form-control form-group mb-2 mr-2" name="hosts" id="hosts">
-                              {% for activity, intent in deeplinks.items %}
-                                <optgroup label="{{ activity }} - Hosts">
-                                  {% for host in intent.hosts %}
-                                    <option value="{{ host }}">{{ host }}</option>
-                                  {% endfor %}
-                                  <option value=""></option>
-                                </optgroup>
-                              {% endfor %}
-                            </select>
-                            <select class="form-select form-control form-group mb-2 mr-2" name="paths" id="paths">
-                              {% for activity, intent in deeplinks.items %}
-                                <optgroup label="{{ activity }} - Paths/PathPrefixes">
-                                  {% for path in intent.paths %}
-                                    <option value="{{ path }}">{{ path }}</option>
-                                  {% endfor %}
-                                  {% for path_prefix in intent.path_prefixs %}
-                                    <option value="{{ path_prefix }}">{{ path_prefix }}</option>
-                                  {% endfor %}
-                                  <option value=""></option>
-                                </optgroup>
-                              {% endfor %}
-                            </select>
-                            <input type="text" class="form-control form-group mb-2 mr-2" id="query" placeholder="/foo?bar=">
-                            <button id="start_deeplink" type="submit" class="btn btn-primary btn-sm form-group mb-2">▶ Deeplink</button>
-                          </div>
-                        </div>
-                        {% endif %}
-                        
-                      </div>
-                      <!-- /.box-body -->
-                     
-                    </form>
-                  </div>
-           
-                 
-
-               
-
-                  
-              <!--tab end-->
-
-                  </div>
-
-                  <div class="tab-pane fade" id="errors" role="tabpanel" aria-labelledby="errors-tab">
-                    <iframe sandbox frameborder="0" width="100%" height="650px" id="er"></iframe>
-                  </div>
-                </div>
-              </div>
-              <!-- /.card -->
-            </div>
-
-
-              </div>
-              <!-- /.card-body -->
-            </div>
-            <!-- /.card -->
-          </div>
-          <!-- /.col -->
-
-           <div class="col-md-5" id="codeedit">
-            <div class="card card-default">
-              <div class="card-header">
-                <h3 class="card-title"><i class="fa fa-code"></i> Frida Code Editor </h3>
-                <!-- /.card-tools -->
-              </div>
-              <!-- /.card-header -->
-              <div class="card-body">
-                <div id="code-editor">
-<textarea id="code-js" rows="100">
-  Java.perform(function() {
-    // Use send() for logging
-  });
-</textarea>
-                </div>
-                <br/>
-                <div class="form-group">
-                  <span class="box-title">Available Scripts (Use CTRL to choose multiple)  </span>
-                  <button id="loadscript" type="submit" class="btn btn-primary btn-sm">Load</button>
-                </div>
-                <div class="form-group">
-                  <select id="fd_scs" size="10" multiple="" class="form-control">
-                  </select>
-                </div>
-              
-              </div>
-              <!-- /.card-body -->
-            </div>
-            <!-- /.card -->
-          </div>
-          <!-- /.col -->
-
-            <div class="col-md-12">
-            <div class="card card-default">
-              <!-- /.card-header -->
-              <div class="card-body">
-                   
-                   <div id="shell">
-                    <output></output>
-                    <div id="input-line" class="input-line">
-                      <div class="prompt"></div><div><input class="cmdline" autofocus /></div>
-                    </div>
-                  </div>
-              
-              </div>
-              <!-- /.card-body -->
-            </div>
-            <!-- /.card -->
-          </div>
-          <!-- /.col -->
-
-
-          <div class="col-md-12">
-            <div class="card card-default">
-              <!-- /.card-header -->
-              <div class="card-body">
-                   <div>
-                    <h4 class="page-header"><strong>Frida Logs </strong></h4>
-                    <div id="messages"></br>Data refreshed in every 3 seconds.</div>
-                    <pre class="frida-pre" id="frida-logs" style="font-size:15pt"></pre>
-                  </div>
-              </div>
-              <!-- /.card-body -->
-            </div>
-            <!-- /.card -->
-          </div>
-          <!-- /.col -->
-
-        
-        </div>
-
-        </div>
-       </div>
-     </div>
-    </div>
 </div>
 
-<!--Loader-->
-<div class="hidden loading">
-  <div class='uil-ring-css' style='transform:scale(0.79);'>
-    <div></div>
-  </div>
-  </div>
-<!-- Modal -->
-<div class="modal fade" id="frida_attach_mdl" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<!-- Frida Attach-to-Process Modal -->
+<div class="modal fade" id="frida_attach_mdl" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLabel">Attach to a Running Process</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+    <div class="modal-content" style="background: #161b22; border: 1px solid #30363d;">
+      <div class="modal-header" style="background: #21262d; border-bottom: 1px solid #30363d;">
+        <h5 class="modal-title" style="color: #f0f6fc;">Attach to a Running Process</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close" style="color: #8b949e;">&times;</button>
       </div>
-      <div class="modal-body">
-        <form role="form">
-          <div class="form-group">
-            <select id="process_select" class="form-select" aria-label="Select a process">
-            </select>
-          </div>
-        </form>
+      <div class="modal-body" style="background: #0d1117;">
+        <select id="process_select" class="form-control" style="background: #0d1117; color: #f0f6fc; border: 1px solid #30363d;" aria-label="Select a process"></select>
       </div>
-      <div class="modal-footer">
-        <button id="attach_to_pid" type="button" class="btn btn-primary"><i class="fas fa-bug"></i> Attach</button>
+      <div class="modal-footer" style="background: #161b22; border-top: 1px solid #30363d;">
+        <button id="attach_to_pid" type="button" class="terminal-btn active"><i class="fas fa-bug"></i> Attach</button>
       </div>
-
     </div>
   </div>
 </div>
 
- <!-- Modal -->
- <div class="modal fade" id="get_code_modal" tabindex="-1" role="dialog">
+<!-- Injected Frida Script Modal -->
+<div class="modal fade" id="get_code_modal" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-xl">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h4 class="modal-title">Injected Frida Script</h4>
-        <button type="button" class="close" data-dismiss="modal">&times;</button>
+    <div class="modal-content" style="background: #161b22; border: 1px solid #30363d;">
+      <div class="modal-header" style="background: #21262d; border-bottom: 1px solid #30363d;">
+        <h4 class="modal-title" style="color: #f0f6fc;">Injected Frida Script</h4>
+        <button type="button" class="close" data-dismiss="modal" style="color: #8b949e;">&times;</button>
       </div>
-      <div class="modal-body" id="injected_content">
-      </div>
+      <div class="modal-body" id="injected_content" style="background: #0d1117;"></div>
     </div>
   </div>
 </div>
-
-
-<!-- Modal -->
-<div class="modal" id="tls_modal" tabindex="-1" role="dialog">
-  <div class="modal-dialog modal-xl">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h4 class="modal-title">Run TLS/SSL Security Tests - {{ package }}</h4>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">×</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        <form role="form">
-            <div class="form-group">
-                <p>TLS/SSL Security test helps you to evaluate the security of your application's network connections. These tests are applicable only for applications that performs network connections over HTTP protocol. We run multiple TLS/SSL tests against the application.<br>
-                </p>
-                <p>
-                <strong>TLS Misconfiguration Test </strong> - Enable HTTPS MITM Proxy, Remove Root CA, Run the App for 25 seconds.<br>
-                <code>This test will uncover insecure configurations that allow HTTPS connections bypassing certificate errors or SSL/TLS errors in WebViews. This is equivalent to not having TLS.</code><br>
-                </p>
-                <p>
-                <strong>TLS Pinning/Certificate Transparency Test </strong> - Enable HTTPS MITM Proxy, Install Root CA, Run the App for 25 seconds.<br>
-                <code>This test will evaluate the application's TLS/SSL hardening controls and will check if the application implement certificate or public key pinning and or certificate transparency.</code><br>
-                <p>
-                <strong>TLS Pinning/Certificate Transparency Bypass Test </strong> - Enable HTTPS MITM Proxy, Install Root CA, Bypass Certificate/Public Key Pinning or Certificate Transparency.<br>
-                <code>This test tries to bypass certificate or public key pinning and or certificate transparency controls in your application. MobSF can bypass most of the generic implementations.</code><br>
-                </p>
-                <p><strong>NOTE: </strong><i>For Better results, while the application is running, navigate through different business logic flows that will trigger network connections over HTTP protocol. Make sure that no other applications are running during the test.</i></p>
-              </div>
-            <div class="form-group">
-              <label>Test Progress</label>
-              <textarea id="tls_text" class="form-control" rows="10" placeholder="" disabled=""></textarea>
-            </div>
-            <div class="form-group">
-              <table class="table table-bordered table-hover table-striped">
-                <thead>
-                    <tr>
-                      <th>TESTS</th>
-                      <th>RESULT</th>
-                  </tr>
-                </thead>
-                <tbody>
-                   <tr>
-                    <td>TLS Misconfiguration Test</td>
-                    <td id="tls_1">-</td>
-                  </tr>
-                  <tr>
-                    <td>TLS Pinning/Certificate Transparency Test</td>
-                    <td id="tls_2">-</td>
-                  </tr>
-                  <tr>
-                    <td>TLS Pinning/Certificate Transparency Bypass Test</td>
-                    <td id="tls_3">-</td>
-                  </tr>
-                  <tr>
-                    <td>Cleartext Traffic Test</td>
-                    <td id="tls_4">-</td>
-                  </tr>
-              </tbody>
-              </table>
-            </div>
-
-          </form>
-      </div>
-       <div class="modal-footer">
-        <button id="run_tls_tests" type="button" class="btn btn-primary"><i class="fas fa-bolt"></i> Run TLS/SSL Tests</button>
-      </div>
-    </div>
-
-
-
-    <!-- /.modal-content -->
-  </div>
-  <!-- /.modal-dialog -->
-</div>
-<!-- End Modal -->
 
 {% endblock %}
 {% block extra_scripts %}
@@ -622,7 +1272,7 @@ function action(url, data, on_success){
     data : data,
     success : function(json){ on_success(json) },
     error : function(xhr, ajaxOptions, thrownError) {
-      document.getElementById("er").srcdoc = xhr.responseText;
+      print_status('Request failed (' + xhr.status + '): ' + (thrownError || 'unknown error'), 'error');
     }
   });
 }
@@ -657,7 +1307,7 @@ function load_frida_others(){
 }
 
 // Code Editor
-var editor = CodeMirror.fromTextArea(document.getElementById("code-js"), {
+var editor = CodeMirror.fromTextArea(document.getElementById("frida_code"), {
     lineNumbers: true,
     mode: "javascript",
     gutters: ["CodeMirror-lint-markers"],
@@ -949,15 +1599,54 @@ if (loc.includes('&install=0')){
 
 
 
-//Print Status
-function print_status(message){
-  $('#stat').append(message + '\n');
-  $('#stat').scrollTop($('#stat')[0].scrollHeight);
+// Build a single terminal log line via safe DOM APIs (no innerHTML concatenation
+// of untrusted data - message may contain device/APK-controlled strings).
+function build_log_line(message, level){
+  var now = new Date();
+  var time = now.toLocaleTimeString('en-US', { hour12: false }) + '.' + String(now.getMilliseconds()).padStart(3, '0');
+  var logLine = document.createElement('div');
+  logLine.className = 'log-line';
+
+  var timestampSpan = document.createElement('span');
+  timestampSpan.className = 'log-timestamp';
+  timestampSpan.textContent = time;
+
+  var levelSpan = document.createElement('span');
+  levelSpan.className = 'log-level ' + level;
+  levelSpan.textContent = level.toUpperCase();
+
+  var messageSpan = document.createElement('span');
+  messageSpan.className = 'log-message';
+  messageSpan.textContent = message;
+
+  logLine.appendChild(timestampSpan);
+  logLine.appendChild(levelSpan);
+  logLine.appendChild(messageSpan);
+  return logLine;
+}
+
+//Print Status - Updated for modern terminal console
+function print_status(message, level){
+  level = level || 'info';
+  var terminalBody = document.getElementById('terminalBody');
+  if (terminalBody) {
+    terminalBody.appendChild(build_log_line(message, level));
+    terminalBody.scrollTop = terminalBody.scrollHeight;
+  } else {
+    $('#stat').append(message + '\n');
+    $('#stat').scrollTop($('#stat')[0].scrollHeight);
+  }
 }
 //Print TLS/SSL test progress inside modal
 function print_tls_progress(message){
-  $('#tls_text').append(message + '\n');
-  $('#tls_text').scrollTop($('#tls_text')[0].scrollHeight);
+  var terminalBody = document.getElementById('terminalBody');
+  if (terminalBody) {
+    terminalBody.appendChild(build_log_line(message, 'info'));
+    terminalBody.scrollTop = terminalBody.scrollHeight;
+  } else {
+    $('#tls_text').append(message + '\n');
+    $('#tls_text').scrollTop($('#tls_text')[0].scrollHeight);
+  }
 }
 
 print_status("Setting up MobSF Dynamic Analysis environment...");
@@ -996,7 +1685,8 @@ var screenfunc;
 $("#screen").click(function() {
       var stext = $("#screen").text();
       if (stext.includes("Show Screen")){
-          $("#screen").html("<i class='fa fa-mobile'></i> Stop Screen");
+          $("#screen .action-icon i").attr('class', 'fa fa-mobile');
+          $("#screen .action-label").text('Stop Screen');
           print_status('Screen streaming started.')
           touch = "on";
           screenfunc = setInterval(function(){
@@ -1020,7 +1710,8 @@ $("#screen").click(function() {
                });
           }, 2000);
       } else {
-          $("#screen").html("<i class='fa fa-mobile-alt'></i> Show Screen");
+          $("#screen .action-icon i").attr('class', 'fa fa-mobile-alt');
+          $("#screen .action-label").text('Show Screen');
           print_status("Screen streaming stopped.");
           $('#my').attr('src', '/static/img/loading.jpg');
           clearInterval(screenfunc);
@@ -1181,13 +1872,13 @@ $("#ss").click(function() {
 //MobSF CA
 
 $("#rootca").click(function() {
-  var stext = $("#rootca").text();
+  var stext = $("#rootca .action-label").text();
   var act;
   if (stext.includes("Remove Root CA")){
-    $("#rootca").html("<i class='fa fa-certificate'></i> Install Root CA");
+    $("#rootca .action-label").text('Install Root CA');
     act = "remove";
   } else {
-    $("#rootca").html("<i class='fa fa-certificate'></i> Remove Root CA");
+    $("#rootca .action-label").text('Remove Root CA');
     act = "install";
   }
   action(document.location.origin + '/mobsf_ca/', {action: act}, function(json) {
@@ -1205,13 +1896,15 @@ $("#rootca").click(function() {
 //MobSF Global Proxy
 
 $("#proxy").click(function() {
-  var stext = $("#proxy").text();
+  var stext = $("#proxy .action-label").text();
   var act;
-  if (stext.includes("Unset HTTP(S) Proxy")){
-    $("#proxy").html("<i class='fas fa-eye'></i> Set HTTP(S) Proxy");
+  if (stext.includes("Unset Proxy")){
+    $("#proxy .action-icon i").attr('class', 'fas fa-eye');
+    $("#proxy .action-label").text('Set Proxy');
     act = "unset";
   } else {
-    $("#proxy").html("<i class='fas fa-eye-slash'></i> Unset HTTP(S) Proxy");
+    $("#proxy .action-icon i").attr('class', 'fas fa-eye-slash');
+    $("#proxy .action-label").text('Unset Proxy');
     act = "set";
   }
   action(document.location.origin + '/global_proxy/', {action: act}, function(json) {
@@ -1490,8 +2183,7 @@ $("#stop").one( "click", function() {
     $("#screen").click();
   action(document.location.origin + '/collect_logs/', { hash: '{{ hash }}'}, function(json) {
     if (json.status==="ok"){
-      $('#stop').addClass("btn btn-success");
-      $('#stop').text("Please Wait...");
+      $('#stop .action-label').text("Please Wait...");
       print_status("Downloading logs.");
       print_status("Stopping Application.");
     } else{

--- a/mobsf/templates/general/about.html
+++ b/mobsf/templates/general/about.html
@@ -1,30 +1,311 @@
-{% extends "base/base_layout.html" %}
- {% block sidebar_option %}
-      sidebar-collapse
-{% endblock %}
-{% block content %}
+{% extends "base/base_layout.html" %}{% block sidebar_option%}sidebar-collapse{% endblock %}{% block content %}
+
 <div class="content-wrapper">
-  <div class="content-header">
-  </div>
-   <div class="container-fluid">
-        <div class="row">
-            <div class="col-lg-12">
-            <div class="card">
-              <div class="card-body">
-                <h1>About Mobile Security Framework</h1>
-              
-                  <p class="lead">
-                    Mobile Security Framework (MobSF) is a security research platform for mobile applications in Android, iOS and Windows Mobile. MobSF can be used for a variety of use cases such as mobile application security, penetration testing, malware analysis, and privacy analysis. The Static Analyzer supports popular mobile app binaries like APK, IPA, APPX and source code. Meanwhile, the Dynamic Analyzer supports both Android and iOS applications and offers a platform for interactive instrumented testing, runtime data and network traffic analysis. MobSF seamlessly integrates with your DevSecOps or CI/CD pipeline, facilitated by REST APIs and CLI tools, enhancing your security workflow with ease.
-                 </p>
-                  <p> <strong>Author:</strong> <a href="//twitter.com/ajinabraham">Ajin Abraham</a> </p>      
-                  <h2>Active Collaborators</h2>
-                    <p><a href="//github.com/magaofei">Magaofei</a></p>
-                    <p><a href="//github.com/matandobr">Matan Dobrushin</a></p>
-                    <p><a href="//github.com/superpoussin22">Vincent Nadal</a></p>
+  <div style="padding: 32px 24px; max-width: 860px; margin: 0 auto">
+    <!-- Header -->
+    <div style="margin-bottom: 32px">
+      <div
+        style="
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          margin-bottom: 10px;
+        ">
+        <div
+          style="
+            width: 42px;
+            height: 42px;
+            background: rgba(88, 166, 255, 0.1);
+            border: 1px solid rgba(88, 166, 255, 0.2);
+            border-radius: 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+          ">
+          <i
+            class="fas fa-shield-alt"
+            style="color: var(--accent-blue, #58a6ff); font-size: 18px"></i>
+        </div>
+        <div>
+          <h1
+            style="
+              margin: 0;
+              font-size: 22px;
+              font-weight: 700;
+              color: var(--text-primary, #e6edf3);
+            ">
+            About MobSF
+          </h1>
+          <p
+            style="
+              margin: 0;
+              color: var(--text-secondary, #8b949e);
+              font-size: 13px;
+            ">
+            Mobile Security Framework
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Description card -->
+    <div class="card" style="margin-bottom: 20px">
+      <div class="card-body" style="padding: 28px !important">
+        <div
+          style="
+            display: flex;
+            gap: 14px;
+            align-items: flex-start;
+            margin-bottom: 20px;
+          ">
+          <div
+            style="
+              flex-shrink: 0;
+              width: 38px;
+              height: 38px;
+              background: rgba(63, 185, 80, 0.1);
+              border: 1px solid rgba(63, 185, 80, 0.2);
+              border-radius: 10px;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+            ">
+            <i
+              class="fas fa-info-circle"
+              style="color: var(--accent-green, #3fb950); font-size: 15px"></i>
+          </div>
+          <div>
+            <h3
+              style="
+                margin: 0 0 10px;
+                font-size: 15px;
+                font-weight: 600;
+                color: var(--text-primary, #e6edf3);
+              ">
+              What is MobSF?
+            </h3>
+            <p
+              style="
+                margin: 0;
+                color: var(--text-secondary, #8b949e);
+                font-size: 13.5px;
+                line-height: 1.75;
+              ">
+              Mobile Security Framework (MobSF) is a security research platform
+              for mobile applications in Android, iOS and Windows Mobile. MobSF
+              can be used for a variety of use cases such as mobile application
+              security, penetration testing, malware analysis, and privacy
+              analysis. The Static Analyzer supports popular mobile app binaries
+              like APK, IPA, APPX and source code. Meanwhile, the Dynamic
+              Analyzer supports both Android and iOS applications and offers a
+              platform for interactive instrumented testing, runtime data and
+              network traffic analysis. MobSF seamlessly integrates with your
+              DevSecOps or CI/CD pipeline, facilitated by REST APIs and CLI
+              tools.
+            </p>
           </div>
         </div>
-       </div>
-     </div>
+
+        <!-- Feature pills -->
+        <div style="display: flex; flex-wrap: wrap; gap: 8px; margin-top: 4px">
+          {% for feat in "Static Analysis" %}
+
+          <span
+            style="
+              background: rgba(88, 166, 255, 0.07);
+              border: 1px solid rgba(88, 166, 255, 0.15);
+              border-radius: 6px;
+              color: var(--text-secondary, #8b949e);
+              font-size: 11.5px;
+              font-weight: 600;
+              padding: 4px 10px;
+              letter-spacing: 0.2px;
+            ">
+            {{ feat }}
+          </span>
+          {% endfor %}
+        </div>
+      </div>
     </div>
+
+    <!-- Author & Collaborators -->
+    <div
+      style="
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+        margin-bottom: 20px;
+      ">
+      <!-- Author -->
+      <div class="card">
+        <div class="card-header">
+          <span class="card-title"
+            ><i class="fas fa-user-circle"></i> Author</span
+          >
+        </div>
+        <div class="card-body" style="padding: 20px !important">
+          <div style="display: flex; align-items: center; gap: 14px">
+            <div
+              style="
+                width: 48px;
+                height: 48px;
+                background: linear-gradient(
+                  135deg,
+                  rgba(88, 166, 255, 0.2),
+                  rgba(88, 166, 255, 0.05)
+                );
+                border: 1px solid rgba(88, 166, 255, 0.2);
+                border-radius: 50%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                flex-shrink: 0;
+              ">
+              <i
+                class="fas fa-user"
+                style="color: var(--accent-blue, #58a6ff); font-size: 18px"></i>
+            </div>
+            <div>
+              <a
+                href="//twitter.com/ajinabraham"
+                target="_blank"
+                rel="noopener"
+                style="
+                  color: var(--text-primary, #e6edf3);
+                  font-weight: 700;
+                  font-size: 14px;
+                  text-decoration: none;
+                  display: flex;
+                  align-items: center;
+                  gap: 6px;
+                ">
+                Ajin Abraham
+                <i
+                  class="fab fa-twitter"
+                  style="color: #1d9bf0; font-size: 12px"></i>
+              </a>
+              <span
+                style="color: var(--text-secondary, #8b949e); font-size: 12px"
+                >Creator &amp; Lead Developer</span
+              >
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Platform -->
+      <div class="card">
+        <div class="card-header">
+          <span class="card-title"
+            ><i class="fas fa-code-branch"></i> Open Source</span
+          >
+        </div>
+        <div class="card-body" style="padding: 20px !important">
+          <div style="display: flex; align-items: center; gap: 14px">
+            <div
+              style="
+                width: 48px;
+                height: 48px;
+                background: rgba(139, 148, 158, 0.08);
+                border: 1px solid rgba(139, 148, 158, 0.15);
+                border-radius: 50%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                flex-shrink: 0;
+              ">
+              <i
+                class="fab fa-github"
+                style="
+                  color: var(--text-primary, #e6edf3);
+                  font-size: 22px;
+                "></i>
+            </div>
+            <div>
+              <a
+                href="https://github.com/MobSF/Mobile-Security-Framework-MobSF"
+                target="_blank"
+                rel="noopener"
+                style="
+                  color: var(--text-primary, #e6edf3);
+                  font-weight: 700;
+                  font-size: 14px;
+                  text-decoration: none;
+                ">
+                MobSF on GitHub
+              </a>
+              <p
+                style="
+                  color: var(--text-secondary, #8b949e);
+                  font-size: 12px;
+                  margin: 0;
+                ">
+                MIT Licensed
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Active Collaborators -->
+    <div class="card">
+      <div class="card-header">
+        <span class="card-title"
+          ><i class="fas fa-users"></i> Active Collaborators</span
+        >
+      </div>
+      <div class="card-body" style="padding: 20px !important">
+        <div style="display: flex; flex-wrap: wrap; gap: 12px">
+          <a
+            href="//github.com/magaofei"
+            target="_blank"
+            rel="noopener"
+            style="
+              display: flex;
+              align-items: center;
+              gap: 10px;
+              background: var(--bg-surface, #111820);
+              border: 1px solid var(--border-subtle, rgba(48, 54, 61, 0.6));
+              border-radius: 10px;
+              padding: 10px 16px;
+              text-decoration: none;
+              transition: all 0.18s ease;
+            "
+            onmouseover="
+              this.style.borderColor = 'rgba(88,166,255,0.3)';
+              this.style.background = 'rgba(88,166,255,0.05)';
+            "
+            onmouseout="
+              this.style.borderColor = 'rgba(48,54,61,0.6)';
+              this.style.background = 'var(--bg-surface,#111820)';
+            ">
+            <div
+              style="
+                width: 32px;
+                height: 32px;
+                background: rgba(88, 166, 255, 0.1);
+                border-radius: 50%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+              ">
+              <i
+                class="fab fa-github"
+                style="color: var(--accent-blue, #58a6ff); font-size: 14px"></i>
+            </div>
+            <span
+              style="
+                color: var(--text-primary, #e6edf3);
+                font-size: 13px;
+                font-weight: 600;
+              "
+              >Magaofei</span
+            >
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/mobsf/templates/general/donate.html
+++ b/mobsf/templates/general/donate.html
@@ -1,62 +1,79 @@
 {% extends "base/base_layout.html" %}
- {% block sidebar_option %}
-      sidebar-collapse
-{% endblock %}
+{% block sidebar_option %}sidebar-collapse{% endblock %}
 {% block content %}
 <div class="content-wrapper">
-  <div class="content-header">
-  </div>
-   <div class="container-fluid">
-        <div class="row">
-            <div class="col-lg-12">
-            <div class="card">
-              <div class="card-body">
-                <h1>Donate to MobSF Project</h1>
-                <p class="lead">
-                    You're Awesome! Thank you for your support ♥
-                </p>
-                <div class="row">
+  <div style="padding:32px 24px;max-width:860px;margin:0 auto;">
 
-                    <div class="col-lg-6">
-                      
-                        <div class="card">
-                            <div class="card-header ui-sortable-handle" >
-                              <h3 class="card-title">
-                            Github Sponsors
-                              </h3>
-                            </div><!-- /.card-header -->
-                            <div class="card-body">
-                                <p style="text-align: center;">
-                                    Donate to MobSF project through Github Sponsors. Github will match the first $5000 in donations.
-                                </br>
-                                </br>
-                                <iframe src="https://github.com/sponsors/ajinabraham/button" title="Sponsor ajinabraham" height="35" width="116" style="border: 0;"></iframe>
-                                </p>
-                            </div><!-- /.card-body -->
-                          </div>
-                    </div>
-                    <div class="col-lg-6">
-                    <div class="card">
-                        <div class="card-header ui-sortable-handle" >
-                          <h3 class="card-title">
-                          Paypal Donations
-                          </h3>
-                        </div><!-- /.card-header -->
-                        <div class="card-body">
-                            <p style="text-align: center;">
-                         You can also donate to MobSF project through PayPal.
-                         </br>
-                         </br>
-                           <a href="https://www.paypal.com/paypalme/ajinabraham" rel="noopener noreferrer"><input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" /></a>
-                        </p>
-                        </div><!-- /.card-body -->
-                    </div>
-                    </div>
-                </div>
+    <!-- Header -->
+    <div style="text-align:center;margin-bottom:40px;">
+      <div style="width:64px;height:64px;background:rgba(248,81,73,0.1);border:1px solid rgba(248,81,73,0.2);border-radius:16px;display:inline-flex;align-items:center;justify-content:center;margin-bottom:16px;">
+        <i class="fas fa-heart" style="color:var(--accent-red,#f85149);font-size:26px;"></i>
+      </div>
+      <h1 style="margin:0 0 8px;font-size:26px;font-weight:800;color:var(--text-primary,#e6edf3);letter-spacing:-0.5px;">Support MobSF</h1>
+      <p style="margin:0;color:var(--text-secondary,#8b949e);font-size:15px;max-width:440px;margin:0 auto;line-height:1.6;">
+        You're awesome! Your support keeps MobSF free and open source for the security community. ♥
+      </p>
+    </div>
+
+    <!-- Donation cards -->
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:20px;margin-bottom:28px;">
+
+      <!-- GitHub Sponsors -->
+      <div class="card" style="border-color:rgba(88,166,255,0.15) !important;">
+        <div class="card-header" style="background:linear-gradient(135deg,rgba(88,166,255,0.08),var(--bg-surface,#111820)) !important;">
+          <span class="card-title">
+            <i class="fab fa-github" style="color:var(--text-primary,#e6edf3);"></i>
+            GitHub Sponsors
+          </span>
+        </div>
+        <div class="card-body" style="padding:28px !important;text-align:center;">
+          <div style="width:52px;height:52px;background:rgba(139,148,158,0.08);border:1px solid rgba(139,148,158,0.15);border-radius:12px;display:inline-flex;align-items:center;justify-content:center;margin-bottom:16px;">
+            <i class="fab fa-github" style="font-size:24px;color:var(--text-primary,#e6edf3);"></i>
+          </div>
+          <p style="color:var(--text-secondary,#8b949e);font-size:13.5px;line-height:1.6;margin:0 0 20px;">
+            Donate through GitHub Sponsors. GitHub matches the first $5,000 in donations — double the impact!
+          </p>
+          <div style="display:flex;justify-content:center;">
+            <iframe src="https://github.com/sponsors/ajinabraham/button"
+                    title="Sponsor ajinabraham" height="35" width="116"
+                    style="border:0;border-radius:6px;"></iframe>
           </div>
         </div>
-       </div>
-     </div>
+      </div>
+
+      <!-- PayPal -->
+      <div class="card" style="border-color:rgba(248,81,73,0.15) !important;">
+        <div class="card-header" style="background:linear-gradient(135deg,rgba(248,81,73,0.06),var(--bg-surface,#111820)) !important;">
+          <span class="card-title">
+            <i class="fab fa-paypal" style="color:#009cde;"></i>
+            PayPal Donation
+          </span>
+        </div>
+        <div class="card-body" style="padding:28px !important;text-align:center;">
+          <div style="width:52px;height:52px;background:rgba(0,156,222,0.08);border:1px solid rgba(0,156,222,0.15);border-radius:12px;display:inline-flex;align-items:center;justify-content:center;margin-bottom:16px;">
+            <i class="fab fa-paypal" style="font-size:24px;color:#009cde;"></i>
+          </div>
+          <p style="color:var(--text-secondary,#8b949e);font-size:13.5px;line-height:1.6;margin:0 0 20px;">
+            Make a one-time or recurring donation to MobSF via PayPal — fast, secure and simple.
+          </p>
+          <a href="https://www.paypal.com/paypalme/ajinabraham" rel="noopener noreferrer" target="_blank"
+             style="display:inline-flex;align-items:center;gap:8px;background:rgba(0,156,222,0.1);border:1px solid rgba(0,156,222,0.25);border-radius:10px;color:#009cde;font-size:13px;font-weight:700;padding:10px 20px;text-decoration:none;transition:all 0.18s ease;"
+             onmouseover="this.style.background='rgba(0,156,222,0.18)';this.style.transform='translateY(-1px)';"
+             onmouseout="this.style.background='rgba(0,156,222,0.1)';this.style.transform='translateY(0)';">
+            <i class="fab fa-paypal"></i> Donate via PayPal
+          </a>
+        </div>
+      </div>
     </div>
+
+    <!-- Thank you note -->
+    <div style="background:rgba(63,185,80,0.05);border:1px solid rgba(63,185,80,0.15);border-radius:14px;padding:24px;text-align:center;">
+      <i class="fas fa-heart" style="color:var(--accent-red,#f85149);font-size:20px;margin-bottom:12px;display:block;"></i>
+      <p style="color:var(--text-secondary,#8b949e);font-size:13.5px;margin:0;line-height:1.7;max-width:520px;margin:0 auto;">
+        Every donation — big or small — directly funds development, server costs, and keeps MobSF free for the global security community. Thank you for your generosity.
+      </p>
+    </div>
+
+  </div>
 </div>
 {% endblock %}

--- a/mobsf/templates/general/dynamic.html
+++ b/mobsf/templates/general/dynamic.html
@@ -1,57 +1,103 @@
 {% extends "base/base_layout.html" %}
- {% block sidebar_option %}
-      sidebar-collapse
-{% endblock %}
+{% block sidebar_option %}sidebar-collapse{% endblock %}
 {% block content %}
 <div class="content-wrapper">
-  <div class="content-header">
-  </div>
-   <div class="container-fluid">
-        <div class="row">
-        
+  <div style="padding:32px 24px;max-width:860px;margin:0 auto;">
 
-            <div class="col-lg-12">
-            <div class="card">
-              <div class="card-body">
-                <h1>MobSF Dynamic Analyzer</h1>
-              </br></br>
-                  <div class="h-100 d-flex align-items-center justify-content-center">
-                    <div class="card justify-content-center" style="width: 25rem;">
+    <!-- Header -->
+    <div style="margin-bottom:32px;">
+      <div style="display:flex;align-items:center;gap:12px;margin-bottom:8px;">
+        <div style="width:42px;height:42px;background:rgba(88,166,255,0.1);border:1px solid rgba(88,166,255,0.2);border-radius:12px;display:flex;align-items:center;justify-content:center;">
+          <i class="fas fa-play-circle" style="color:var(--accent-blue,#58a6ff);font-size:18px;"></i>
+        </div>
+        <div>
+          <h1 style="margin:0;font-size:22px;font-weight:700;color:var(--text-primary,#e6edf3);">Dynamic Analyzer</h1>
+          <p style="margin:0;color:var(--text-secondary,#8b949e);font-size:13px;">Runtime analysis and instrumented testing</p>
+        </div>
+      </div>
+    </div>
 
-                      
-                        <i style="color:#A4C639;" class="fab fa-android fa-10x d-flex justify-content-center"></i>
-                        <div class="card-body">
-                          <h4 class="d-flex justify-content-center">Android Dynamic Analyzer</h4>
-                          <p class="card-text">Perform Dynamic Analysis of Android Applications.</p>
-                          <a href="{% url 'dynamic_android' %}" class="btn btn-primary d-flex justify-content-center">Android Dynamic Analyzer</a>
-                        </div>
-                      </div>
-                      <div class="h-100 d-flex align-items-center justify-content-center">&nbsp;&nbsp;&nbsp;</div>
-                      <div class="card justify-content-center" style="width: 25rem;">
-                        <i style="color:#cccccc;" class="fab fa-apple fa-10x d-flex justify-content-center"></i>
-                        <div class="card-body">
-                          <h4 class="d-flex justify-content-center">iOS Dynamic Analyzer</h4>
-                          <p class="card-text">Perform Dynamic Analysis of iOS Applications.</p>
-                          <div class="dropdown d-flex justify-content-center">
-                            <button class="btn btn-primary dropdown-toggle" type="button" id="iosDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                              iOS Dynamic Analyzer
-                            </button>
-                            <div class="dropdown-menu" aria-labelledby="iosDropdown">
-                              <a class="dropdown-item" href="{% url 'dynamic_ios' %}">
-                                <i class="fa fa-microchip mr-2"></i>Corellium VM
-                              </a>
-                              <a class="dropdown-item" href="{% url 'dynamic_ios_device' %}">
-                                <i class="fas fa-mobile-alt mr-2"></i>Jailbroken Device
-                              </a>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
+    <!-- Platform cards -->
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:20px;">
+
+      <!-- Android -->
+      <div class="card" style="border-color:rgba(164,198,57,0.2) !important;transition:all 0.2s ease;"
+           onmouseover="this.style.borderColor='rgba(164,198,57,0.4)';this.style.transform='translateY(-2px)';"
+           onmouseout="this.style.borderColor='rgba(164,198,57,0.2)';this.style.transform='translateY(0)';">
+        <div class="card-body" style="padding:36px 28px !important;text-align:center;">
+          <div style="width:80px;height:80px;background:rgba(164,198,57,0.08);border:1px solid rgba(164,198,57,0.2);border-radius:20px;display:inline-flex;align-items:center;justify-content:center;margin-bottom:20px;">
+            <i class="fab fa-android" style="font-size:38px;color:#A4C639;"></i>
+          </div>
+          <h3 style="margin:0 0 8px;font-size:17px;font-weight:700;color:var(--text-primary,#e6edf3);">Android Dynamic Analyzer</h3>
+          <p style="color:var(--text-secondary,#8b949e);font-size:13.5px;line-height:1.6;margin:0 0 24px;">
+            Perform runtime analysis of Android applications with instrumented testing and network traffic inspection.
+          </p>
+
+          <div style="display:flex;flex-wrap:wrap;gap:6px;justify-content:center;margin-bottom:24px;">
+            <span style="background:rgba(164,198,57,0.08);border:1px solid rgba(164,198,57,0.15);border-radius:6px;color:#A4C639;font-size:11px;font-weight:700;padding:3px 9px;">APK</span>
+            <span style="background:rgba(164,198,57,0.08);border:1px solid rgba(164,198,57,0.15);border-radius:6px;color:#A4C639;font-size:11px;font-weight:700;padding:3px 9px;">APKS</span>
+            <span style="background:rgba(164,198,57,0.08);border:1px solid rgba(164,198,57,0.15);border-radius:6px;color:#A4C639;font-size:11px;font-weight:700;padding:3px 9px;">XAPK</span>
+          </div>
+
+          <a href="{% url 'dynamic_android' %}"
+             style="display:inline-flex;align-items:center;gap:8px;background:rgba(164,198,57,0.1);border:1px solid rgba(164,198,57,0.3);border-radius:10px;color:#A4C639;font-size:13.5px;font-weight:700;padding:11px 24px;text-decoration:none;transition:all 0.18s ease;width:100%;justify-content:center;"
+             onmouseover="this.style.background='rgba(164,198,57,0.18)';this.style.boxShadow='0 4px 16px rgba(164,198,57,0.15)';"
+             onmouseout="this.style.background='rgba(164,198,57,0.1)';this.style.boxShadow='none';">
+            <i class="fas fa-play"></i> Launch Android Analyzer
+          </a>
+        </div>
+      </div>
+
+      <!-- iOS -->
+      <div class="card" style="border-color:rgba(200,200,200,0.15) !important;transition:all 0.2s ease;"
+           onmouseover="this.style.borderColor='rgba(200,200,200,0.3)';this.style.transform='translateY(-2px)';"
+           onmouseout="this.style.borderColor='rgba(200,200,200,0.15)';this.style.transform='translateY(0)';">
+        <div class="card-body" style="padding:36px 28px !important;text-align:center;">
+          <div style="width:80px;height:80px;background:rgba(200,200,200,0.06);border:1px solid rgba(200,200,200,0.12);border-radius:20px;display:inline-flex;align-items:center;justify-content:center;margin-bottom:20px;">
+            <i class="fab fa-apple" style="font-size:38px;color:#cccccc;"></i>
+          </div>
+          <h3 style="margin:0 0 8px;font-size:17px;font-weight:700;color:var(--text-primary,#e6edf3);">iOS Dynamic Analyzer</h3>
+          <p style="color:var(--text-secondary,#8b949e);font-size:13.5px;line-height:1.6;margin:0 0 24px;">
+            Analyze iOS applications on Corellium virtual machines or physical jailbroken devices with full instrumentation support.
+          </p>
+
+          <div style="display:flex;flex-wrap:wrap;gap:6px;justify-content:center;margin-bottom:24px;">
+            <span style="background:rgba(200,200,200,0.06);border:1px solid rgba(200,200,200,0.12);border-radius:6px;color:#cccccc;font-size:11px;font-weight:700;padding:3px 9px;">IPA</span>
+            <span style="background:rgba(200,200,200,0.06);border:1px solid rgba(200,200,200,0.12);border-radius:6px;color:#cccccc;font-size:11px;font-weight:700;padding:3px 9px;">DYLIB</span>
+            <span style="background:rgba(200,200,200,0.06);border:1px solid rgba(200,200,200,0.12);border-radius:6px;color:#cccccc;font-size:11px;font-weight:700;padding:3px 9px;">.A</span>
+          </div>
+
+          <!-- Dropdown buttons -->
+          <div class="dropdown" style="width:100%;">
+            <button class="btn btn-secondary dropdown-toggle"
+                    style="width:100%;justify-content:center;background:rgba(200,200,200,0.06) !important;border-color:rgba(200,200,200,0.2) !important;color:#cccccc !important;font-size:13.5px;font-weight:700;padding:11px 24px !important;"
+                    type="button" id="iosDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <i class="fas fa-play" style="margin-right:8px;"></i> Launch iOS Analyzer
+            </button>
+            <div class="dropdown-menu" aria-labelledby="iosDropdown" style="width:100%;">
+              <a class="dropdown-item" href="{% url 'dynamic_ios' %}">
+                <i class="fa fa-microchip" style="width:18px;opacity:.7;color:var(--accent-blue,#58a6ff);"></i>
+                Corellium VM
+              </a>
+              <a class="dropdown-item" href="{% url 'dynamic_ios_device' %}">
+                <i class="fas fa-mobile-alt" style="width:18px;opacity:.7;color:var(--accent-green,#3fb950);"></i>
+                Jailbroken Device
+              </a>
+            </div>
           </div>
         </div>
-       </div>
-     </div>
+      </div>
     </div>
+
+    <!-- Info bar -->
+    <div style="margin-top:20px;background:rgba(88,166,255,0.05);border:1px solid rgba(88,166,255,0.12);border-radius:12px;padding:16px 20px;display:flex;align-items:center;gap:12px;">
+      <i class="fas fa-info-circle" style="color:var(--accent-blue,#58a6ff);font-size:16px;flex-shrink:0;"></i>
+      <p style="margin:0;color:var(--text-secondary,#8b949e);font-size:13px;line-height:1.5;">
+        Dynamic analysis requires a connected Android emulator/device or iOS VM/jailbroken device. Ensure your environment is properly configured before proceeding.
+        <a href="https://mobsf.github.io/docs/#/" target="_blank" style="color:var(--accent-blue,#58a6ff);margin-left:4px;">View Setup Guide →</a>
+      </p>
+    </div>
+
+  </div>
 </div>
 {% endblock %}

--- a/mobsf/templates/general/dynamic.html
+++ b/mobsf/templates/general/dynamic.html
@@ -69,10 +69,12 @@
 
           <!-- Dropdown buttons -->
           <div class="dropdown" style="width:100%;">
-            <button class="btn btn-secondary dropdown-toggle"
-                    style="width:100%;justify-content:center;background:rgba(200,200,200,0.06) !important;border-color:rgba(200,200,200,0.2) !important;color:#cccccc !important;font-size:13.5px;font-weight:700;padding:11px 24px !important;"
+            <button class="btn btn-secondary"
+                    style="width:100%;display:flex;align-items:center;justify-content:center;background:rgba(200,200,200,0.06) !important;border-color:rgba(200,200,200,0.2) !important;color:#cccccc !important;font-size:13.5px;font-weight:700;padding:11px 24px !important;"
                     type="button" id="iosDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <i class="fas fa-play" style="margin-right:8px;"></i> Launch iOS Analyzer
+              <i class="fas fa-play" style="margin-right:8px;"></i>
+              <span>Launch iOS Analyzer</span>
+              <i class="fas fa-chevron-down" style="margin-left:8px;font-size:10px;"></i>
             </button>
             <div class="dropdown-menu" aria-labelledby="iosDropdown" style="width:100%;">
               <a class="dropdown-item" href="{% url 'dynamic_ios' %}">

--- a/mobsf/templates/general/error.html
+++ b/mobsf/templates/general/error.html
@@ -1,23 +1,81 @@
 {% extends "base/base_layout.html" %}
- {% block sidebar_option %}
-      sidebar-collapse
+{% block sidebar_option %}sidebar-collapse{% endblock %}
+{% block extra_css %}
+<style>
+  .error-page-wrap {
+    padding: 32px 24px;
+    max-width: 760px;
+    margin: 0 auto;
+  }
+
+  .error-page-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 20px;
+  }
+
+  .error-page-actions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border-radius: 10px;
+    font-size: 13px;
+    font-weight: 700;
+    padding: 10px 20px;
+    text-decoration: none;
+    transition: all .18s ease;
+  }
+
+  .error-page-actions .action-new {
+    background: rgba(63,185,80,0.1);
+    border: 1px solid rgba(63,185,80,0.25);
+    color: var(--accent-green,#3fb950);
+  }
+  .error-page-actions .action-new:hover {
+    background: rgba(63,185,80,0.18);
+    transform: translateY(-1px);
+  }
+
+  .error-page-actions .action-recent {
+    background: rgba(88,166,255,0.08);
+    border: 1px solid rgba(88,166,255,0.2);
+    color: var(--accent-blue,#58a6ff);
+  }
+  .error-page-actions .action-recent:hover {
+    background: rgba(88,166,255,0.15);
+    transform: translateY(-1px);
+  }
+
+  .error-page-actions .action-docs {
+    background: rgba(139,148,158,0.08);
+    border: 1px solid rgba(139,148,158,0.15);
+    color: var(--text-secondary,#8b949e);
+  }
+  .error-page-actions .action-docs:hover {
+    background: rgba(139,148,158,0.15);
+    color: var(--text-primary,#e6edf3);
+  }
+</style>
 {% endblock %}
 {% block content %}
 <div class="content-wrapper">
-  <div class="content-header">
-  </div>
-   <div class="container-fluid">
-        <div class="row">
-            <div class="col-lg-12">
-            <div class="card">
-              <div class="card-body">
-                <h2>Error</h2>
-                  <p class="lead">{{ exp }}</p>
-                  <p>{{ doc }}</p>
-          </div>
-        </div>
-       </div>
-     </div>
+  <div class="error-page-wrap">
+
+    {% include "components/error_card.html" with error_title="Analysis Error" error_summary=exp error_suggestion=doc error_type="error" %}
+
+    <div class="error-page-actions">
+      <a href="{% url 'home' %}" class="action-new">
+        <i class="fas fa-upload"></i> New Analysis
+      </a>
+      <a href="{% url 'recent' %}" class="action-recent">
+        <i class="fas fa-history"></i> Recent Scans
+      </a>
+      <a href="https://mobsf.github.io/docs/#/" target="_blank" rel="noopener" class="action-docs">
+        <i class="fas fa-book"></i> Documentation
+      </a>
     </div>
+
+  </div>
 </div>
 {% endblock %}

--- a/mobsf/templates/general/home.html
+++ b/mobsf/templates/general/home.html
@@ -32,8 +32,13 @@
       font-family: var(--font-main);
       font-size: 14px;
       overflow-x: hidden;
-      zoom: 0.85;
     }
+
+    /* Same rationale as base_layout.html: this standalone page never has
+       real sidebar content, so the pushmenu hamburger has nothing to
+       reveal. Keyed off actual content (.nav-sidebar), not the
+       sidebar-collapse class - see base_layout.html for why. */
+    body:not(:has(.nav-sidebar)) #nbar { display: none !important; }
 
     /* ── Background grid (matches other pages) ── */
     body::before {

--- a/mobsf/templates/general/home.html
+++ b/mobsf/templates/general/home.html
@@ -1,355 +1,794 @@
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">
-   <head>
-      <meta charset="utf-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <meta name="viewport" content="width=device-width, initial-scale=1">
-      <meta name="description" content="Mobile Security Framework (MobSF) is an automated, all-in-one mobile application (Android/iOS/Windows) pen-testing, malware analysis and security assessment framework capable of performing static and dynamic analysis.">
-      <meta name="author" content="Ajin Abraham">
-      <link rel="icon" href="{% static "img/favicon.ico" %}">
-      <title>Mobile Security Framework - MobSF</title>
-      <link rel="stylesheet" href="{% static "adminlte/dashboard/css/adminlte.min.css" %}">
-      <link rel="stylesheet" href="{% static "adminlte/plugins/fontawesome-free/css/all.min.css" %}">
-      <link rel="stylesheet" href="{% static "others/css/spinner.css" %}">
-      <link rel="stylesheet" href="{% static "landing/css/home.css" %}">
-      <!-- Google Font: Source Sans Pro -->
-      <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
-   </head>
-   <body class="text-center">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Mobile Security Framework (MobSF) — Automated mobile application security analysis platform.">
+  <meta name="author" content="Ajin Abraham">
+  <link rel="icon" href="{% static "img/favicon.ico" %}">
+  <title>Mobile Security Framework - MobSF</title>
 
-    <div class="d-flex h-100 p-3 mx-auto flex-column">  
-        <nav class="nav nav-masthead justify-content-center">
-            <a class="nav-link active" href="{% url 'recent' %}">SCANS</a>
-            <a class="nav-link" href="{% url 'dynamic' %}">DYNAMIC ANALYZER</a>
-            <div class="pad">
-                <img src="{% static "img/mobsf_logo.png" %}" alt="MobSF Logo" height="30" width="90" />
-            </div>  
-            <a class="nav-link" href="{% url 'api_docs' %}">API</a>
-            <a class="nav-link" href="{% url 'about' %}">ABOUT</a>
-            {% if user.is_authenticated %}
-            <a id="dropdownSubMenu1" href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="nav-link dropdown-toggle"><i class="fa fa-user-circle" aria-hidden="true"></i> </a>
-            <a class="nav-link"></a>
-            <ul aria-labelledby="dropdownSubMenu1" class="dropdown-menu border-0 shadow" style="left: 0px; right: inherit;">
-                <li><a href="#" class="dropdown-item"> <small>{{ request.user.username }} <span class="badge badge-primary"> {% if user.is_staff %} Admin {% else %}{{ request.user.groups.all.0 }} {% endif %}</span></small></a></li>
-                <li class="dropdown-divider"></li>
-                <li><a href="{% url 'change_password' %}" class="dropdown-item"><i class="fa fa-asterisk" aria-hidden="true"></i> Change Password </a></li>
-                {% if user.is_staff %}<li><a href="{% url 'users' %}" class="dropdown-item"><i class="fa fa-users" aria-hidden="true"></i> User Management </a></li>{% endif %}
-                <li><a href="{% url 'logout' %}" class="dropdown-item"><i class="fa fa-power-off" aria-hidden="true"></i> Logout </a></li>
-            </ul>
-            {% endif %}
-            <a class="nav-link">
-                <form action="/search" method="GET">
-                    <input name="query" type="text" class="form-control form-control-sm" placeholder="Search">
-                </form>
-            </a>
-        </nav>
+  <!-- Same CSS stack as base_layout so the shared nav renders identically -->
+  <link rel="stylesheet" href="{% static "adminlte/plugins/fontawesome-free/css/all.min.css" %}">
+  <link rel="stylesheet" href="{% static "others/css/mobsf-modern.css" %}">
+  <link rel="stylesheet" href="{% static "adminlte/dashboard/css/adminlte.min.css" %}">
+  <link rel="stylesheet" href="{% static "adminlte/plugins/overlayScrollbars/css/OverlayScrollbars.min.css" %}">
+  <link rel="stylesheet" href="{% static "others/css/spinner.css" %}">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
-        <header class="masthead mb-auto">
-            <div class="inner">
-            </div>
-        </header>
+  <style>
+    /* Design tokens (--bg-*, --text-*, --accent-*, etc.) are defined once in
+       others/css/mobsf-modern.css, linked above - do not redeclare them here. */
 
-        <main role="main" class="inner cover">
-            <div class="inner cover">
-                <div style="visibility:hidden; opacity:0" id="drop">
-                <div id="textnode">Drop anywhere!</div>
-                </div>
-                </br>
-                <form id="upload_form" enctype="multipart/form-data" method="post">
-                {% csrf_token %}
-                <div class="fileUpload btn btn-lg btn-secondary" id="but">
-                    <input type="file" name="file" id="uploadFile" placeholder="Choose File" multiple>
-                    <span class="fas fa-cloud-upload-alt"></span>
-                    Upload &amp; Analyze
-                </div>
-                <br />
-                <small><i>Drag &amp; Drop anywhere!</i></small>
-                <p></p>
-                <h5 class="lead" id="status"></h5>
-                <progress id="progressBar" value="0" max="100" style="width:300px;visibility:hidden;" ></progress>
-                </form>
-            </div>
-        </main>
+    *, *::before, *::after { box-sizing: border-box; }
 
-        <footer class="mastfoot mt-auto">
-            <input type="download" id="package" class="form-control form-control-sm" placeholder="Download & Scan Package"/>
-            <p></p>
-            <div class="inner">
-                <h6> <a href="{% url 'recent' %}">RECENT SCANS</a>  |  <a href="{% url 'dynamic' %}">DYNAMIC ANALYZER</a>  |  <a href="{% url 'api_docs' %}">API</a>   |  <a href="{% url 'donate' %}">DONATE ♥</a> |  <a target="_blank"
-                    href="https://mobsf.github.io/docs/#/">DOCS</a>  | <a href="{% url 'about' %}">ABOUT</a></h6>
-                </br>
-                <p>&copy; {% now "Y" %}  Mobile Security Framework - MobSF {{ version }}</p>
-            </div>
-            <div id="alert" class="alert-bar">Analysis started! Please wait to be redirected or check recent scans after sometime.</div>
-        </footer>
+    html, body {
+      margin: 0; padding: 0;
+      min-height: 100%;
+      background: var(--bg-base);
+      color: var(--text-primary);
+      font-family: var(--font-main);
+      font-size: 14px;
+      overflow-x: hidden;
+      zoom: 0.85;
+    }
+
+    /* ── Background grid (matches other pages) ── */
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background-image:
+        linear-gradient(rgba(88,166,255,0.025) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(88,166,255,0.025) 1px, transparent 1px);
+      background-size: 48px 48px;
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    body::after {
+      content: '';
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      height: 400px;
+      background:
+        radial-gradient(ellipse 700px 300px at 50% -50px, rgba(35,134,54,0.07) 0%, transparent 100%),
+        radial-gradient(ellipse 400px 200px at 20% 100px, rgba(88,166,255,0.04) 0%, transparent 100%);
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    /* ── Wrapper ── */
+    .wrapper {
+      position: relative;
+      z-index: 1;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ── Navbar overrides so base nav.html looks right on this standalone page ── */
+    .main-header {
+      background: var(--bg-surface) !important;
+      border-bottom: 1px solid var(--border-subtle) !important;
+      box-shadow: 0 2px 16px rgba(0,0,0,0.4) !important;
+      position: sticky !important;
+      top: 0;
+      z-index: 100;
+      width: 100%;
+    }
+    .navbar-dark .nav-link {
+      color: var(--text-secondary) !important;
+      font-size: 12px !important;
+      font-weight: 600 !important;
+      letter-spacing: 0.6px !important;
+      text-transform: uppercase;
+      transition: color var(--transition);
+    }
+    .navbar-dark .nav-link:hover { color: var(--accent-blue) !important; }
+    #nbar { color: var(--text-secondary) !important; }
+    .form-control-navbar {
+      background: var(--bg-input) !important;
+      border: 1px solid var(--border-default) !important;
+      color: var(--text-primary) !important;
+      border-radius: 8px !important;
+      font-size: 12.5px !important;
+      padding: 6px 12px !important;
+    }
+    .form-control-navbar:focus {
+      border-color: var(--accent-blue) !important;
+      box-shadow: 0 0 0 3px var(--glow-blue) !important;
+    }
+    .btn-navbar { background: none !important; color: var(--text-secondary) !important; }
+    .btn-navbar:hover { color: var(--accent-blue) !important; }
+    /* Dropdown */
+    .dropdown-menu {
+      background: var(--bg-elevated) !important;
+      border: 1px solid var(--border-default) !important;
+      border-radius: 14px !important;
+      box-shadow: 0 12px 40px rgba(0,0,0,0.5) !important;
+      padding: 6px !important;
+      animation: dropIn 0.15s ease;
+    }
+    @keyframes dropIn { from { opacity:0; transform:translateY(-6px); } to { opacity:1; transform:translateY(0); } }
+    .dropdown-item {
+      color: var(--text-primary) !important;
+      border-radius: 7px !important;
+      padding: 8px 12px !important;
+      font-size: 13px !important;
+      transition: all var(--transition);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .dropdown-item:hover { background: rgba(88,166,255,0.1) !important; color: var(--accent-blue) !important; }
+    .dropdown-divider { border-color: var(--border-subtle) !important; margin: 4px 0 !important; }
+    .badge.bg-info {
+      background: rgba(88,166,255,0.12) !important;
+      color: var(--accent-blue) !important;
+      border: 1px solid rgba(88,166,255,0.25) !important;
+      font-size: 10px !important;
+      padding: 3px 8px !important;
+      border-radius: 20px !important;
+    }
+
+    /* ── Hero ── */
+    .hero {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 64px 20px 48px;
+      text-align: center;
+    }
+
+    .hero-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      background: rgba(63,185,80,0.08);
+      border: 1px solid rgba(63,185,80,0.2);
+      border-radius: 20px;
+      color: var(--accent-green);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 5px 16px;
+      margin-bottom: 26px;
+      letter-spacing: 0.3px;
+    }
+
+    .hero-title {
+      font-size: clamp(34px, 5vw, 54px);
+      font-weight: 800;
+      line-height: 1.1;
+      letter-spacing: -1.2px;
+      margin-bottom: 18px;
+      background: linear-gradient(135deg, var(--text-primary) 0%, rgba(230,237,243,0.55) 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .hero-sub {
+      color: var(--text-secondary);
+      font-size: 16px;
+      max-width: 500px;
+      line-height: 1.65;
+      margin-bottom: 48px;
+    }
+
+    /* ── Drop zone wrapper ── */
+    .drop-zone-wrapper {
+      width: 100%;
+      max-width: 600px;
+      position: relative;
+    }
+
+    /* ── Full-page drag overlay ── */
+    #page-drop-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      z-index: 9000;
+      background: rgba(8,11,15,0.82);
+      backdrop-filter: blur(6px);
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      gap: 16px;
+      border: 3px dashed rgba(88,166,255,0.4);
+      animation: overlayIn 0.15s ease;
+      pointer-events: none;
+    }
+    #page-drop-overlay.active {
+      display: flex;
+      pointer-events: all;
+    }
+    @keyframes overlayIn {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+    #page-drop-overlay i {
+      font-size: 52px;
+      color: var(--accent-blue);
+      animation: bounce 0.8s ease infinite alternate;
+    }
+    @keyframes bounce {
+      from { transform: translateY(0); }
+      to   { transform: translateY(-10px); }
+    }
+    #page-drop-overlay p {
+      color: var(--accent-blue);
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: 0.3px;
+      margin: 0;
+    }
+    #page-drop-overlay small {
+      color: var(--text-secondary);
+      font-size: 13px;
+    }
+
+    /* ── Upload button ── */
+    .upload-area { position: relative; width: 100%; }
+
+    .upload-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 14px;
+      width: 100%;
+      background: linear-gradient(135deg, var(--accent-green-dim) 0%, #2ea043 100%);
+      border: none;
+      border-radius: 16px;
+      color: #fff;
+      font-size: 17px;
+      font-weight: 700;
+      padding: 20px 28px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      position: relative;
+      overflow: hidden;
+      letter-spacing: 0.2px;
+      box-shadow: 0 4px 24px rgba(35,134,54,0.25);
+    }
+    .upload-btn::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(255,255,255,0.1), transparent);
+      pointer-events: none;
+    }
+    .upload-btn::after {
+      content: '';
+      position: absolute;
+      top: 0; left: -100%;
+      width: 100%; height: 100%;
+      background: linear-gradient(90deg, transparent, rgba(255,255,255,0.07), transparent);
+      transition: left 0.6s ease;
+    }
+    .upload-btn:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 40px rgba(35,134,54,0.4), 0 0 0 1px rgba(63,185,80,0.3);
+    }
+    .upload-btn:hover::after { left: 100%; }
+    .upload-btn:active { transform: translateY(0); box-shadow: 0 4px 16px rgba(35,134,54,0.25); }
+
+    .upload-btn input[type=file] {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
+      width: 100%;
+      z-index: 2;
+    }
+
+    .upload-icon {
+      width: 38px; height: 38px;
+      background: rgba(255,255,255,0.18);
+      border-radius: 9px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 17px;
+      flex-shrink: 0;
+    }
+
+    /* ── Drag hint strip ── */
+    .upload-hint {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      color: var(--text-muted);
+      font-size: 12.5px;
+      margin-top: 12px;
+    }
+    .upload-hint .hint-divider {
+      width: 40px; height: 1px;
+      background: var(--border-subtle);
+    }
+
+    /* ── Package input ── */
+    .pkg-row { margin-top: 16px; width: 100%; position: relative; }
+
+    .pkg-input {
+      width: 100%;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-default);
+      border-radius: 12px;
+      color: var(--text-primary);
+      font-size: 13.5px;
+      padding: 12px 16px 12px 44px;
+      outline: none;
+      transition: all 0.18s;
+    }
+    .pkg-input:focus {
+      border-color: var(--accent-blue);
+      box-shadow: 0 0 0 3px var(--glow-blue);
+    }
+    .pkg-input::placeholder { color: var(--text-muted); }
+
+    .pkg-icon {
+      position: absolute;
+      left: 15px;
+      top: 50%;
+      transform: translateY(-50%);
+      color: var(--text-muted);
+      font-size: 14px;
+      pointer-events: none;
+    }
+
+    /* ── Status / progress ── */
+    .upload-status { margin-top: 14px; min-height: 24px; text-align: center; }
+    #status {
+      color: var(--accent-blue);
+      font-family: var(--font-mono);
+      font-size: 12.5px;
+      letter-spacing: 0.3px;
+    }
+    #progressBar {
+      width: 100%; height: 4px;
+      border-radius: 4px;
+      background: var(--border-default);
+      border: none; outline: none;
+      margin-top: 8px;
+      appearance: none; -webkit-appearance: none;
+    }
+    #progressBar::-webkit-progress-bar { background: var(--border-default); border-radius: 4px; }
+    #progressBar::-webkit-progress-value {
+      background: linear-gradient(90deg, var(--accent-green-dim), var(--accent-green));
+      border-radius: 4px;
+    }
+
+    /* ── Format pills ── */
+    .formats-section { margin-top: 28px; }
+    .formats-label {
+      color: var(--text-muted);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.8px;
+      text-transform: uppercase;
+      margin-bottom: 10px;
+    }
+    .formats-row {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 6px;
+    }
+    .format-pill {
+      background: var(--bg-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: 6px;
+      color: var(--text-muted);
+      font-size: 11px;
+      font-weight: 700;
+      font-family: var(--font-mono);
+      letter-spacing: 0.5px;
+      padding: 4px 10px;
+      transition: all 0.15s ease;
+    }
+    .format-pill:hover {
+      border-color: var(--border-default);
+      color: var(--text-secondary);
+    }
+
+    /* ── Alert bar ── */
+    #alert {
+      position: fixed;
+      bottom: 28px;
+      left: 50%;
+      transform: translateX(-50%) translateY(20px);
+      background: linear-gradient(135deg, var(--accent-green-dim), #2ea043);
+      color: #fff;
+      border-radius: 12px;
+      padding: 13px 26px;
+      font-size: 13.5px;
+      font-weight: 600;
+      box-shadow: 0 8px 32px rgba(35,134,54,0.4);
+      opacity: 0;
+      transition: all 0.3s cubic-bezier(0.4,0,0.2,1);
+      z-index: 10000;
+      white-space: nowrap;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    #alert.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+    /* ── Footer ── */
+    .main-footer {
+      background: var(--bg-surface) !important;
+      border-top: 1px solid var(--border-subtle) !important;
+      color: var(--text-muted) !important;
+      font-size: 12px !important;
+      padding: 14px 24px !important;
+      text-align: center;
+      z-index: 1;
+      position: relative;
+    }
+    .main-footer a { color: var(--text-secondary) !important; text-decoration: none; transition: color var(--transition); margin: 0 8px; }
+    .main-footer a:hover { color: var(--accent-blue) !important; }
+    .footer-links { display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 2px; margin-bottom: 8px; }
+    .footer-links .sep { color: var(--border-default); font-size: 10px; }
+
+    /* ── Loading overlay ── */
+    .loading {
+      position: fixed;
+      inset: 0;
+      background: rgba(8,11,15,0.85);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9999;
+      backdrop-filter: blur(6px);
+    }
+    .hidden { display: none !important; }
+
+    /* ── Scrollbar ── */
+    html { scrollbar-width: thin; scrollbar-color: var(--border-default) var(--bg-base); }
+    ::-webkit-scrollbar { width: 6px; }
+    ::-webkit-scrollbar-track { background: var(--bg-base); }
+    ::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: 3px; }
+  </style>
+</head>
+<body class="hold-transition sidebar-collapse layout-fixed layout-navbar-fixed">
+<div class="wrapper">
+
+  <!-- ── Shared Navbar (identical to all other pages) ── -->
+  {% include "base/nav.html" %}
+
+  <!-- ── Hero ── -->
+  <main class="hero">
+    <div class="hero-badge">
+      <i class="fas fa-circle" style="font-size:8px;"></i>
+      Automated Mobile Security Analysis
     </div>
 
-    <!--Loading Ring-->
-    <div class="hidden loading">
-        <div class='uil-ring-css' style='transform:scale(0.79);'>
-          <div></div>
+    <h1 class="hero-title">Analyze. Detect. Secure.</h1>
+    <p class="hero-sub">Upload any Android, iOS or Windows mobile application for automated static and dynamic security analysis.</p>
+
+    <div class="drop-zone-wrapper">
+
+      <!-- Upload button -->
+      <form id="upload_form" enctype="multipart/form-data" method="post">
+        {% csrf_token %}
+        <div class="upload-area">
+          <label class="upload-btn" id="but" for="uploadFile">
+            <div class="upload-icon"><i class="fas fa-cloud-upload-alt"></i></div>
+            <span>Upload &amp; Analyze</span>
+            <input type="file" name="file" id="uploadFile" placeholder="Choose File" multiple>
+          </label>
         </div>
+      </form>
+
+      <!-- Drag hint -->
+      <div class="upload-hint">
+        <span class="hint-divider"></span>
+        <i class="fas fa-arrows-alt" style="font-size:11px;"></i>
+        Drag &amp; drop files anywhere on this page
+        <span class="hint-divider"></span>
+      </div>
+
+      <!-- Package / URL download -->
+      <div class="pkg-row">
+        <i class="fas fa-download pkg-icon"></i>
+        <input id="package" class="pkg-input" type="text"
+               placeholder="Or paste package name / URL to download &amp; scan…">
+      </div>
+
+      <!-- Status -->
+      <div class="upload-status">
+        <h5 id="status"></h5>
+        <progress id="progressBar" value="0" max="100" style="visibility:hidden;"></progress>
+      </div>
+
+      <!-- Supported formats -->
+      <div class="formats-section">
+        <p class="formats-label">Supported formats</p>
+        <div class="formats-row">
+          <span class="format-pill">.APK</span>
+          <span class="format-pill">.APKS</span>
+          <span class="format-pill">.XAPK</span>
+          <span class="format-pill">.AAB</span>
+          <span class="format-pill">.JAR</span>
+          <span class="format-pill">.AAR</span>
+          <span class="format-pill">.SO</span>
+          <span class="format-pill">.IPA</span>
+          <span class="format-pill">.DYLIB</span>
+          <span class="format-pill">.A</span>
+          <span class="format-pill">.ZIP</span>
+          <span class="format-pill">.APPX</span>
+        </div>
+      </div>
+
+    </div><!-- /.drop-zone-wrapper -->
+  </main>
+
+  <!-- ── Full-page drag & drop overlay ── -->
+  <div id="page-drop-overlay">
+    <i class="fas fa-cloud-upload-alt"></i>
+    <p>Drop your file to analyze</p>
+    <small>APK · IPA · APPX · ZIP · AAB and more</small>
+  </div>
+
+  <!-- ── Alert toast ── -->
+  <div id="alert">
+    <i class="fas fa-check-circle"></i>
+    Analysis started! Redirecting to results…
+  </div>
+
+  <!-- ── Loading spinner ── -->
+  <div class="hidden loading">
+    <div class="uil-ring-css" style="transform:scale(0.79);">
+      <div></div>
     </div>
+  </div>
 
-    <script src="{% static "adminlte/plugins/jquery.min.js" %}"></script>
-    <script src="{% static "adminlte/plugins/bootstrap/bootstrap.bundle.min.js" %}"></script>
-      <script>
-            let warning = "This is a demo MobSF instance. Anything uploaded here will be publicly available. Do you want to continue?";
-            // Result View
-            function load_result(url){
-                hide_loader();
-                // Display alert notification
-                var x = document.getElementById("alert");
-                x.className = "alert-bar show slide-up";
-                setTimeout(function () {
-                    x.className = x.className.replace("show", "");
-                }, 10000);
+  <!-- ── Footer ── -->
+  <footer class="main-footer">
+    <div class="footer-links">
+      <a href="{% url 'recent' %}"><i class="fas fa-history" style="margin-right:4px;font-size:10px;"></i>Recent Scans</a>
+      <span class="sep">·</span>
+      <a href="{% url 'dynamic' %}"><i class="fas fa-play-circle" style="margin-right:4px;font-size:10px;"></i>Dynamic Analyzer</a>
+      <span class="sep">·</span>
+      <a href="{% url 'api_docs' %}">API</a>
+      <span class="sep">·</span>
+      <a href="{% url 'donate' %}" style="color:var(--accent-red) !important;"><i class="fas fa-heart" style="margin-right:4px;font-size:10px;"></i>Donate</a>
+      <span class="sep">·</span>
+      <a href="https://mobsf.github.io/docs/#/" target="_blank" rel="noopener">Docs</a>
+      <span class="sep">·</span>
+      <a href="{% url 'about' %}">About</a>
+    </div>
+    <strong>© {% now "Y" %} Mobile Security Framework — MobSF &nbsp;|&nbsp;
+      <a href="https://ajinabraham.com">Ajin Abraham</a> &nbsp;|&nbsp;
+      <a href="https://opensecurity.in">OpenSecurity</a>
+    </strong>
+    <div style="color:var(--text-muted);margin-top:4px;">v{{ version }}</div>
+  </footer>
 
-                // Redirect after showing alertbar
-                setTimeout(function () {
-                    window.location.href = url;
-                }, 1000); // Adjust delay as needed
-            }
+</div><!-- /.wrapper -->
 
-            //Download and scan APK
-            $('#package').keypress(function(event){
-                var keycode = (event.keyCode ? event.keyCode : event.which);
-                if(keycode == '13'){
-                    _("status").innerText = 'Trying to download ...';
-                    show_loader();
-                    $.ajax({
-                        url : '{% url "download_scan" %}', 
-                        type : "POST",
-                        dataType: "json", 
-                        data : {
-                            package: $('#package').val(),
-                            csrfmiddlewaretoken: '{{ csrf_token }}',
-                        },
-                        success : function(json){
-                            if (json.status === 'ok'){
-                                setInterval(function() {
-                                    get_status(json.hash);
-                                }, 500);
+<script src="{% static "adminlte/plugins/jquery.min.js" %}"></script>
+<script src="{% static "adminlte/plugins/bootstrap/bootstrap.bundle.min.js" %}"></script>
+<script src="{% static "adminlte/dashboard/js/adminlte.min.js" %}"></script>
+<script>
+  /* ────────────────────────────────────────────────
+     Helpers
+  ──────────────────────────────────────────────── */
+  const _  = (id) => document.getElementById(id);
+  const overlay = _('page-drop-overlay');
 
-                                url = json.analyzer + '/' + json.hash + '/';
-                                load_result(url);
-                            } else {
-                                hide_loader();
-                                _("status").innerText = json.description;
-                            }
-                        },
-                        error : function(xhr, ajaxOptions, thrownError) {
-                            hide_loader();
-                            if (thrownError === 'Forbidden'){
-                                _("status").innerText = "You do not have permission to download and scan!";
-                            }
-                        }
-                    });
-                }
-            });
-            function show_loader(){
-                var loadingOverlay = document.querySelector('.loading');
-                loadingOverlay.classList.remove('hidden');
-            }
+  let warning = "This is a demo MobSF instance. Anything uploaded here will be publicly available. Do you want to continue?";
 
-            function hide_loader(){
-                var loadingOverlay = document.querySelector('.loading');
-                loadingOverlay.classList.add('hidden');
-            }
-            // Existing
-            function _(el){
-                return document.getElementById(el);
-            }
+  function show_loader() { document.querySelector('.loading').classList.remove('hidden'); }
+  function hide_loader() { document.querySelector('.loading').classList.add('hidden'); }
 
-            // Response Handler     
-            function responseHandler(json, isbutton) {
-                if (json.status === 'error') {
-                    _("status").innerText = json.description;
-                } else {
-                    setInterval(function() {
-                        get_status(json.hash);
-                    }, 500);
-                    var url = json.analyzer + '/' + json.hash + '/';
-                    load_result(url);
-                }
-            }
+  function load_result(url) {
+    hide_loader();
+    const alert_el = _('alert');
+    alert_el.classList.add('show');
+    setTimeout(() => { alert_el.classList.remove('show'); }, 10000);
+    setTimeout(() => { window.location.href = url; }, 1000);
+  }
 
-
-           // Get Scan status
-           function get_status(checksum){
-                var xhr = new XMLHttpRequest();
-                xhr.open("POST", '{% url "status" %}', true);
-                xhr.setRequestHeader("X-CSRFToken", '{{ csrf_token }}');
-                xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
-                xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-                xhr.onload = function() {
-                    if (xhr.status >= 200 && xhr.status < 300) {
-                        var response = JSON.parse(xhr.responseText);
-                        if (response.status === 'ok') {
-                            const last_log = response.logs[response.logs.length - 1];
-                            _("status").innerText = last_log.status + ' .';
-                            var number = Math.ceil((Math.floor(Math.random() * 5)));
-                            for (i=0;i<number;i++){
-                                _("status").innerText += '.';
-                            }
-                        }
-                    } else {
-                        console.log("Error:", xhr.statusText);
-                    }
-                };
-                xhr.onerror = function() {
-                    console.log("Failed to get scan status");
-                };
-                xhr.send('hash=' + checksum);
-           }
-
-            function progressHandler(event) {
-                var percent = (event.loaded / event.total) * 100;
-                console.log("Uploaded ..." + Math.round(percent));
-                _("progressBar").value = Math.round(percent);
-                _("status").innerText = Math.round(percent) + "% Uploaded ...";
-            }
-            function completeHandler(event) {
-                if(event.currentTarget.status === 403){
-                    _("status").innerText = "You do not have permission to upload!";
-                    return;
-                } else {
-                    var json = JSON.parse(event.target.responseText);
-                    responseHandler(json);
-                }
-            }
-            function errorHandler(event) {
-                _("status").innerText = "Upload Failed!";
-            }
-            function abortHandler(event) {
-                _("status").innerText = "Upload Aborted!";
-            }
-          // Is valid file extensions
-          function isValidExt(file_name){
-                var val = file_name.toLowerCase();
-                var regex = new RegExp("^(.{1,300}?)\.({{exts}})$");
-                val = val.replace(/^.*[\\\/]/, '');
-                if (!(regex.test(val))) {
-                    _('status').innerText = "MobSF only supports APK, APKS, XAPK, AAB, JAR, AAR, SO, IPA, DYLIB, A, ZIP, and APPX files.";
-                    return false;
-                }
-                return true;
+  /* ────────────────────────────────────────────────
+     Status polling
+  ──────────────────────────────────────────────── */
+  function get_status(checksum) {
+    var xhr = new XMLHttpRequest();
+    xhr.open("POST", '{% url "status" %}', true);
+    xhr.setRequestHeader("X-CSRFToken", '{{ csrf_token }}');
+    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+    xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+    xhr.onload = function() {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          var response = JSON.parse(xhr.responseText);
+          if (response.status === 'ok') {
+            var last_log = response.logs[response.logs.length - 1];
+            _('status').innerText = last_log.status + ' …';
           }
-          // Is allowed mimetype
-          function isValidMime(file_mime){
-                if (file_mime.length < 1)
-                    // bypass if mime is not available
-                    return true; 
-                var supported = [{% for mime in mimes %}'{{mime}}',{% endfor %}];
-                if(supported.indexOf(file_mime) >-1)
-                    return true;
-                 _('status').innerText = "MIME type (" + file_mime + ") is not supported!";
-                return false;
-          }
-         // File Upload
-         function uploadFile(file, i) {
-           try {
-                if (!isValidExt(file.name) || !isValidMime(file.type)){
-                    return;
-                }
-                _("progressBar").style.visibility = "visible";
-                var url = '{% url "upload" %}'
-                var xhr = new XMLHttpRequest()
-                xhr.open('POST', url, true)
-                xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
-                xhr.setRequestHeader("X-CSRFToken", '{{ csrf_token }}');
-                xhr.upload.addEventListener("progress", progressHandler, false);
-                xhr.addEventListener("load", completeHandler, false);
-                xhr.addEventListener("error", errorHandler, false);
-                xhr.addEventListener("abort", abortHandler, false);
-                var formdata = new FormData();
-                formdata.append("file", file);
-                xhr.send(formdata)
-            } catch (e) {
-                alert("Error:" + e);
-            }
-           }
-         
-           function handleFiles(files) {
-               files = [...files]
-               files.forEach(uploadFile)
-           }
-         
-           // Full Screen Drag & Drop File Upload
-           var lastTarget = null;
-           function isFile(evt) {
-               var dt = evt.dataTransfer;
-         
-               for (var i = 0; i < dt.types.length; i++) {
-                   if (dt.types[i] === "Files") {
-                       return true;
-                   }
-               }
-               return false;
-           }
-         
-           window.addEventListener("dragenter", function (e) {
-               if (isFile(e)) {
-                   lastTarget = e.target;
-                   document.querySelector("#drop").style.visibility = "";
-                   document.querySelector("#drop").style.opacity = 1;
-                   document.querySelector("#textnode").style.fontSize = "48px";
-               }
-           });
-         
-           window.addEventListener("dragleave", function (e) {
-               e.preventDefault();
-               if (e.target === document || e.target === lastTarget) {
-                   document.querySelector("#drop").style.visibility = "hidden";
-                   document.querySelector("#drop").style.opacity = 0;
-                   document.querySelector("#textnode").style.fontSize = "42px";
-               }
-           });
-         
-           window.addEventListener("dragover", function (e) {
-               e.preventDefault();
-           });
-         
-           window.addEventListener("drop", function (e) {
-               e.preventDefault();
-               document.querySelector("#drop").style.visibility = "hidden";
-               document.querySelector("#drop").style.opacity = 0;
-               document.querySelector("#textnode").style.fontSize = "42px";
-               if(e.dataTransfer.files.length > 0) {
-                if (document.location.host === 'mobsf.live'){
-                    if (confirm(warning) == true) {
-                        handleFiles(e.dataTransfer.files);
-                    } else {
-                        return;
-                    }
-                } else {
-                    handleFiles(e.dataTransfer.files);
-                }
-               }
-           });
+        } catch(e) {}
+      }
+    };
+    xhr.send('hash=' + checksum);
+  }
 
-            $(document).ready(function() {
-                // Button File Upload
-                $('input[type=file]').change(function() {
-                    _('status').innerText = "";
-                    if (_("uploadFile").files.length === 0) {
-                        return;
-                    }
-                    var files = _("uploadFile").files;
-                    if (document.location.host === 'mobsf.live'){
-                        if (confirm(warning) == true) {
-                            _("uploadFile").style.display = "none";
-                            handleFiles(files);
-                        } else {
-                            return;
-                        }
-                    } else {
-                        _("uploadFile").style.display = "none";
-                        handleFiles(files);
-                    }
-                });
-            });
-      </script>
-   </body>
+  /* ────────────────────────────────────────────────
+     Response handler
+  ──────────────────────────────────────────────── */
+  function responseHandler(json) {
+    if (json.status === 'error') {
+      _('status').innerText = json.description;
+    } else {
+      setInterval(() => { get_status(json.hash); }, 500);
+      load_result(json.analyzer + '/' + json.hash + '/');
+    }
+  }
+
+  /* ────────────────────────────────────────────────
+     Progress
+  ──────────────────────────────────────────────── */
+  function progressHandler(event) {
+    if (!event.lengthComputable) return;
+    var pct = Math.round((event.loaded / event.total) * 100);
+    _('progressBar').value = pct;
+    _('status').innerText = pct + '% uploaded…';
+  }
+  function completeHandler(event) {
+    if (event.currentTarget.status === 403) {
+      _('status').innerText = "You do not have permission to upload!";
+      return;
+    }
+    try { responseHandler(JSON.parse(event.target.responseText)); }
+    catch(e) { _('status').innerText = "Upload error."; }
+  }
+  function errorHandler() { _('status').innerText = "Upload failed."; }
+  function abortHandler() { _('status').innerText = "Upload aborted."; }
+
+  /* ────────────────────────────────────────────────
+     Validation
+  ──────────────────────────────────────────────── */
+  function isValidExt(file_name) {
+    var val = file_name.toLowerCase().replace(/^.*[\\\/]/, '');
+    var regex = new RegExp("^(.{1,300}?)\\.({{exts}})$");
+    if (!regex.test(val)) {
+      _('status').innerText = "MobSF supports APK, APKS, XAPK, AAB, JAR, AAR, SO, IPA, DYLIB, A, ZIP, and APPX files.";
+      return false;
+    }
+    return true;
+  }
+
+  function isValidMime(file_mime) {
+    if (!file_mime || file_mime.length < 1) return true;
+    var supported = [{% for mime in mimes %}'{{mime}}',{% endfor %}];
+    if (supported.indexOf(file_mime) > -1) return true;
+    _('status').innerText = "MIME type (" + file_mime + ") is not supported!";
+    return false;
+  }
+
+  /* ────────────────────────────────────────────────
+     Upload
+  ──────────────────────────────────────────────── */
+  function uploadFile(file) {
+    try {
+      if (!isValidExt(file.name) || !isValidMime(file.type)) return;
+      _('progressBar').style.visibility = 'visible';
+      _('status').innerText = 'Uploading…';
+      var xhr = new XMLHttpRequest();
+      xhr.open('POST', '{% url "upload" %}', true);
+      xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+      xhr.setRequestHeader('X-CSRFToken', '{{ csrf_token }}');
+      xhr.upload.addEventListener('progress', progressHandler, false);
+      xhr.addEventListener('load', completeHandler, false);
+      xhr.addEventListener('error', errorHandler, false);
+      xhr.addEventListener('abort', abortHandler, false);
+      var formdata = new FormData();
+      formdata.append('file', file);
+      show_loader();
+      xhr.send(formdata);
+    } catch(e) { alert("Error: " + e); }
+  }
+
+  function handleFiles(files) {
+    [...files].forEach(uploadFile);
+  }
+
+  /* ────────────────────────────────────────────────
+     File input change
+  ──────────────────────────────────────────────── */
+  document.getElementById('uploadFile').addEventListener('change', function() {
+    _('status').innerText = '';
+    if (this.files.length === 0) return;
+    var files = this.files;
+    if (document.location.host === 'mobsf.live') {
+      if (confirm(warning)) { this.style.display = 'none'; handleFiles(files); }
+    } else {
+      this.style.display = 'none';
+      handleFiles(files);
+    }
+  });
+
+  /* ────────────────────────────────────────────────
+     Drag & Drop — full page listener
+  ──────────────────────────────────────────────── */
+  var dragCounter = 0; // track nested dragenter/dragleave pairs
+
+  function hasDragFiles(e) {
+    if (!e.dataTransfer) return false;
+    for (var i = 0; i < e.dataTransfer.types.length; i++) {
+      if (e.dataTransfer.types[i] === 'Files') return true;
+    }
+    return false;
+  }
+
+  document.addEventListener('dragenter', function(e) {
+    if (!hasDragFiles(e)) return;
+    e.preventDefault();
+    dragCounter++;
+    if (dragCounter === 1) overlay.classList.add('active');
+  });
+
+  document.addEventListener('dragleave', function(e) {
+    if (!hasDragFiles(e) && dragCounter === 0) return;
+    dragCounter--;
+    if (dragCounter <= 0) {
+      dragCounter = 0;
+      overlay.classList.remove('active');
+    }
+  });
+
+  document.addEventListener('dragover', function(e) {
+    if (!hasDragFiles(e)) return;
+    e.preventDefault(); // required to allow drop
+    e.dataTransfer.dropEffect = 'copy';
+  });
+
+  document.addEventListener('drop', function(e) {
+    e.preventDefault();
+    dragCounter = 0;
+    overlay.classList.remove('active');
+    if (!e.dataTransfer || !e.dataTransfer.files || e.dataTransfer.files.length === 0) return;
+    if (document.location.host === 'mobsf.live') {
+      if (confirm(warning)) handleFiles(e.dataTransfer.files);
+    } else {
+      handleFiles(e.dataTransfer.files);
+    }
+  });
+
+  /* ────────────────────────────────────────────────
+     Package / URL download on Enter
+  ──────────────────────────────────────────────── */
+  document.getElementById('package').addEventListener('keypress', function(event) {
+    if (event.key !== 'Enter') return;
+    _('status').innerText = 'Downloading…';
+    show_loader();
+    $.ajax({
+      url: '{% url "download_scan" %}',
+      type: 'POST',
+      dataType: 'json',
+      data: { package: this.value, csrfmiddlewaretoken: '{{ csrf_token }}' },
+      success: function(json) {
+        if (json.status === 'ok') {
+          setInterval(() => { get_status(json.hash); }, 500);
+          load_result(json.analyzer + '/' + json.hash + '/');
+        } else {
+          hide_loader();
+          _('status').innerText = json.description;
+        }
+      },
+      error: function(xhr, ajaxOptions, thrownError) {
+        hide_loader();
+        if (thrownError === 'Forbidden') _('status').innerText = "You do not have permission to download and scan!";
+        else _('status').innerText = "Download failed.";
+      }
+    });
+  });
+</script>
+</body>
 </html>

--- a/mobsf/templates/general/recent.html
+++ b/mobsf/templates/general/recent.html
@@ -1,343 +1,456 @@
-
 {% extends "base/base_layout.html" %}
 {% load static %}
- {% block sidebar_option %}
-      sidebar-collapse
-{% endblock %}
- {% block extra_css %}
+{% block sidebar_option %}sidebar-collapse{% endblock %}
+{% block extra_css %}
 <link href="{% static "adminlte/plugins/sweetalert2/sweetalert2.min.css" %}" rel="stylesheet">
-
 <style>
-#app_icon{
-        width: 64px;
-        height: 64px;
-    }
-.selected {
-    background-color: lightgreen !important;
-}
+  .page-header-strip {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 0 14px;
+    border-bottom: 1px solid var(--border-sub, rgba(48,54,61,0.5));
+    margin-bottom: 20px;
+  }
+  .page-header-strip h2 {
+    font-size: 18px !important;
+    font-weight: 700 !important;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--text-primary, #e6edf3) !important;
+  }
+  .page-header-strip h2 i { color: var(--accent-blue, #58a6ff); font-size: 16px; }
 
-.selectable_table tr:hover {
-    background-color: lightgreen !important;
-}
+  .scan-queue-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(88,166,255,0.08);
+    border: 1px solid rgba(88,166,255,0.2);
+    border-radius: 8px;
+    color: var(--accent-blue, #58a6ff);
+    font-size: 12.5px;
+    font-weight: 600;
+    padding: 6px 14px;
+    text-decoration: none;
+    transition: all 0.18s;
+  }
+  .scan-queue-link:hover { background: rgba(88,166,255,0.14); color: var(--accent-blue, #58a6ff); }
+
+  /* ── App icon cell ── */
+  .app-icon-cell { text-align: center; }
+  .app-icon-cell img { width: 52px; height: 52px; border-radius: 12px; border: 1px solid var(--border-sub, rgba(48,54,61,0.5)); object-fit: contain; background: var(--bg-surface, #111820); }
+  .app-name { font-weight: 600; font-size: 13px; color: var(--text-primary, #e6edf3); margin-top: 5px; }
+  .app-pkg  { font-size: 11.5px; color: var(--text-secondary, #8b949e); font-family: 'JetBrains Mono', monospace; margin-top: 2px; }
+
+  .scan-complete-badge {
+    display: inline-block;
+    background: rgba(248,81,73,0.1);
+    border: 1px solid rgba(248,81,73,0.2);
+    border-radius: 6px;
+    color: var(--accent-red, #f85149);
+    font-size: 11px;
+    font-weight: 700;
+    padding: 2px 8px;
+    margin-top: 4px;
+  }
+
+  /* ── Type icons ── */
+  .type-icon-cell { text-align: center; vertical-align: middle !important; }
+  .type-icon-cell i { font-size: 28px; }
+  .type-icon-cell .fa-android { color: #78c257; }
+  .type-icon-cell .fa-apple { color: #b0b8c1; }
+  .type-icon-cell .fa-java { color: #e76f00; }
+  .type-icon-cell .fa-windows { color: #00adef; }
+  .type-icon-cell .fa-file-archive { color: var(--accent-yellow, #e3b341); }
+  .type-icon-cell .fa-th-large { color: var(--text-secondary, #8b949e); }
+
+  /* ── Hash ── */
+  .hash-cell {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11.5px;
+    color: var(--text-secondary, #8b949e);
+    max-width: 140px;
+    word-break: break-all;
+  }
+
+  /* ── Timestamp ── */
+  .ts-cell { font-size: 12px; color: var(--text-secondary, #8b949e); white-space: nowrap; }
+
+  /* ── Action buttons ── */
+  .action-cell { white-space: nowrap; }
+  .action-cell .btn { margin: 2px; }
+
+  /* ── Report button row ── */
+  .report-btns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px;
+    margin-top: 8px;
+    width: 100%;
+  }
+
+  /* ── Scan action buttons ── */
+  .scan-action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    padding: 5px 8px;
+    border-radius: 7px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.2px;
+    text-decoration: none !important;
+    border: 1px solid transparent;
+    transition: all 0.18s ease;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+  .scan-action-btn i { font-size: 11px; flex-shrink: 0; }
+  .scan-action-btn span { line-height: 1; }
+
+  /* Static — blue */
+  .btn-static-action {
+    background: rgba(88,166,255,0.1);
+    border-color: rgba(88,166,255,0.25);
+    color: var(--accent-blue, #58a6ff) !important;
+  }
+  .btn-static-action:hover {
+    background: rgba(88,166,255,0.22);
+    border-color: rgba(88,166,255,0.5);
+    color: #fff !important;
+    box-shadow: 0 0 10px rgba(88,166,255,0.2);
+    transform: translateY(-1px);
+  }
+
+  /* Scorecard — purple */
+  .btn-score-action {
+    background: rgba(188,140,255,0.1);
+    border-color: rgba(188,140,255,0.25);
+    color: var(--accent-purple, #bc8cff) !important;
+  }
+  .btn-score-action:hover {
+    background: rgba(188,140,255,0.22);
+    border-color: rgba(188,140,255,0.5);
+    color: #fff !important;
+    box-shadow: 0 0 10px rgba(188,140,255,0.2);
+    transform: translateY(-1px);
+  }
+
+  /* Report — green */
+  .btn-report-action {
+    background: rgba(63,185,80,0.1);
+    border-color: rgba(63,185,80,0.25);
+    color: var(--accent-green, #3fb950) !important;
+  }
+  .btn-report-action:hover {
+    background: rgba(63,185,80,0.22);
+    border-color: rgba(63,185,80,0.5);
+    color: #fff !important;
+    box-shadow: 0 0 10px rgba(63,185,80,0.2);
+    transform: translateY(-1px);
+  }
+
+  /* Dynamic — orange */
+  .btn-dynamic-action {
+    background: rgba(240,136,62,0.1);
+    border-color: rgba(240,136,62,0.25);
+    color: var(--accent-orange, #f0883e) !important;
+  }
+  .btn-dynamic-action:hover {
+    background: rgba(240,136,62,0.22);
+    border-color: rgba(240,136,62,0.5);
+    color: #fff !important;
+    box-shadow: 0 0 10px rgba(240,136,62,0.2);
+    transform: translateY(-1px);
+  }
+  .btn-dynamic-disabled {
+    opacity: 0.35 !important;
+    pointer-events: none;
+  }
+
+  /* ── Diff selected row ── */
+  .selected td { background: rgba(63,185,80,0.06) !important; border-top: 1px solid rgba(63,185,80,0.2) !important; }
+  .selectable_table tr:hover td { background: rgba(88,166,255,0.04) !important; }
+
+  /* ── Pagination ── */
+  .pagination-wrap { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 16px 0 4px; flex-wrap: wrap; }
+
+  /* ── SweetAlert2 dark theme patches ── */
+  .swal2-popup { background: var(--bg-elevated, #1a2233) !important; border: 1px solid var(--border-def, #30363d) !important; border-radius: 16px !important; }
+  .swal2-title { color: var(--text-primary, #e6edf3) !important; }
+  .swal2-content, .swal2-html-container { color: var(--text-secondary, #8b949e) !important; }
+  .swal2-styled.swal2-confirm { border-radius: 8px !important; }
+  .swal2-styled.swal2-cancel { border-radius: 8px !important; }
+
 </style>
 {% endblock %}
 {% block content %}
 <div class="content-wrapper">
-  <div class="content-header">
-  </div>
-   <div class="container-fluid">
-        <div class="row">
-            <div class="col-lg-12">
-            <div class="card">
-              <div class="card-body">
-                
+  <div class="content-header"></div>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-lg-12">
 
-                 <div class="box">
-        <div class="box-header with-border">
-            <h3 class="box-title"><i class="fa fa-rocket"></i> Recent Scans</h3>
-            {% if async_scans %}
-            <p class="lead">View scan progress in the <strong><a href="{% url 'list_tasks' %}">Scan Queue</a></strong></p>
-            {% endif %}
+        <div class="page-header-strip">
+          <h2>
+            <i class="fas fa-history"></i>
+            Recent Scans
+          </h2>
+          {% if async_scans %}
+          <a href="{% url 'list_tasks' %}" class="scan-queue-link">
+            <i class="fas fa-tasks"></i> View Scan Queue
+          </a>
+          {% endif %}
         </div>
 
-        <div class="box-body">
+        <div class="card">
+          <div class="card-body" style="padding:0 !important;">
             <div class="table-responsive">
-                <table class="table table-bordered table-hover table-striped">
-                    <thead>
-                    <tr>
-                        <th>APP</th>
-                        <th>FILE</th>
-                        <th>TYPE</th>
-                        <th>HASH</th>
-                        <th>SCAN DATE</th>
-                        <th style="width: 9%">ACTIONS</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for e in entries %}
-                        <tr>
-                            <td style="text-align: center;">
-                                <img id="app_icon" src="{% if e.ICON_PATH %}/download/{{ e.ICON_PATH }}{% else %}{% static 'img/no_icon.png' %}{% endif %}">
-                                {% if e.PACKAGE_NAME or e.APP_NAME %}
-                                  <br/><strong>{{ e.APP_NAME }} {% if e.VERSION_NAME %} - {{ e.VERSION_NAME }} {% endif %}</strong>
-                                  </br>{{ e.PACKAGE_NAME }}
-                                  {% if e.FILE_NAME|slice:"-6:" != '.dylib' %}
-                                  {% if e.FILE_NAME|slice:"-5:" != '.appx' %}
-                                    {% if e.FILE_NAME|slice:"-3:" != '.so' %}
-                                      {% if e.FILE_NAME|slice:"-2:" != '.a' %}
-                                    <p> <a href="{% url "appsec_dashboard" checksum=e.MD5 %}" class="btn btn-sm btn-outline-primary" role="button"><i class="fas fa-user-shield"></i> MobSF Scorecard</a></p>
-                                      {% endif %}
-                                    {% endif %}
-                                    {% endif %}
-                                  {% endif %}
-                                  <p><a class="btn btn-primary btn-sm" href="../../../{{ e.ANALYZER }}/{{e.MD5}}/"><i class="fas fa-eye"></i> Static Report</a>
-                                  {% if '.apk' == e.FILE_NAME|slice:"-4:" or '.xapk' == e.FILE_NAME|slice:"-5:" or '.apks' == e.FILE_NAME|slice:"-5:" or '.aab' == e.FILE_NAME|slice:"-4:" %}
-                                    <a  class="btn btn-success btn-sm {% if not e.DYNAMIC_REPORT_EXISTS %}disabled{% endif %}" href="{% url "dynamic_report" checksum=e.MD5 %}"><i class="fa fa-mobile"></i> Dynamic Report</a>
-                                  {% elif '.ipa' == e.FILE_NAME|slice:"-4:" %}
-                                    {% if e.PACKAGE_NAME %}
-                                        <a  class="btn btn-success btn-sm {% if not e.DYNAMIC_REPORT_EXISTS %}disabled{% endif %}" href="{% url "ios_view_report" bundle_id=e.PACKAGE_NAME %}"><i class="fa fa-mobile"></i> Dynamic Report</a>
-                                    {% endif %}
-                                  {% endif %}
-                                  </p>
-                                {% else %}
-                                </br><span class="badge bg-warning">scan not completed</span>
-                                {% endif %}
-                            </td>
-                            <td>{{ e.FILE_NAME }}
-                            </td>
-                            <td style="text-align: center;">
-                                {% if '.apk' == e.FILE_NAME|slice:"-4:"%}<i class="fab fa-android fa-3x"></i>
-                                {% elif '.xapk' == e.FILE_NAME|slice:"-5:"%}<i class="fab fa-android fa-3x"></i>
-                                {% elif '.apks' == e.FILE_NAME|slice:"-5:"%}<i class="fab fa-android fa-3x"></i>
-                                {% elif '.aab' == e.FILE_NAME|slice:"-4:"%}<i class="fab fa-android fa-3x"></i>
-                                {% elif '.jar' == e.FILE_NAME|slice:"-4:"%}<i class="fab fa-java fa-3x"></i>
-                                {% elif '.aar' == e.FILE_NAME|slice:"-4:"%}<i class="fas fa-table fa-3x"></i>
-                                {% elif '.so' == e.FILE_NAME|slice:"-3:"%}<i class="fa fa-th-large fa-3x"></i>
-                                {% elif '.ipa' == e.FILE_NAME|slice:"-4:"%}<i class="fab fa-apple fa-3x"></i>
-                                {% elif '.dylib' == e.FILE_NAME|slice:"-6:"%}<i class="fa fa-th-large fa-3x"></i>
-                                {% elif '.a' == e.FILE_NAME|slice:"-2:"%}<i class="fa fa-th-large fa-3x"></i>
-                                {% elif '.zip' == e.FILE_NAME|slice:"-4:"%}<i class="fas fa-file-archive fa-3x"></i>
-                                {% elif '.appx' == e.FILE_NAME|slice:"-5:"%}<i class="fab fa-windows fa-3x"></i>
-                                {% endif %}
-                            </td>
-                            <td>{{ e.MD5 }}</td>
-                            <td>{{ e.TIMESTAMP }}</td>
-                            <td><p>
-                                   <a class="btn btn-outline-primary btn-sm" href="{% url "pdf" checksum=e.MD5%}"><i class="fas fa-file-pdf"></i></a>
-                                   <a class="btn btn-outline-info btn-sm" href="../../../{{ e.ANALYZER }}/{{e.MD5}}/?rescan=1"><i class="fas fa-sync-alt"></i></a>
-                                   <a class="btn btn-outline-secondary btn-sm" href="{% url "download_binary" checksum=e.MD5%}"><i class="fas fa-download"></i></a>
-                                </p>
-                            {% if '.apk' == e.FILE_NAME|slice:"-4:" or '.xapk' == e.FILE_NAME|slice:"-5:" or '.apks' == e.FILE_NAME|slice:"-5:" or '.aab' == e.FILE_NAME|slice:"-4:"%}
-                                <p><a class="diffButton btn btn-warning btn-sm" id="{{ e.MD5 }}_{{ e.FILE_NAME }}"><i class="fas fa-not-equal"></i> Diff or Compare</a>
-                                </p>
+              <table class="table table-hover table-striped" style="margin:0;">
+                <thead>
+                  <tr>
+                    <th style="width:200px;">App</th>
+                    <th>File</th>
+                    <th style="width:60px;text-align:center;">Type</th>
+                    <th style="width:150px;">Hash</th>
+                    <th style="width:140px;">Scan Date</th>
+                    <th style="width:130px;">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for e in entries %}
+                  <tr>
+                    <td class="app-icon-cell">
+                      <img src="{% if e.ICON_PATH %}/download/{{ e.ICON_PATH }}{% else %}{% static 'img/no_icon.png' %}{% endif %}" alt="icon">
+                      {% if e.PACKAGE_NAME or e.APP_NAME %}
+                        <div class="app-name">{{ e.APP_NAME }}{% if e.VERSION_NAME %} <span style="font-weight:400;color:var(--text-secondary,#8b949e);font-size:11px;">{{ e.VERSION_NAME }}</span>{% endif %}</div>
+                        <div class="app-pkg">{{ e.PACKAGE_NAME }}</div>
+                        <div class="report-btns">
+                          {% if e.FILE_NAME|slice:"-6:" != '.dylib' and e.FILE_NAME|slice:"-5:" != '.appx' and e.FILE_NAME|slice:"-3:" != '.so' and e.FILE_NAME|slice:"-2:" != '.a' %}
+                          <a class="scan-action-btn btn-score-action" href="{% url "appsec_dashboard" checksum=e.MD5 %}" title="Security Scorecard">
+                            <i class="fas fa-user-shield"></i><span>Scorecard</span>
+                          </a>
+                          {% endif %}
+                          <a class="scan-action-btn btn-report-action" href="../../../{{ e.ANALYZER }}/{{e.MD5}}/" title="Full Report">
+                            <i class="fas fa-file-alt"></i><span>Static Report</span>
+                          </a>
+                          {% if '.apk' == e.FILE_NAME|slice:"-4:" or '.xapk' == e.FILE_NAME|slice:"-5:" or '.apks' == e.FILE_NAME|slice:"-5:" or '.aab' == e.FILE_NAME|slice:"-4:" %}
+                          <a class="scan-action-btn btn-dynamic-action {% if not e.DYNAMIC_REPORT_EXISTS %}btn-dynamic-disabled{% endif %}" href="{% url "dynamic_report" checksum=e.MD5 %}" title="Dynamic Analysis">
+                            <i class="fa fa-mobile-alt"></i><span>Dynamic</span>
+                          </a>
+                          {% elif '.ipa' == e.FILE_NAME|slice:"-4:" %}
+                            {% if e.PACKAGE_NAME %}
+                            <a class="scan-action-btn btn-dynamic-action {% if not e.DYNAMIC_REPORT_EXISTS %}btn-dynamic-disabled{% endif %}" href="{% url "ios_view_report" bundle_id=e.PACKAGE_NAME %}" title="Dynamic Analysis">
+                              <i class="fa fa-mobile-alt"></i><span>Dynamic</span>
+                            </a>
                             {% endif %}
-                            <p> <a class="btn btn-danger btn-sm" id="{{ e.MD5 }}" onclick="delete_scan(this)" href="#"><i class="fa fa-trash"></i> Delete Scan</a> </p>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-            <!--pagination-->
-            <nav aria-label="Pagination">
-                <ul class="pagination justify-content-center">
-                  {% if page_obj.has_previous %}
-                  <li class="page-item">
-                    <a class="page-link" href="{% url 'scans_paginated' page_size=page_obj.page_size page_number=page_obj.previous_page_number %}">Previous</a>
-                  </li>   
-                  {% else %}
-                  <li class="page-item">
-                  <a class="page-link">Previous</a>
-                  </li>
-                  {% endif %}
-      
-                  {% for i in page_obj.paginator.page_range %}
-                  {% if page_obj.number == i %}
-                  <li class="page-item active">
-                      <a class="page-link" href="#">{{ i }} </a>
-                  </li>
-                  {% else %}
-                  <li class="page-item">
-                      <a class="page-link" href="{% url 'scans_paginated' page_size=page_obj.page_size page_number=i %}">{{ i }}</a>
-                  </li>
-                  {% endif %}
-                  {% endfor %}
-      
-                  {% if page_obj.has_next %}
-                  <li class="page-item">
-                    <a class="page-link" href="{% url 'scans_paginated' page_size=page_obj.page_size page_number=page_obj.next_page_number %}">Next</a>
-                   </li>
-                  {% else %}
-                  <li class="page-item">
-                    <a class="page-link">Next</a>
-                  </li>
-                  {% endif %}
-                  <li class="page-item">
-                    <div class="dropdown">
-                        <button class="page-link dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                          Items per page
-                        </button>
-                        <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                          <a class="dropdown-item" href="{% url 'scans_paginated' page_size=5 page_number=page_obj.number %}">5</a>
-                          <a class="dropdown-item" href="{% url 'scans_paginated' page_size=10 page_number=page_obj.number %}">10</a>
-                          <a class="dropdown-item" href="{% url 'scans_paginated' page_size=20 page_number=page_obj.number %}">20</a>
-                          <a class="dropdown-item" href="{% url 'scans_paginated' page_size=50 page_number=page_obj.number %}">50</a>
-                          <a class="dropdown-item" href="{% url 'scans_paginated' page_size=100 page_number=page_obj.number %}">100</a>
-                          <a class="dropdown-item" href="{% url 'scans_paginated' page_size=250 page_number=page_obj.number %}">250</a>
+                          {% endif %}
                         </div>
-                      </div>
-                </ul>
-              </nav>
-            <!--end pagination-->
-        </div>
-        <!-- /.box-body -->
-    </div>
+                      {% else %}
+                        <span class="scan-complete-badge"><i class="fas fa-exclamation-triangle" style="margin-right:4px;"></i>Scan incomplete</span>
+                      {% endif %}
+                    </td>
 
+                    <td style="vertical-align:middle;font-size:12.5px;font-family:'JetBrains Mono',monospace;color:var(--text-secondary,#8b949e);max-width:200px;word-break:break-all;">
+                      {{ e.FILE_NAME }}
+                    </td>
+
+                    <td class="type-icon-cell">
+                      {% if '.apk' == e.FILE_NAME|slice:"-4:" or '.xapk' == e.FILE_NAME|slice:"-5:" or '.apks' == e.FILE_NAME|slice:"-5:" or '.aab' == e.FILE_NAME|slice:"-4:" %}
+                        <i class="fab fa-android"></i>
+                      {% elif '.jar' == e.FILE_NAME|slice:"-4:" %}
+                        <i class="fab fa-java"></i>
+                      {% elif '.aar' == e.FILE_NAME|slice:"-4:" %}
+                        <i class="fas fa-table" style="color:var(--text-secondary,#8b949e);font-size:22px;"></i>
+                      {% elif '.so' == e.FILE_NAME|slice:"-3:" or '.a' == e.FILE_NAME|slice:"-2:" or '.dylib' == e.FILE_NAME|slice:"-6:" %}
+                        <i class="fas fa-th-large"></i>
+                      {% elif '.ipa' == e.FILE_NAME|slice:"-4:" %}
+                        <i class="fab fa-apple"></i>
+                      {% elif '.zip' == e.FILE_NAME|slice:"-4:" %}
+                        <i class="fas fa-file-archive"></i>
+                      {% elif '.appx' == e.FILE_NAME|slice:"-5:" %}
+                        <i class="fab fa-windows"></i>
+                      {% endif %}
+                    </td>
+
+                    <td class="hash-cell">{{ e.MD5 }}</td>
+                    <td class="ts-cell">{{ e.TIMESTAMP }}</td>
+
+                    <td class="action-cell" style="vertical-align:middle;">
+                      <div style="display:flex;flex-direction:column;gap:4px;align-items:flex-start;">
+                        <div style="display:flex;gap:4px;flex-wrap:wrap;">
+                          <a class="btn btn-secondary btn-xs" href="{% url "pdf" checksum=e.MD5 %}" title="PDF Report">
+                            <i class="fas fa-file-pdf"></i>
+                          </a>
+                          <a class="btn btn-info btn-xs" href="../../../{{ e.ANALYZER }}/{{e.MD5}}/?rescan=1" title="Rescan">
+                            <i class="fas fa-sync-alt"></i>
+                          </a>
+                          <a class="btn btn-warning btn-xs" href="{% url "download_binary" checksum=e.MD5 %}" title="Download">
+                            <i class="fas fa-download"></i>
+                          </a>
+                        </div>
+                        {% if '.apk' == e.FILE_NAME|slice:"-4:" or '.xapk' == e.FILE_NAME|slice:"-5:" or '.apks' == e.FILE_NAME|slice:"-5:" or '.aab' == e.FILE_NAME|slice:"-4:" %}
+                        <button class="diffButton btn btn-secondary btn-xs" id="{{ e.MD5 }}_{{ e.FILE_NAME }}">
+                          <i class="fas fa-not-equal"></i> Diff
+                        </button>
+                        {% endif %}
+                        <button class="btn btn-danger btn-xs" id="{{ e.MD5 }}" onclick="delete_scan(this)">
+                          <i class="fa fa-trash"></i> Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+
+            <!-- Pagination -->
+            <div class="pagination-wrap">
+              {% if page_obj.has_previous %}
+              <a class="btn btn-secondary btn-sm" href="{% url 'scans_paginated' page_size=page_obj.page_size page_number=page_obj.previous_page_number %}">
+                <i class="fas fa-chevron-left"></i>
+              </a>
+              {% else %}
+              <button class="btn btn-secondary btn-sm" disabled><i class="fas fa-chevron-left"></i></button>
+              {% endif %}
+
+              {% for i in page_obj.paginator.page_range %}
+              {% if page_obj.number == i %}
+              <a class="btn btn-primary btn-sm" href="#">{{ i }}</a>
+              {% else %}
+              <a class="btn btn-secondary btn-sm" href="{% url 'scans_paginated' page_size=page_obj.page_size page_number=i %}">{{ i }}</a>
+              {% endif %}
+              {% endfor %}
+
+              {% if page_obj.has_next %}
+              <a class="btn btn-secondary btn-sm" href="{% url 'scans_paginated' page_size=page_obj.page_size page_number=page_obj.next_page_number %}">
+                <i class="fas fa-chevron-right"></i>
+              </a>
+              {% else %}
+              <button class="btn btn-secondary btn-sm" disabled><i class="fas fa-chevron-right"></i></button>
+              {% endif %}
+
+              <div class="dropdown" style="margin-left:8px;">
+                <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-toggle="dropdown">
+                  <i class="fas fa-list" style="margin-right:4px;"></i>{{ page_obj.page_size }} / page
+                </button>
+                <div class="dropdown-menu">
+                  <a class="dropdown-item" href="{% url 'scans_paginated' page_size=5 page_number=page_obj.number %}">5 per page</a>
+                  <a class="dropdown-item" href="{% url 'scans_paginated' page_size=10 page_number=page_obj.number %}">10 per page</a>
+                  <a class="dropdown-item" href="{% url 'scans_paginated' page_size=20 page_number=page_obj.number %}">20 per page</a>
+                  <a class="dropdown-item" href="{% url 'scans_paginated' page_size=50 page_number=page_obj.number %}">50 per page</a>
+                  <a class="dropdown-item" href="{% url 'scans_paginated' page_size=100 page_number=page_obj.number %}">100 per page</a>
+                  <a class="dropdown-item" href="{% url 'scans_paginated' page_size=250 page_number=page_obj.number %}">250 per page</a>
+                </div>
+              </div>
+            </div>
 
           </div>
         </div>
-       </div>
-     </div>
+
+      </div>
     </div>
+  </div>
 </div>
 {% endblock %}
+
 {% block extra_scripts %}
 <script src="{% static "adminlte/plugins/sweetalert2/sweetalert2.min.js" %}"></script>
 <script>
+  function escapeHtml(unsafe) {
+    return unsafe.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#039;");
+  }
 
-    // Escape HTML
-    function escapeHtml(unsafe)
-    {
-        return unsafe
-            .replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&#039;");
-    }
+  var diff_first_md5 = '', diff_first_name = '';
 
-    // Diff functions
-    var diff_first_md5 = '';
-    var diff_first_name = '';
+  function enable_partner_select() {
+    $('table tr').on('click', function(e) {
+      e.preventDefault();
+      if (diff_first_md5 == '') return;
+      diff_confirmation($(this));
+    });
+  }
 
-    // When a row is clicked, we check if we already have first scan, if so, ask for confirmation
-    function enable_partner_select() {
-        $('table tr').on('click', function (e) {
-            e.preventDefault();
-            if (diff_first_md5 == '') {
-                return;
-            }
-            diff_confirmation($(this));
-        })
-    }
+  function enable_diff_button() {
+    $(".diffButton").on('click', function(e) {
+      e.stopPropagation();
+      diff_select($(this));
+    });
+  }
 
+  function disable_diff_button() { $('.diffButton').off('click'); }
 
-    function enable_diff_button(){
-        $(".diffButton").on('click', function(e){
-            e.stopPropagation();
-            diff_select($(this));
-        });
-    }
+  function diff_select(item) {
+    Swal.fire({ title: 'Select Second App', icon: 'info', text: 'Please select the second scan result for comparison', timer: 10000 });
+    diff_first_md5 = item.attr('id').slice(0, 32);
+    diff_first_name = item.attr('id').slice(33);
+    item.closest("tr").addClass("selected");
+    item.closest("tbody").addClass("selectable_table");
+    enable_partner_select();
+    disable_diff_button();
+  }
 
-    function disable_diff_button() {
-        $('.diffButton').off('click');
-    }
+  function diff_cleanup() {
+    var id = diff_first_md5 + '_' + escapeHtml(diff_first_name);
+    $('[id="' + id + '"]').closest("tr").removeClass("selected");
+    $('[id="' + id + '"]').closest("tbody").removeClass("selectable_table");
+    diff_first_md5 = ""; diff_first_name = "";
+    enable_diff_button();
+  }
 
-    // First pop up only saves the first scan to diff and tells the user to select a partner
-    function diff_select(item) {
-
-        Swal.fire({
-            title: '<strong>Select App to Compare</strong>',
-            type: 'info',
-            text: 'Please select the second scan result for comparison',
-            timer: 10000
-        });
-        diff_first_md5 = item.attr('id').slice(0, 32);
-        diff_first_name = item.attr('id').slice(33);
-        item.closest("tr").addClass("selected");
-        item.closest("tbody").addClass("selectable_table");
-
-        // Enable the second partner selection
-        enable_partner_select();
-        disable_diff_button();
-    }
-
-    function diff_cleanup() {
-        first_td_id = diff_first_md5 + '_' + escapeHtml(diff_first_name);
-        $('[id="' + first_td_id + '"]').closest("tr").removeClass("selected");
-        $('[id="' + first_td_id + '"]').closest("tbody").removeClass("selectable_table");
-        diff_first_md5 = "";
-        diff_first_name = "";
-        enable_diff_button();
-    }
-
-    // Here we get jquery row
-    function diff_confirmation(item) {
-        // First we need the id which has the md5 and name
-        rows_tds = item.find('td');
-        selected_md5 = rows_tds[3].innerText;
-        if (diff_first_md5 == selected_md5) {
-            return;
-        }
-        diff_second_md5 = selected_md5;
-        diff_second_name = rows_tds[1].innerText;
-
-        Swal.fire({
-            title: '<strong>Diff confirmation</strong>',
-            type: 'info',
-            html:
-                '<strong>Do you want to diff - </strong><br />' + escapeHtml(diff_first_name) +
-                '<br /> <strong>with - <br /> </strong>' + escapeHtml(diff_second_name) + ' <br /> <strong>?</strong>',
-
-            showCancelButton: true,
-            cancelButtonText: 'Cancel',
-            confirmButtonText: 'Start Diffing!',
-        }).then((result) => {
-            if (result.value) {
-                window.location = '/compare/' + diff_first_md5 + '/' + diff_second_md5 + '/';
-            } else {
-                 diff_cleanup();
-            }
-        })
-    }
-
-    function delete_scan(item){
-      Swal.fire({
-      title: 'Are you sure?',
-      text: "This will permanently remove the scan results from MobSF",
-      type: 'warning',
+  function diff_confirmation(item) {
+    var rows_tds = item.find('td');
+    var selected_md5 = rows_tds[3] ? rows_tds[3].innerText : '';
+    if (diff_first_md5 == selected_md5) return;
+    var diff_second_md5 = selected_md5;
+    var diff_second_name = rows_tds[1] ? rows_tds[1].innerText : '';
+    Swal.fire({
+      title: 'Compare Scans',
+      icon: 'info',
+      html: '<strong>' + escapeHtml(diff_first_name) + '</strong><br>vs<br><strong>' + escapeHtml(diff_second_name) + '</strong>',
       showCancelButton: true,
-      confirmButtonText: 'Yes',
-      cancelButtonText: 'No',
-      confirmButtonColor: '#d33',
-      cancelButtonColor: '#2da532',
+      cancelButtonText: 'Cancel',
+      confirmButtonText: 'Start Diff',
     }).then((result) => {
-        if (result.value) {
-            var md5_hash = item.id;
-            $.ajax({
-                    url: '{% url "delete_scan" %}',
-                        type : 'POST',
-                    dataType: 'json',
-                        data : {
-                                csrfmiddlewaretoken: '{{ csrf_token }}',
-                                md5: md5_hash,
-                                },
-                            success : function(json) {
-                                if (json.deleted ==='yes'){
-                                    Swal.fire(
-                                        'Deleted!',
-                                        'The scan result is deleted!',
-                                        'success'
-                                    ).then(function () {
-                                        location.reload();
-                                    })
-                                }
-                                else {
-                                    Swal.fire(
-                                    'Delete Failed',
-                                    json.deleted,
-                                    'error'
-                                    )
-                                }
-                            },
-                            error : function(xhr,errmsg,err) {
-                                Swal.fire(
-                                    'Delete Failed',
-                                    errmsg,
-                                    'error'
-                                    )
-                            }
-                });
-               
-        } else {
-                diff_cleanup();
-        }
+      if (result.value) window.location = '/compare/' + diff_first_md5 + '/' + diff_second_md5 + '/';
+      else diff_cleanup();
+    });
+  }
+
+  function delete_scan(item) {
+    Swal.fire({
+      title: 'Delete Scan?',
+      text: "This will permanently remove the scan results from MobSF.",
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Delete',
+      cancelButtonText: 'Cancel',
+      confirmButtonColor: '#f85149',
+      cancelButtonColor: '#30363d',
+    }).then((result) => {
+      if (result.value) {
+        $.ajax({
+          url: '{% url "delete_scan" %}',
+          type: 'POST',
+          dataType: 'json',
+          data: { csrfmiddlewaretoken: '{{ csrf_token }}', md5: item.id },
+          success: function(json) {
+            if (json.deleted === 'yes') {
+              Swal.fire('Deleted!', 'The scan result has been removed.', 'success').then(function(){ location.reload(); });
+            } else {
+              Swal.fire('Error', 'Could not delete the scan.', 'error');
+            }
+          },
+          error: function(xhr, errmsg) { Swal.fire('Error', errmsg, 'error'); }
         });
-}
-    
+      } else { diff_cleanup(); }
+    });
+  }
 
-enable_diff_button();
-
+  enable_diff_button();
 </script>
-
 {% endblock %}

--- a/mobsf/templates/general/recent.html
+++ b/mobsf/templates/general/recent.html
@@ -193,11 +193,6 @@
   /* ── Pagination ── */
   .pagination-wrap { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 16px 0 4px; flex-wrap: wrap; }
 
-  /* The page-size dropdown menu was getting clipped by .card's
-     overflow:hidden (used elsewhere to clip rounded corners). Only this
-     card needs to allow it to escape. */
-  .card { overflow: visible; }
-
   /* ── SweetAlert2 dark theme patches ── */
   .swal2-popup { background: var(--bg-elevated, #1a2233) !important; border: 1px solid var(--border-def, #30363d) !important; border-radius: 16px !important; }
   .swal2-title { color: var(--text-primary, #e6edf3) !important; }

--- a/mobsf/templates/general/recent.html
+++ b/mobsf/templates/general/recent.html
@@ -79,8 +79,23 @@
   .ts-cell { font-size: 12px; color: var(--text-secondary, #8b949e); white-space: nowrap; }
 
   /* ── Action buttons ── */
-  .action-cell { white-space: nowrap; }
-  .action-cell .btn { margin: 2px; }
+  .action-cell { text-align: center; vertical-align: middle !important; }
+  .action-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .action-toolbar .btn {
+    margin: 0;
+    width: 30px;
+    height: 30px;
+    padding: 0 !important;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
 
   /* ── Report button row ── */
   .report-btns {
@@ -178,6 +193,11 @@
   /* ── Pagination ── */
   .pagination-wrap { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 16px 0 4px; flex-wrap: wrap; }
 
+  /* The page-size dropdown menu was getting clipped by .card's
+     overflow:hidden (used elsewhere to clip rounded corners). Only this
+     card needs to allow it to escape. */
+  .card { overflow: visible; }
+
   /* ── SweetAlert2 dark theme patches ── */
   .swal2-popup { background: var(--bg-elevated, #1a2233) !important; border: 1px solid var(--border-def, #30363d) !important; border-radius: 16px !important; }
   .swal2-title { color: var(--text-primary, #e6edf3) !important; }
@@ -209,15 +229,15 @@
         <div class="card">
           <div class="card-body" style="padding:0 !important;">
             <div class="table-responsive">
-              <table class="table table-hover table-striped" style="margin:0;">
+              <table class="table table-hover table-striped" style="margin:0;min-width:960px;">
                 <thead>
                   <tr>
-                    <th style="width:200px;">App</th>
-                    <th>File</th>
-                    <th style="width:60px;text-align:center;">Type</th>
-                    <th style="width:150px;">Hash</th>
+                    <th style="width:210px;">App</th>
+                    <th style="width:210px;">File</th>
+                    <th style="width:70px;text-align:center;">Type</th>
+                    <th style="width:170px;">Hash</th>
                     <th style="width:140px;">Scan Date</th>
-                    <th style="width:130px;">Actions</th>
+                    <th style="width:160px;text-align:center;">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -279,26 +299,24 @@
                     <td class="hash-cell">{{ e.MD5 }}</td>
                     <td class="ts-cell">{{ e.TIMESTAMP }}</td>
 
-                    <td class="action-cell" style="vertical-align:middle;">
-                      <div style="display:flex;flex-direction:column;gap:4px;align-items:flex-start;">
-                        <div style="display:flex;gap:4px;flex-wrap:wrap;">
-                          <a class="btn btn-secondary btn-xs" href="{% url "pdf" checksum=e.MD5 %}" title="PDF Report">
-                            <i class="fas fa-file-pdf"></i>
-                          </a>
-                          <a class="btn btn-info btn-xs" href="../../../{{ e.ANALYZER }}/{{e.MD5}}/?rescan=1" title="Rescan">
-                            <i class="fas fa-sync-alt"></i>
-                          </a>
-                          <a class="btn btn-warning btn-xs" href="{% url "download_binary" checksum=e.MD5 %}" title="Download">
-                            <i class="fas fa-download"></i>
-                          </a>
-                        </div>
+                    <td class="action-cell">
+                      <div class="action-toolbar">
+                        <a class="btn btn-secondary" href="{% url "pdf" checksum=e.MD5 %}" title="PDF Report">
+                          <i class="fas fa-file-pdf"></i>
+                        </a>
+                        <a class="btn btn-info" href="../../../{{ e.ANALYZER }}/{{e.MD5}}/?rescan=1" title="Rescan">
+                          <i class="fas fa-sync-alt"></i>
+                        </a>
+                        <a class="btn btn-warning" href="{% url "download_binary" checksum=e.MD5 %}" title="Download">
+                          <i class="fas fa-download"></i>
+                        </a>
                         {% if '.apk' == e.FILE_NAME|slice:"-4:" or '.xapk' == e.FILE_NAME|slice:"-5:" or '.apks' == e.FILE_NAME|slice:"-5:" or '.aab' == e.FILE_NAME|slice:"-4:" %}
-                        <button class="diffButton btn btn-secondary btn-xs" id="{{ e.MD5 }}_{{ e.FILE_NAME }}">
-                          <i class="fas fa-not-equal"></i> Diff
+                        <button class="diffButton btn btn-secondary" id="{{ e.MD5 }}_{{ e.FILE_NAME }}" title="Diff Against Another Scan">
+                          <i class="fas fa-not-equal"></i>
                         </button>
                         {% endif %}
-                        <button class="btn btn-danger btn-xs" id="{{ e.MD5 }}" onclick="delete_scan(this)">
-                          <i class="fa fa-trash"></i> Delete
+                        <button class="btn btn-danger" id="{{ e.MD5 }}" onclick="delete_scan(this)" title="Delete Scan">
+                          <i class="fa fa-trash"></i>
                         </button>
                       </div>
                     </td>

--- a/mobsf/templates/general/tasks.html
+++ b/mobsf/templates/general/tasks.html
@@ -1,291 +1,343 @@
-
 {% extends "base/base_layout.html" %}
 {% load static %}
-{% block sidebar_option %}
-      sidebar-collapse
-{% endblock %}
+{% block sidebar_option %}sidebar-collapse{% endblock %}
 {% block extra_css %}
 <link href="{% static "adminlte/plugins/sweetalert2/sweetalert2.min.css" %}" rel="stylesheet">
 <style>
-    /* Loader Spinner */
-    .loader {
-        border: 2px solid #f3f3f3; /* Light gray */
-        border-top: 2px solid #3498db; /* Blue */
-        border-radius: 50%;
-        width: 12px;
-        height: 12px;
-        animation: spin 1s linear infinite;
-        display: inline-block;
-        vertical-align: middle;
-    }
-    
-    @keyframes spin {
-        0% {
-            transform: rotate(0deg);
-        }
-        100% {
-            transform: rotate(360deg);
-        }
-    }
+  .tasks-page {
+    padding: 28px 24px;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .page-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 24px;
+  }
+
+  .page-header-icon {
+    width: 42px; height: 42px;
+    background: rgba(88,166,255,0.1);
+    border: 1px solid rgba(88,166,255,0.2);
+    border-radius: 12px;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .page-title { margin: 0; font-size: 22px; font-weight: 700; color: var(--text-primary, #e6edf3); }
+  .page-sub { margin: 0; color: var(--text-secondary, #8b949e); font-size: 13px; }
+
+  .page-sub a {
+    color: var(--accent-blue, #58a6ff);
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .page-sub a:hover { text-decoration: underline; }
+
+  /* Table card */
+  .tasks-card {
+    background: var(--bg-card, #161d27);
+    border: 1px solid var(--border-subtle, rgba(48,54,61,0.6));
+    border-radius: 16px;
+    overflow: hidden;
+  }
+
+  .tasks-card-header {
+    background: var(--bg-surface, #111820);
+    border-bottom: 1px solid var(--border-subtle);
+    padding: 16px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .tasks-table { width: 100%; border-collapse: collapse; }
+
+  .tasks-table thead th {
+    background: var(--bg-surface, #111820);
+    border-bottom: 1px solid var(--border-subtle);
+    color: var(--text-secondary, #8b949e);
+    font-size: 11px; font-weight: 700; letter-spacing: 0.8px;
+    text-transform: uppercase;
+    padding: 12px 20px;
+    white-space: nowrap;
+  }
+
+  .tasks-table tbody tr {
+    border-bottom: 1px solid rgba(48,54,61,0.4);
+    transition: background 0.15s ease;
+  }
+
+  .tasks-table tbody tr:last-child { border-bottom: none; }
+  .tasks-table tbody tr:hover { background: rgba(88,166,255,0.03); }
+
+  .tasks-table td {
+    padding: 16px 20px;
+    vertical-align: middle;
+    color: var(--text-primary, #e6edf3);
+    font-size: 13px;
+  }
+
+  /* Scan task cell */
+  .task-id-label { color: var(--text-muted, #484f58); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; }
+  .task-id-value { font-family: var(--font-mono, 'JetBrains Mono', monospace); font-size: 12px; color: var(--accent-blue, #58a6ff); }
+  .task-checksum-value { font-family: var(--font-mono, 'JetBrains Mono', monospace); font-size: 11.5px; color: var(--text-secondary, #8b949e); }
+
+  /* Timeline cell */
+  .timeline-item { margin-bottom: 4px; display: flex; align-items: center; gap: 8px; }
+  .timeline-label { color: var(--text-muted, #484f58); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.4px; min-width: 82px; }
+  .timeline-val { color: var(--text-secondary, #8b949e); font-size: 12px; }
+
+  /* Status badge */
+  .status-badge {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 4px 10px; border-radius: 20px;
+    font-size: 11.5px; font-weight: 700;
+  }
+  .status-pending { background: rgba(227,179,65,0.1); border: 1px solid rgba(227,179,65,0.25); color: var(--accent-yellow, #e3b341); }
+  .status-success { background: rgba(63,185,80,0.1); border: 1px solid rgba(63,185,80,0.25); color: var(--accent-green, #3fb950); }
+  .status-failed  { background: rgba(248,81,73,0.1); border: 1px solid rgba(248,81,73,0.25); color: var(--accent-red, #f85149); }
+
+  /* Spinner */
+  .spin-ring {
+    width: 14px; height: 14px;
+    border: 2px solid rgba(227,179,65,0.2);
+    border-top-color: var(--accent-yellow, #e3b341);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    display: inline-block;
+    flex-shrink: 0;
+  }
+
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* View report link */
+  .report-link {
+    display: inline-flex; align-items: center; gap: 5px;
+    background: rgba(88,166,255,0.08);
+    border: 1px solid rgba(88,166,255,0.2);
+    border-radius: 6px;
+    color: var(--accent-blue, #58a6ff);
+    font-size: 12px; font-weight: 600;
+    padding: 3px 10px;
+    text-decoration: none;
+    margin-top: 4px;
+    transition: all 0.15s ease;
+  }
+  .report-link:hover {
+    background: rgba(88,166,255,0.15);
+    color: var(--accent-blue, #58a6ff);
+    text-decoration: none;
+  }
+
+  /* App name chip */
+  .app-name-chip {
+    display: inline-flex; align-items: center; gap: 5px;
+    background: rgba(139,148,158,0.08);
+    border: 1px solid rgba(139,148,158,0.15);
+    border-radius: 6px;
+    color: var(--text-secondary, #8b949e);
+    font-size: 11.5px;
+    padding: 2px 8px;
+    margin-top: 4px;
+  }
+
+  /* Empty state */
+  .empty-row td {
+    text-align: center;
+    padding: 48px;
+    color: var(--text-muted, #484f58);
+    font-size: 14px;
+  }
+
+  .empty-icon {
+    display: block;
+    font-size: 32px;
+    margin-bottom: 10px;
+  }
+
+  /* Live badge */
+  .live-badge {
+    display: inline-flex; align-items: center; gap: 6px;
+    background: rgba(63,185,80,0.08);
+    border: 1px solid rgba(63,185,80,0.2);
+    border-radius: 20px;
+    color: var(--accent-green, #3fb950);
+    font-size: 11px; font-weight: 700;
+    padding: 3px 10px;
+  }
+
+  .live-dot {
+    width: 6px; height: 6px;
+    background: var(--accent-green, #3fb950);
+    border-radius: 50%;
+    animation: pulse 1.5s infinite;
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+  }
 </style>
 {% endblock %}
 {% block content %}
 <div class="content-wrapper">
-    <div class="content-header">
+  <div class="tasks-page">
+
+    <div class="page-header">
+      <div class="page-header-icon">
+        <i class="fas fa-rocket" style="color:var(--accent-blue,#58a6ff);font-size:18px;"></i>
+      </div>
+      <div>
+        <h1 class="page-title">Scan Queue</h1>
+        <p class="page-sub">
+          Results will appear in <a href="{% url 'recent' %}">Recent Scans</a> once analysis completes.
+        </p>
+      </div>
     </div>
-     <div class="container-fluid">
-          <div class="row">
-              <div class="col-lg-12">
-              <div class="card">
-                <div class="card-body">
-                   <div class="box">
-          <div class="box-header with-border">
-              <h3 class="box-title"><i class="fa fa-rocket"></i> Scan Queue</h3>
-              <p class="lead">The scan results will appear in <strong><a href="{% url 'recent' %}">Recent Scans</a></strong> once completed.</p>
-          </div>
-          <div class="box-body">
-            <div class="table-responsive">
-                <table id="tasks-table" class="table table-bordered table-hover table-striped">
-                    <thead>
-                        <tr>
-                            <th>Scan Task</th>
-                            <th>Filename</th>
-                            <th>Timeline</th>
-                            <th>Status</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <!-- Rows will be populated dynamically -->
-                    </tbody>
-                </table>
-            </div>
-<!-- /.box-body -->
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
+
+    <div class="tasks-card">
+      <div class="tasks-card-header">
+        <span style="color:var(--text-primary);font-size:14px;font-weight:600;">
+          <i class="fas fa-list" style="margin-right:8px;opacity:.6;"></i>Active Tasks
+        </span>
+        <span class="live-badge">
+          <span class="live-dot"></span>
+          Live &nbsp;· updates every 5s
+        </span>
+      </div>
+
+      <div style="overflow-x:auto;">
+        <table class="tasks-table" id="tasks-table">
+          <thead>
+            <tr>
+              <th>Scan Task</th>
+              <th>Filename</th>
+              <th>Timeline</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <!-- Populated by JS -->
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+  </div>
 </div>
 {% endblock %}
 {% block extra_scripts %}
 <script src="{% static "adminlte/plugins/sweetalert2/sweetalert2.min.js" %}"></script>
 <script>
-   document.addEventListener("DOMContentLoaded", function () {
-    const tasksTableBody = document.querySelector("#tasks-table tbody");
+document.addEventListener("DOMContentLoaded", function () {
+  const tasksTableBody = document.querySelector("#tasks-table tbody");
 
-    // Fetch tasks using POST request
-    async function fetchTasks() {
-        const response = await fetch("{% url 'list_tasks' %}", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "X-CSRFToken": "{{ csrf_token }}",
-            },
-        });
+  async function fetchTasks() {
+    const response = await fetch("{% url 'list_tasks' %}", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": "{{ csrf_token }}",
+      },
+    });
+    if (!response.ok) { console.error("Failed to fetch tasks."); return []; }
+    return await response.json();
+  }
 
-        if (!response.ok) {
-            console.error("Failed to fetch tasks.");
-            return [];
-        }
+  function getStatusClass(task) {
+    if (!task.completed_at) return 'status-pending';
+    return task.status === 'Success' ? 'status-success' : 'status-failed';
+  }
 
-        return await response.json();
+  function getStatusIcon(task) {
+    if (!task.completed_at) return '<span class="spin-ring"></span>';
+    if (task.status === 'Success') return '<i class="fas fa-check-circle" style="font-size:12px;"></i>';
+    return '<i class="fas fa-times-circle" style="font-size:12px;"></i>';
+  }
+
+  function buildTimelineCell(task) {
+    const fmt = (v) => v ? new Date(v).toLocaleString() : '—';
+    return `
+      <div class="timeline-item"><span class="timeline-label">Queued</span><span class="timeline-val">${fmt(task.created_at)}</span></div>
+      <div class="timeline-item"><span class="timeline-label">Started</span><span class="timeline-val">${fmt(task.started_at)}</span></div>
+      <div class="timeline-item"><span class="timeline-label">Finished</span><span class="timeline-val">${fmt(task.completed_at)}</span></div>
+    `;
+  }
+
+  function buildStatusCell(task) {
+    let html = `<span class="status-badge ${getStatusClass(task)}">${getStatusIcon(task)} ${task.status}</span>`;
+    if (task.completed_at && task.status === 'Success') {
+      html += `<br><a class="report-link" href="/search?query=${encodeURIComponent(task.checksum)}"><i class="fas fa-eye"></i> View Report</a>`;
     }
-
-    function addLoader(statusCell) {
-        const loader = document.createElement("span");
-        loader.classList.add("loader");
-        loader.style.marginLeft = "10px"; 
-        statusCell.appendChild(loader);
+    if (task.app_name) {
+      html += `<br><span class="app-name-chip"><i class="fas fa-mobile-alt" style="font-size:10px;"></i> ${task.app_name}</span>`;
     }
+    return html;
+  }
 
-    function addAppName(task, statusCell) {
-        if (task.app_name) {
-            const strongElement = document.createElement("strong");
-            strongElement.textContent = ` ${task.app_name}`;
-            statusCell.appendChild(document.createElement("br"));
-            statusCell.appendChild(strongElement);
-        }
+  function buildTableRow(task) {
+    const row = document.createElement("tr");
+    row.setAttribute("data-task-id", task.task_id);
+    row.innerHTML = `
+      <td>
+        <div class="task-id-label">Task ID</div>
+        <div class="task-id-value">${task.task_id}</div>
+        <div class="task-id-label" style="margin-top:6px;">Checksum</div>
+        <div class="task-checksum-value">${task.checksum}</div>
+      </td>
+      <td style="font-weight:600;color:var(--text-primary);">${task.file_name}</td>
+      <td id="timeline-${task.task_id}">${buildTimelineCell(task)}</td>
+      <td id="status-${task.task_id}">${buildStatusCell(task)}</td>
+    `;
+    return row;
+  }
+
+  async function renderTable() {
+    const tasks = await fetchTasks();
+    tasksTableBody.innerHTML = "";
+    if (tasks.length === 0) {
+      tasksTableBody.innerHTML = `
+        <tr class="empty-row">
+          <td colspan="4">
+            <i class="fas fa-inbox empty-icon" style="color:var(--text-muted);"></i>
+            No tasks in queue
+          </td>
+        </tr>`;
+    } else {
+      tasks.forEach(task => tasksTableBody.appendChild(buildTableRow(task)));
     }
+  }
 
-    function addReportLink(task, statusCell) {
-        const reportLink = document.createElement("a");
-        reportLink.href = `/search?query=${encodeURIComponent(task.checksum)}`;
-        reportLink.textContent = ' View Report';
+  async function updateTaskStatuses() {
+    const tasks = await fetchTasks();
+    const existingIds = Array.from(document.querySelectorAll("#tasks-table tbody tr")).map(r => r.getAttribute("data-task-id"));
+    tasks.forEach(task => {
+      const statusCell = document.getElementById(`status-${task.task_id}`);
+      const timelineCell = document.getElementById(`timeline-${task.task_id}`);
+      if (statusCell && timelineCell) {
+        statusCell.innerHTML = buildStatusCell(task);
+        timelineCell.innerHTML = buildTimelineCell(task);
+      } else if (!existingIds.includes(task.task_id)) {
+        tasksTableBody.prepend(buildTableRow(task));
+      }
+    });
+  }
 
-        const icon = document.createElement("i");
-        icon.classList.add("fa", "fa-eye");
-        reportLink.prepend(icon);
+  renderTable();
+  setInterval(updateTaskStatuses, 5000);
 
-        statusCell.appendChild(document.createElement("br"));
-        statusCell.appendChild(reportLink);
-    }
-
-    function buildTableRow(task) {
-        const row = document.createElement("tr");
-        row.setAttribute("data-task-id", task.task_id);
-
-        // Scan Task
-        const taskIdCell = document.createElement("td");
-        const taskP = document.createElement("p");
-        const checksumP = document.createElement("p");
-
-        const taskLabel = document.createElement("strong");
-        taskLabel.textContent = "Task ID: ";
-        taskP.appendChild(taskLabel);
-        taskP.appendChild(document.createTextNode(task.task_id));
-
-        const checksumLabel = document.createElement("strong");
-        checksumLabel.textContent = "Checksum: ";
-        checksumP.appendChild(checksumLabel);
-        checksumP.appendChild(document.createTextNode(task.checksum));
-
-        taskIdCell.appendChild(taskP);
-        taskIdCell.appendChild(checksumP);
-
-        // File Name
-        const fileNameCell = document.createElement("td");
-        fileNameCell.textContent = task.file_name;
-
-        // Timeline
-        const timelineCell = document.createElement("td");
-        timelineCell.setAttribute("id", `timeline-${task.task_id}`);
-
-        // Status
-        const statusCell = document.createElement("td");
-        statusCell.setAttribute("id", `status-${task.task_id}`);
-        statusCell.classList.add(task.completed_at ? "text-success" : "text-warning");
-
-        updateCellStatus(task, statusCell, timelineCell);
-
-        // Append cells to row
-        row.appendChild(taskIdCell);
-        row.appendChild(fileNameCell);
-        row.appendChild(timelineCell);
-        row.appendChild(statusCell);
-
-        return row;
-    }
-
-    function updateCellStatus(task, statusCell, timelineCell) {
-        // Update the status text
-        statusCell.textContent = task.status;
-
-        // Clear existing content in timelineCell
-        while (timelineCell.firstChild) {
-            timelineCell.removeChild(timelineCell.firstChild);
-        }
-
-        // Create and append "Queued At"
-        const queuedAtElement = document.createElement("p");
-        const queuedAtLabel = document.createElement("strong");
-        queuedAtLabel.textContent = "Queued At: ";
-        queuedAtElement.appendChild(queuedAtLabel);
-        queuedAtElement.appendChild(document.createTextNode(task.created_at ? new Date(task.created_at).toLocaleString() : "N/A"));
-        timelineCell.appendChild(queuedAtElement);
-
-        // Create and append "Started At"
-        const startedAtElement = document.createElement("p");
-        const startedAtLabel = document.createElement("strong");
-        startedAtLabel.textContent = "Started At: ";
-        startedAtElement.appendChild(startedAtLabel);
-        startedAtElement.appendChild(document.createTextNode(task.started_at ? new Date(task.started_at).toLocaleString() : "N/A"));
-        timelineCell.appendChild(startedAtElement);
-
-        // Create and append "Completed At"
-        const completedAtElement = document.createElement("p");
-        const completedAtLabel = document.createElement("strong");
-        completedAtLabel.textContent = "Completed At: ";
-        completedAtElement.appendChild(completedAtLabel);
-        completedAtElement.appendChild(document.createTextNode(task.completed_at ? new Date(task.completed_at).toLocaleString() : "N/A"));
-        timelineCell.appendChild(completedAtElement);
-
-        // Add loader or success indicators
-        if (!task.completed_at) {
-            addLoader(statusCell);
-        } else {
-            if (task.status === "Success") {
-                statusCell.classList.add("text-success");
-                statusCell.classList.remove("text-warning");
-                addReportLink(task, statusCell);
-            } else if (task.status === "Failed") {
-                statusCell.classList.add("text-danger");
-                statusCell.classList.remove("text-warning");
-            }
-        }
-
-        addAppName(task, statusCell);
-    }
-
-    async function renderTable() {
-        const tasks = await fetchTasks();
-        tasksTableBody.innerHTML = ""; // Clear existing rows
-
-        if (tasks.length === 0) {
-            const noTasksRow = document.createElement("tr");
-            const noTasksCell = document.createElement("td");
-            noTasksCell.setAttribute("colspan", "4");
-            noTasksCell.textContent = "No tasks in queue.";
-            noTasksRow.appendChild(noTasksCell);
-            tasksTableBody.appendChild(noTasksRow);
-        } else {
-            tasks.forEach((task) => {
-                const row = buildTableRow(task);
-                tasksTableBody.appendChild(row);
-            });
-        }
-    }
-
-    async function updateTaskStatuses() {
-        const tasks = await fetchTasks();
-        const existingTaskIds = Array.from(document.querySelectorAll("#tasks-table tbody tr"))
-            .map(row => row.getAttribute("data-task-id")); // Get existing task IDs from the table
-
-        tasks.forEach((task) => {
-            const statusCell = document.getElementById(`status-${task.task_id}`);
-            const timelineCell = document.getElementById(`timeline-${task.task_id}`);
-
-            if (statusCell && timelineCell) {
-                // Update existing task status and timeline
-                updateCellStatus(task, statusCell, timelineCell);
-            } else if (!existingTaskIds.includes(task.task_id)) {
-                // Add a new row if the task ID is not found, at the top of the table
-                const newRow = buildTableRow(task);
-                tasksTableBody.prepend(newRow); // Add the new row to the top
-            }
-        });
-    }
-
-
-
-    // Initial render
-    renderTable();
-
-    // Periodically update statuses
-    setInterval(updateTaskStatuses, 5000); // Update every 5 seconds
-
-    function getQueryParam(paramName) {
-        const urlParams = new URLSearchParams(window.location.search); // Get the query string
-        return urlParams.has(paramName) ? urlParams.get(paramName) : null;
-    }
-
-    const q = getQueryParam('q');
-
-    if (q && q === 'completed') {
-        Swal.fire(
-            'Scan Task Recently Completed!',
-            'The scan was recently processed.',
-            'warning'
-        )
-    } else if (q && q === 'queued') {
-        Swal.fire(
-            'Scan Task Already Added!',
-            'This scan task has already been added to the scan queue.',
-            'warning'
-        )
-    }
+  // SweetAlert notifications
+  const q = new URLSearchParams(window.location.search).get('q');
+  if (q === 'completed') {
+    Swal.fire({ title: 'Scan Completed!', text: 'The scan was recently processed.', icon: 'success',
+      background: '#161d27', color: '#e6edf3', confirmButtonColor: '#238636' });
+  } else if (q === 'queued') {
+    Swal.fire({ title: 'Already Queued', text: 'This scan task has already been added to the queue.', icon: 'info',
+      background: '#161d27', color: '#e6edf3', confirmButtonColor: '#58a6ff' });
+  }
 });
-
-    </script>
+</script>
 {% endblock %}

--- a/mobsf/templates/general/view.html
+++ b/mobsf/templates/general/view.html
@@ -1,124 +1,250 @@
-
 {% extends "base/base_layout.html" %}
 {% load static %}
-{% block sidebar_option %}
-      sidebar-collapse
-{% endblock %}
+{% block sidebar_option %}sidebar-collapse{% endblock %}
 {% block extra_css %}
 <link rel="stylesheet" href="{% static "enlighterjs/enlighterjs.min.css" %}" />
 <style>
-pre {
-  white-space: pre-wrap;       /* css-3 */
-  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
-  white-space: -pre-wrap;      /* Opera 4-6 */
-  white-space: -o-pre-wrap;    /* Opera 7 */
-  word-wrap: break-word;       /* Internet Explorer 5.5+ */
+  .view-page {
+    padding: 24px;
+    max-width: 1200px;
+    margin: 0 auto;
   }
 
-  /* custom yellow line highlight */
-  .enlighter-t-enlighter div.enlighter>div.enlighter-special {
-    background-color: #fff8bb;
+  .view-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 20px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid var(--border-subtle, rgba(48,54,61,0.6));
   }
 
+  .view-file-icon {
+    width: 38px; height: 38px;
+    background: rgba(88,166,255,0.1);
+    border: 1px solid rgba(88,166,255,0.2);
+    border-radius: 10px;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .view-filename {
+    color: var(--text-primary, #e6edf3);
+    font-size: 16px;
+    font-weight: 700;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    word-break: break-all;
+    margin: 0;
+  }
+
+  .view-card {
+    background: var(--bg-card, #161d27);
+    border: 1px solid var(--border-subtle, rgba(48,54,61,0.6));
+    border-radius: 14px;
+    overflow: hidden;
+  }
+
+  .view-card-header {
+    background: var(--bg-surface, #111820);
+    border-bottom: 1px solid var(--border-subtle);
+    padding: 12px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  .lang-badge {
+    background: rgba(88,166,255,0.08);
+    border: 1px solid rgba(88,166,255,0.2);
+    border-radius: 6px;
+    color: var(--accent-blue, #58a6ff);
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+    font-size: 11px;
+    font-weight: 700;
+    padding: 3px 10px;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+  }
+
+  .view-body {
+    padding: 0;
+  }
+
+  /* EnlighterJS overrides */
+  pre {
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -o-pre-wrap;
+    word-wrap: break-word;
+    margin: 0 !important;
+    border-radius: 0 !important;
+    border: none !important;
+    background: var(--bg-card, #161d27) !important;
+    font-size: 13px !important;
+    line-height: 1.7 !important;
+    padding: 20px 24px !important;
+  }
+
+  .enlighter-t-enlighter div.enlighter > div.enlighter-special {
+    background-color: rgba(227,179,65,0.12) !important;
+  }
+
+  /* SQLite table styles */
+  .sqlite-section { padding: 20px 24px; }
+
+  .sqlite-table-wrap {
+    margin-bottom: 24px;
+  }
+
+  .sqlite-table-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .sqlite-table-name {
+    color: var(--text-primary, #e6edf3);
+    font-size: 14px;
+    font-weight: 700;
+    font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  }
+
+  .sqlite-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+
+  .sqlite-table thead th {
+    background: var(--bg-surface, #111820);
+    border-bottom: 1px solid var(--border-subtle);
+    color: var(--text-secondary, #8b949e);
+    font-size: 11px; font-weight: 700; letter-spacing: 0.6px;
+    text-transform: uppercase;
+    padding: 10px 14px;
+    white-space: nowrap;
+  }
+
+  .sqlite-table tbody td {
+    padding: 10px 14px;
+    border-bottom: 1px solid rgba(48,54,61,0.4);
+    color: var(--text-primary, #e6edf3);
+    word-break: break-word;
+    max-width: 200px;
+  }
+
+  .sqlite-table tbody tr:last-child td { border-bottom: none; }
+  .sqlite-table tbody tr:hover { background: rgba(88,166,255,0.03); }
 </style>
 {% endblock %}
 {% block content %}
 <div class="content-wrapper">
-  <div class="content-header">
-  </div>
-   <div class="container-fluid">
-        <div class="row">
-            <div class="col-lg-12">
-            <div class="card">
-              <div class="card-body">
-                 <div class="box box-default">
-                   <div class="box-body">
-                      <h3>{{file}} </h3>
-                      <br />
-                      {% if sqlite %}
-                      {% for table, data in sqlite.items %}
-                      <div class="box">
-                          <div class="box-header">
-                            <h4 class="box-title"><b>{{table}}</b></h4>
-                          </div>
-                          <!-- /.box-header -->
-                          <div class="box-body no-padding">
-                            <div class="table-responsive">
-                            <table class="table table-striped">
-                              <tbody><tr>
-                              {% for head in data|key:"head" %}
-                                <th>{{ head }}</th>
-                              {% endfor %}
-                              </tr>
-                              {% for dat in data|key:"data" %}
-                                <tr>
-                                  {% for item in dat %}
-                                    <td style="word-wrap: break-word;min-width: 160px;max-width: 160px;">{{ item }}</td>
-                                  {% endfor %}
-                                </tr>
-                              {% endfor %}
-                          
-                            </tbody></table>
-                            </div>
-                          </div>
-                          <!-- /.box-body -->
-                        </div>
-                      {% endfor %}
-                      {% else %}
-                        <pre id="code_block">{{ data }}</pre>
-                      {% endif %}
-                        </div>
-                        <!-- /.box-body -->
-                      </div>
+  <div class="view-page">
+
+    <div class="view-header">
+      <div class="view-file-icon">
+        <i class="fas fa-file-code" style="color:var(--accent-blue,#58a6ff);font-size:16px;"></i>
+      </div>
+      <div>
+        <h3 class="view-filename">{{ file }}</h3>
+      </div>
+    </div>
+
+    <div class="view-card">
+
+      {% if sqlite %}
+      <div class="view-card-header">
+        <span style="color:var(--text-primary);font-size:14px;font-weight:600;">
+          <i class="fas fa-database" style="margin-right:8px;opacity:.7;color:var(--accent-blue,#58a6ff);"></i>SQLite Database
+        </span>
+        <span class="lang-badge">SQLite</span>
+      </div>
+      <div class="sqlite-section">
+        {% for table, data in sqlite.items %}
+        <div class="sqlite-table-wrap">
+          <div class="sqlite-table-title">
+            <i class="fas fa-table" style="color:var(--accent-blue,#58a6ff);font-size:13px;opacity:.8;"></i>
+            <span class="sqlite-table-name">{{ table }}</span>
+          </div>
+          <div style="overflow-x:auto;border-radius:10px;border:1px solid var(--border-subtle);">
+            <table class="sqlite-table">
+              <thead>
+                <tr>
+                  {% for head in data|key:"head" %}
+                  <th>{{ head }}</th>
+                  {% endfor %}
+                </tr>
+              </thead>
+              <tbody>
+                {% for dat in data|key:"data" %}
+                <tr>
+                  {% for item in dat %}
+                  <td>{{ item }}</td>
+                  {% endfor %}
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
           </div>
         </div>
-       </div>
-     </div>
+        {% endfor %}
+      </div>
+
+      {% else %}
+      <div class="view-card-header">
+        <span style="color:var(--text-primary);font-size:14px;font-weight:600;">
+          <i class="fas fa-code" style="margin-right:8px;opacity:.7;color:var(--accent-blue,#58a6ff);"></i>Source Code
+        </span>
+        <span class="lang-badge">{{ type }}</span>
+      </div>
+      <div class="view-body">
+        <pre id="code_block">{{ data }}</pre>
+      </div>
+      {% endif %}
+
     </div>
+  </div>
 </div>
 {% endblock %}
 
 {% block extra_scripts %}
 <script type="text/javascript" src="{% static "enlighterjs/enlighterjs.min.js" %}"></script>
-
-<!-- Init Code -->
 <script type="text/javascript">
-    const get_lines = function(){
-        const pat = new RegExp(/^[\d,]{1,1000}$/);
-        const urlParams = new URLSearchParams(window.location.search);
-        var i;
-        var lines = urlParams.get("lines");
-        if (!pat.test(lines)){
-          return 0;
-        } else {
-          const parts = lines.split(",");
-          for (i = 0; i < parts.length; i++) {
-             if (parseInt(parts[i]) > 50000)
-               return 0;
-          }
-          return lines;
-        }
+  const get_lines = function() {
+    const pat = new RegExp(/^[\d,]{1,1000}$/);
+    const urlParams = new URLSearchParams(window.location.search);
+    var i;
+    var lines = urlParams.get("lines");
+    if (!pat.test(lines)) { return 0; }
+    else {
+      const parts = lines.split(",");
+      for (i = 0; i < parts.length; i++) {
+        if (parseInt(parts[i]) > 50000) return 0;
+      }
+      return lines;
     }
-    code_blk = document.getElementById('code_block');
-    if (code_blk){
-        EnlighterJS.enlight(code_blk, {
-          theme: 'enlighter',
-          linehover: false,
-          textOverflow: 'scroll',
-          highlight: get_lines(),
-          language: '{{ type }}',
-        });
-    }
-    const toolbar = document.getElementsByClassName("enlighter-toolbar")[0];
-    if (toolbar)
-      toolbar.style.display = 'none';
-    const hcls = document.getElementsByClassName("enlighter-special")[0];
-    if (hcls){
-      if (hcls.scrollIntoViewIfNeeded)
-        hcls.scrollIntoViewIfNeeded();
-      else
-        hcls.scrollIntoView();
-    }
-    
+  };
+
+  const code_blk = document.getElementById('code_block');
+  if (code_blk) {
+    EnlighterJS.enlight(code_blk, {
+      theme: 'enlighter',
+      linehover: false,
+      textOverflow: 'scroll',
+      highlight: get_lines(),
+      language: '{{ type }}',
+    });
+  }
+  const toolbar = document.getElementsByClassName("enlighter-toolbar")[0];
+  if (toolbar) toolbar.style.display = 'none';
+  const hcls = document.getElementsByClassName("enlighter-special")[0];
+  if (hcls) {
+    if (hcls.scrollIntoViewIfNeeded) hcls.scrollIntoViewIfNeeded();
+    else hcls.scrollIntoView();
+  }
 </script>
 {% endblock %}

--- a/mobsf/templates/general/zip.html
+++ b/mobsf/templates/general/zip.html
@@ -1,31 +1,97 @@
 {% extends "base/base_layout.html" %}
- {% block sidebar_option %}
-      sidebar-collapse
-{% endblock %}
+{% block sidebar_option %}sidebar-collapse{% endblock %}
 {% block content %}
 <div class="content-wrapper">
-  <div class="content-header">
-  </div>
-   <div class="container-fluid">
-        <div class="row">
-            <div class="col-lg-12">
-            <div class="card">
-              <div class="card-body">
-                  <h1>Zipped Source Code Instruction</h1>
-                      <p class="lead">Mobile Security Framework supports iOS and Android (eclipse and Android Studio) project files.</p>  
-                      <p>
-                        <strong>Eclipse Project:</strong> The file AndroidManifest.xml and the directory 'src' must exist in the root directory of ZIPPED Source files for eclipse projects.
-                      </p>
-                      <p>
-                        <strong> Android Studio Project:</strong> AndroidManifest.xml must be located at 'app/src/main/AndroidManifest.xml' and the directory 'app/src/main/java/' must exist for Android Studio projects. 
-                      </p>
-                      <p>
-                        <strong>iOS Project:</strong> For iOS projects, the .xcodeproj file must exist in the root directory of the ZIPPED Source files.
-                      </p>
+  <div style="padding:32px 24px;max-width:860px;margin:0 auto;">
+
+    <!-- Header -->
+    <div style="margin-bottom:28px;">
+      <div style="display:flex;align-items:center;gap:12px;">
+        <div style="width:42px;height:42px;background:rgba(227,179,65,0.1);border:1px solid rgba(227,179,65,0.2);border-radius:12px;display:flex;align-items:center;justify-content:center;">
+          <i class="fas fa-file-archive" style="color:var(--accent-yellow,#e3b341);font-size:18px;"></i>
+        </div>
+        <div>
+          <h1 style="margin:0;font-size:22px;font-weight:700;color:var(--text-primary,#e6edf3);">Zipped Source Code</h1>
+          <p style="margin:0;color:var(--text-secondary,#8b949e);font-size:13px;">Requirements for ZIP-based project uploads</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Intro -->
+    <div style="background:rgba(227,179,65,0.05);border:1px solid rgba(227,179,65,0.15);border-radius:12px;padding:16px 20px;display:flex;gap:12px;align-items:flex-start;margin-bottom:24px;">
+      <i class="fas fa-lightbulb" style="color:var(--accent-yellow,#e3b341);font-size:15px;flex-shrink:0;margin-top:2px;"></i>
+      <p style="margin:0;color:var(--text-secondary,#8b949e);font-size:13.5px;line-height:1.65;">
+        MobSF supports iOS and Android (Eclipse and Android Studio) project files uploaded as ZIP archives.
+        Each project type has specific structural requirements described below.
+      </p>
+    </div>
+
+    <!-- Cards -->
+    <div style="display:flex;flex-direction:column;gap:14px;">
+
+      <!-- Eclipse -->
+      <div class="card">
+        <div class="card-body" style="padding:24px !important;">
+          <div style="display:flex;gap:14px;align-items:flex-start;">
+            <div style="width:40px;height:40px;background:rgba(164,198,57,0.08);border:1px solid rgba(164,198,57,0.18);border-radius:10px;display:flex;align-items:center;justify-content:center;flex-shrink:0;">
+              <i class="fab fa-android" style="color:#A4C639;font-size:18px;"></i>
+            </div>
+            <div>
+              <h3 style="margin:0 0 8px;font-size:14px;font-weight:700;color:var(--text-primary,#e6edf3);">Eclipse Project</h3>
+              <p style="margin:0;color:var(--text-secondary,#8b949e);font-size:13px;line-height:1.65;">
+                The file <code>AndroidManifest.xml</code> and the directory <code>src/</code> must exist in the <strong>root directory</strong> of the zipped source files.
+              </p>
+              <div style="margin-top:12px;display:flex;flex-wrap:wrap;gap:6px;">
+                <span style="background:var(--bg-surface,#111820);border:1px solid var(--border-subtle,rgba(48,54,61,0.6));border-radius:6px;color:var(--text-secondary,#8b949e);font-size:11.5px;font-family:var(--font-mono,'JetBrains Mono',monospace);padding:3px 10px;">/ AndroidManifest.xml</span>
+                <span style="background:var(--bg-surface,#111820);border:1px solid var(--border-subtle,rgba(48,54,61,0.6));border-radius:6px;color:var(--text-secondary,#8b949e);font-size:11.5px;font-family:var(--font-mono,'JetBrains Mono',monospace);padding:3px 10px;">/ src/</span>
+              </div>
+            </div>
           </div>
         </div>
-       </div>
-     </div>
+      </div>
+
+      <!-- Android Studio -->
+      <div class="card">
+        <div class="card-body" style="padding:24px !important;">
+          <div style="display:flex;gap:14px;align-items:flex-start;">
+            <div style="width:40px;height:40px;background:rgba(63,185,80,0.08);border:1px solid rgba(63,185,80,0.18);border-radius:10px;display:flex;align-items:center;justify-content:center;flex-shrink:0;">
+              <i class="fas fa-mobile-alt" style="color:var(--accent-green,#3fb950);font-size:18px;"></i>
+            </div>
+            <div>
+              <h3 style="margin:0 0 8px;font-size:14px;font-weight:700;color:var(--text-primary,#e6edf3);">Android Studio Project</h3>
+              <p style="margin:0;color:var(--text-secondary,#8b949e);font-size:13px;line-height:1.65;">
+                <code>AndroidManifest.xml</code> must be located at <code>app/src/main/AndroidManifest.xml</code> and the directory <code>app/src/main/java/</code> must exist.
+              </p>
+              <div style="margin-top:12px;display:flex;flex-wrap:wrap;gap:6px;">
+                <span style="background:var(--bg-surface,#111820);border:1px solid var(--border-subtle,rgba(48,54,61,0.6));border-radius:6px;color:var(--text-secondary,#8b949e);font-size:11.5px;font-family:var(--font-mono,'JetBrains Mono',monospace);padding:3px 10px;">app/src/main/AndroidManifest.xml</span>
+                <span style="background:var(--bg-surface,#111820);border:1px solid var(--border-subtle,rgba(48,54,61,0.6));border-radius:6px;color:var(--text-secondary,#8b949e);font-size:11.5px;font-family:var(--font-mono,'JetBrains Mono',monospace);padding:3px 10px;">app/src/main/java/</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- iOS -->
+      <div class="card">
+        <div class="card-body" style="padding:24px !important;">
+          <div style="display:flex;gap:14px;align-items:flex-start;">
+            <div style="width:40px;height:40px;background:rgba(200,200,200,0.06);border:1px solid rgba(200,200,200,0.12);border-radius:10px;display:flex;align-items:center;justify-content:center;flex-shrink:0;">
+              <i class="fab fa-apple" style="color:#cccccc;font-size:18px;"></i>
+            </div>
+            <div>
+              <h3 style="margin:0 0 8px;font-size:14px;font-weight:700;color:var(--text-primary,#e6edf3);">iOS Project</h3>
+              <p style="margin:0;color:var(--text-secondary,#8b949e);font-size:13px;line-height:1.65;">
+                The <code>.xcodeproj</code> file must exist in the <strong>root directory</strong> of the zipped source files.
+              </p>
+              <div style="margin-top:12px;display:flex;flex-wrap:wrap;gap:6px;">
+                <span style="background:var(--bg-surface,#111820);border:1px solid var(--border-subtle,rgba(48,54,61,0.6));border-radius:6px;color:var(--text-secondary,#8b949e);font-size:11.5px;font-family:var(--font-mono,'JetBrains Mono',monospace);padding:3px 10px;">/ YourProject.xcodeproj</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
     </div>
+  </div>
 </div>
 {% endblock %}

--- a/mobsf/templates/static_analysis/android_binary_analysis.html
+++ b/mobsf/templates/static_analysis/android_binary_analysis.html
@@ -411,7 +411,7 @@
               <h5 class="card-title"></h5>
                 <div class="row">
        
-                <div class="col-2">
+                <div class="col-12 col-md-2">
                   <p><strong><i class="fas fa-check-double"></i> APP SCORES</strong></p>
           {% if app_type not in 'so' %}
                   <img id="app_icon" src="{% if icon_path %}/download/{{icon_path}}{% else %}{% static 'img/no_icon.png' %}{% endif %}"/>
@@ -439,7 +439,7 @@
                 {% endif %}
                 </div>
    
-                <div class="col-6">
+                <div class="col-12 col-md-6">
                   <p><strong><i class="fas fa-box-open"></i> FILE INFORMATION </strong></p>
                   <span class="badge bg-primary">File Name</span>
                   {{ file_name }}<br/>
@@ -453,7 +453,7 @@
                   {{ sha256 }}<br/>
                 </div>
                 {% if app_type not in 'jar,aar,so' %}
-                <div class="col-4">
+                <div class="col-12 col-md-4">
                   <p><strong><i class="fas fa-info"></i> APP INFORMATION </strong></p>
                   <span class="badge bg-primary">App Name</span>
                   {{ app_name }}<br/>

--- a/mobsf/templates/static_analysis/android_source_analysis.html
+++ b/mobsf/templates/static_analysis/android_source_analysis.html
@@ -305,7 +305,7 @@
             <div class="card-body">
               <h5 class="card-title"></h5>
                 <div class="row">
-                <div class="col-2">
+                <div class="col-12 col-md-2">
                   <p><strong><i class="fas fa-check-double"></i> APP SCORES</strong></p>
                   <img id="app_icon" src="{% if icon_path %}/download/{{ icon_path }}{% else %}{% static 'img/no_icon.png' %}{% endif %}"/>
                   <p>
@@ -322,8 +322,8 @@
                   <p> <a href="{% url 'appsec_dashboard' checksum=md5 %}" class="btn btn-outline-primary btn-sm" role="button"><i class="fas fa-user-shield"></i> MobSF Scorecard</a></p>
 
                 </div>
-                <div class="col-6">
-                  <p><strong><i class="fas fa-box-open"></i> FILE INFORMATION </strong></p>                         
+                <div class="col-12 col-md-6">
+                  <p><strong><i class="fas fa-box-open"></i> FILE INFORMATION </strong></p>
                   <span class="badge bg-primary">File Name</span>
                   {{ file_name }}<br/>
                   <span class="badge bg-primary">Size</span>
@@ -335,8 +335,8 @@
                   <span class="badge bg-primary">SHA256</span>
                   {{ sha256 }}<br/>
                 </div>
-                <div class="col-4">
-                  <p><strong><i class="fas fa-info"></i> APP INFORMATION </strong></p>                                       
+                <div class="col-12 col-md-4">
+                  <p><strong><i class="fas fa-info"></i> APP INFORMATION </strong></p>
                   <span class="badge bg-primary">App Name</span>
                   {{ app_name }}<br/>                                   
                   <span class="badge bg-primary">Package Name</span>

--- a/mobsf/templates/static_analysis/ios_binary_analysis.html
+++ b/mobsf/templates/static_analysis/ios_binary_analysis.html
@@ -302,7 +302,7 @@
             <div class="card-body">
               <h5 class="card-title"></h5>
                 <div class="row">
-                <div class="col-2">
+                <div class="col-12 col-md-2">
                   <p><strong><i class="fas fa-check-double"></i> APP SCORES</strong></p>
               {% if app_type not in 'Dylib,A' %}
                   <img id="app_icon" src="{% if not appstore_details.error %}{{appstore_details.icon}}{% elif icon_path %}/download/{{ icon_path }}{% else %}{% static 'img/no_icon.png' %}{% endif %}"/>
@@ -329,7 +329,7 @@
                   <p> <a href="{% url 'appsec_dashboard' checksum=md5 %}" class="btn btn-outline-primary btn-sm" role="button"><i class="fas fa-user-shield"></i> MobSF Scorecard</a></p>
                 {% endif %}
                 </div>
-                <div class="col-4">
+                <div class="col-12 col-md-4">
                   <p><strong><i class="fas fa-box-open"></i> FILE INFORMATION </strong></p>                         
                   <span class="badge bg-primary">File Name</span>
                   {{ file_name }}<br/>
@@ -343,7 +343,7 @@
                   {{ sha256 }}<br/>
                 </div>
                 {% if app_type not in 'Dylib,A' %}
-                <div class="col-3">
+                <div class="col-12 col-md-3">
                   <p><strong><i class="fas fa-info"></i> APP INFORMATION </strong></p>                                       
                   <span class="badge bg-primary">App Name</span>
                   {{ app_name }}<br/>
@@ -367,7 +367,7 @@
                   {% endfor %}
                 </div>
                 {% endif %}
-                 <div class="col-3">
+                 <div class="col-12 col-md-3">
                   <p><strong><i class="fas fa-ad"></i> BINARY INFORMATION </strong></p>                                       
                   <span class="badge bg-primary">Arch</span>
                   {{ binary_info.arch }}<br/>

--- a/mobsf/templates/static_analysis/ios_source_analysis.html
+++ b/mobsf/templates/static_analysis/ios_source_analysis.html
@@ -242,7 +242,7 @@
             <div class="card-body">
               <h5 class="card-title"></h5>
                 <div class="row">
-                <div class="col-2">
+                <div class="col-12 col-md-2">
                   <p><strong><i class="fas fa-check-double"></i> APP SCORES</strong></p>
                   <img id="app_icon" src="{% if not appstore_details.error %}{{appstore_details.icon}}{% elif icon_path %}/download/{{ icon_path }}{% else %}{% static 'img/no_icon.png' %}{% endif %}"/>
                   <p>
@@ -259,7 +259,7 @@
                   <p> <a href="{% url 'appsec_dashboard' checksum=md5 %}" class="btn btn-outline-primary btn-sm" role="button"><i class="fas fa-user-shield"></i> MobSF Scorecard</a></p>
                 </div>
 
-                <div class="col-5">
+                <div class="col-12 col-md-5">
                   <p><strong><i class="fas fa-box-open"></i> FILE INFORMATION </strong></p>                         
                   <span class="badge bg-primary">File Name</span>
                   {{ file_name }}<br/>
@@ -272,7 +272,7 @@
                   <span class="badge bg-primary">SHA256</span>
                   {{ sha256 }}<br/>
                 </div>
-                <div class="col-5">
+                <div class="col-12 col-md-5">
                   <p><strong><i class="fas fa-info"></i> APP INFORMATION </strong></p>                                       
                   <span class="badge bg-primary">App Name</span>
                   {{ app_name }}<br/>

--- a/mobsf/templates/static_analysis/windows_binary_analysis.html
+++ b/mobsf/templates/static_analysis/windows_binary_analysis.html
@@ -133,7 +133,7 @@
             <div class="card-body">
               <h5 class="card-title"></h5>
                 <div class="row">
-                <div class="col-2">
+                <div class="col-12 col-md-2">
                   <p><strong><i class="fas fa-info"></i> APP INFORMATION </strong></p>
                     <span class="badge bg-primary">App Name</span>
                     {{ app_name }} <br/>
@@ -151,7 +151,7 @@
                       {% endif %}
                     {% endif %}
                 </div>
-                <div class="col-5">
+                <div class="col-12 col-md-5">
                   <p><strong><i class="fas fa-box-open"></i> FILE INFORMATION </strong></p>                         
                       <span class="badge bg-primary">File Name</span>
                       {{ file_name }} <br/>
@@ -165,7 +165,7 @@
                       {{ sha256 }}
                 </p>
                 </div>
-                <div class="col-5">
+                <div class="col-12 col-md-5">
                   <p><strong><i class="fas fa-file-code"></i> XML INFORMATION </strong></p>                                       
                     <span class="badge bg-primary">Compiler Version</span>
                     {{ compiler_version }}


### PR DESCRIPTION
Closes #2653

## Summary

Redesigns the web UI around a consistent dark theme (backgrounds, borders, text, and accent colors defined once and shared everywhere), applied across the shared layout, dashboard, recent scans, static/dynamic analysis reports, auth pages, and error pages. Existing functionality and workflows are unchanged - this is a visual/theming pass.

## Notable fixes included

The redesign had introduced several regressions that this PR also fixes, since they were part of the same UI work:

- **Dynamic Analyzer**: a stray extra `{% endblock %}` caused a 500 on every request. The redesign had also dropped the ADB shell, Frida hooks panel, attach-to-process, activity/deeplink tester, and TLS tester from the markup while leaving their JS handlers wired up - all restored. Fixed an XSS regression (unescaped device/APK-controlled strings going into `innerHTML` in the log console) and a few dangling element-id references.
- **Responsive navbar/sidebar**: removed a `zoom` hack that was compounding across templates and making some pages render smaller than others; added a working mobile menu (the nav links had no way to be reached below the `sm` breakpoint); fixed the sidebar toggle being hidden on pages that actually have sidebar content.
- **Recent Scans table**: fixed column widths so space isn't wasted, consolidated the action buttons into a consistent icon toolbar, and fixed the page-size dropdown being clipped by a card's `overflow:hidden`.
- **Static analysis reports**: fixed info columns (App Scores/File Information/App Information/etc.) that used bare Bootstrap column classes with no responsive breakpoint, so they never stacked on mobile.
- Fixed a table-wide bug where hovering any row made its text nearly invisible (Bootstrap's default hover text color wasn't overridden for the dark theme).
- Deduplicated CSS that had been copy-pasted across the error pages (403/404/500) and auth pages (login/register/change password) into shared stylesheets, and removed unused orphaned component files.

## Test plan

- [x] All touched templates compile and render via Django's template engine and test client (including with real form/view context)
- [x] Manually verified in-browser: home, login, register, recent scans, dynamic analyzer, error pages, and static analysis reports at desktop and mobile widths
- [x] Verified the Dynamic Analyzer page loads and its restored features (Frida hooks, ADB shell, TLS tester, activity/deeplink tester) render correctly