### PR TITLE
fix: mitmdump process leaked and respawned on every dynamic analysis run

### DIFF
--- a/mobsf/DynamicAnalyzer/tools/webproxy.py
+++ b/mobsf/DynamicAnalyzer/tools/webproxy.py
@@ -56,22 +56,35 @@ def start_httptools_ui(port):
     time.sleep(3)
 
 
+def _mitm_ca_file():
+    """Path to the mitmproxy generated CA cert."""
+    from mitmproxy import options
+    ca_dir = Path(options.CONF_DIR).expanduser()
+    return ca_dir / 'mitmproxy-ca-cert.pem'
+
+
 def create_ca():
     """Generate CA on first run."""
+    ca_file = _mitm_ca_file()
     argz = ['mitmdump', '-n']
-    subprocess.Popen(argz,
-                     stdin=None,
-                     stdout=None,
-                     stderr=None,
-                     close_fds=True)
-    time.sleep(3)
+    proc = subprocess.Popen(argz,
+                            stdin=None,
+                            stdout=None,
+                            stderr=None,
+                            close_fds=True)
+    # mitmdump is only needed here to generate the CA cert. Stop it
+    # once the cert file appears instead of leaving it running as a
+    # leaked background process.
+    for _ in range(30):
+        if ca_file.exists():
+            break
+        time.sleep(0.5)
+    proc.terminate()
 
 
 def get_ca_file():
     """Get CA Dir."""
-    from mitmproxy import options
-    ca_dir = Path(options.CONF_DIR).expanduser()
-    ca_file = ca_dir / 'mitmproxy-ca-cert.pem'
+    ca_file = _mitm_ca_file()
     if not ca_file.exists():
         create_ca()
     return ca_file.as_posix()

--- a/mobsf/DynamicAnalyzer/views/android/environment.py
+++ b/mobsf/DynamicAnalyzer/views/android/environment.py
@@ -18,7 +18,6 @@ from OpenSSL import crypto
 from frida import __version__ as frida_version
 
 from mobsf.DynamicAnalyzer.tools.webproxy import (
-    create_ca,
     get_ca_file,
     get_http_tools_url,
     start_proxy,
@@ -601,8 +600,9 @@ class Environment:
 
     def mobsf_agents_setup(self, agent):
         """Setup MobSF agents."""
-        create_ca()
-        # Install MITM RootCA
+        # Install MITM RootCA. This generates the CA cert on first
+        # run only, instead of spawning a new mitmdump process on
+        # every dynamic analysis session.
         self.install_mobsf_ca('install')
         if agent == 'frida':
             agent_file = '.mobsf-f'


### PR DESCRIPTION
Closes #2543

## Root cause

`mobsf_agents_setup()` in `environment.py` called `create_ca()` unconditionally on every dynamic analysis session. `create_ca()` spawns a detached `mitmdump -n` process to generate the CA cert, but:

1. It was called even when the CA cert file already existed, spawning a redundant new `mitmdump` process on every single run.
2. The spawned process was never stopped — it's fully detached (`close_fds=True`, no stdin/stdout/stderr), so it stayed running forever after the session ended.

This matches the reported behavior: a new `mitmdump` process appears every time Dynamic Analysis starts, and it never exits after stopping the analysis.

## Fix

- `create_ca()` now waits (polling, up to ~15s) for the CA cert file to actually appear, then calls `proc.terminate()` on the `mitmdump` process it started, since it's only needed transiently to generate the cert.
- Removed the unconditional `create_ca()` call in `mobsf_agents_setup()`. `install_mobsf_ca('install')`, called right after, already goes through `get_ca_file()`, which only generates the CA if it doesn't already exist. The unconditional call was redundant and was the source of the "new process every run" behavior.

## Testing

- `python -m py_compile` on both changed files.
- `flake8` on both changed files — clean.
- Manually traced all call sites of `create_ca()` / `get_ca_file()` to confirm no other code path relies on the old unconditional-spawn behavior.