### PR TITLE
fix: APKiD YARA rules version mismatch crashes the whole scan

### DIFF
--- a/mobsf/MalwareAnalyzer/views/android/apkid.py
+++ b/mobsf/MalwareAnalyzer/views/android/apkid.py
@@ -45,7 +45,17 @@ def apkid_analysis(checksum, apk_file):
         rules_manager=RulesManager(),
         include_types=False,
     )
-    rules = options.rules_manager.load()
+    try:
+        rules = options.rules_manager.load()
+    except Exception as exp:
+        # Typically a YARA version mismatch between the libyara used
+        # to compile APKiD's bundled rules.yarc and the installed
+        # yara-python. APKiD is optional, so skip it instead of
+        # failing the whole scan.
+        msg = 'APKiD - Failed to load YARA rules. Skipping APKiD analysis!'
+        logger.error(msg)
+        append_scan_status(checksum, msg, repr(exp))
+        return {}
     scanner = Scanner(rules, options)
     findings = {}
     res = None


### PR DESCRIPTION
Closes #2614

## Root cause

`apkid_analysis()` calls `options.rules_manager.load()`, which loads APKiD's bundled precompiled `rules.yarc` via `yara.load()`. Precompiled YARA rule caches are tied to the exact libyara version they were compiled with - if the installed `yara-python` is a different version than what compiled the bundled `rules.yarc`, this raises:

```
Error('rules file ".../apkid/rules/rules.yarc" is incompatible with this version of YARA')
```

This call wasn't wrapped in a try/except, so the exception propagated out of `apkid_analysis()` and was caught by `apk_analysis_task()`'s outer exception handler, which marks the **entire scan** as failed - not just the APKiD step. That matches the report: every APK scan fails with this error.

APKiD is already treated as optional/best-effort elsewhere in the same function (missing dependency and scan timeout are both caught and just skip APKiD), the rules-loading call was the one path that wasn't.

## Fix

Wrap `options.rules_manager.load()` in try/except. On failure, log it, record it in the scan status, and return `{}` (skip APKiD) instead of letting the exception bubble up and fail the whole scan - consistent with the existing `ImportError` handling right above it.

## Testing

- Confirmed the failure mode is real in this environment's own APKiD/yara-python install is actually compatible (`rules_manager.load()` succeeds normally), so I verified the fix by monkeypatching `RulesManager.load` to raise the same error message reported in the issue, then calling `apkid_analysis()`:
  - Before the fix: exception propagates.
  - After the fix: returns `{}` and logs a clear "Skipping APKiD analysis!" message, scan can proceed.
- Confirmed the unmodified happy path (`rules_manager.load()` with no mocking) still returns real `yara.Rules` normally - no behavior change when there's no mismatch.
- `flake8` clean on the changed file.

This doesn't fix the underlying YARA/APKiD version compatibility itself (that's an upstream packaging concern), but it stops a version mismatch from taking down an entire scan for something that's meant to be an optional check.